### PR TITLE
docs: correct wkhtmltopdf's default margins and the bare-number unit

### DIFF
--- a/bindings/ruby/lib/sghtmltopdf/options.rb
+++ b/bindings/ruby/lib/sghtmltopdf/options.rb
@@ -63,10 +63,10 @@ module Sghtmltopdf
       # 配列は同じオプションの繰り返し。要素ごとに同じ規則を適用する。
       when Array then value.flat_map { |element| pairs_for(key, element) }
       when Hash
-        # wicked_pdfの`margin: {top: 10}`のような入れ子は受けない。数値の
-        # 単位の解釈が違う(wicked_pdfはmm・こちらはpx)ため、機械的に
-        # 平坦化すると黙って別の余白になる。移行時は
-        # 移行ガイドの対応表を見て書き換えてもらう。
+        # wicked_pdfの`margin: {top: 10}`のような入れ子は受けない。対応する
+        # CLIフラグが無く、機械的に平坦化すると綴り違いのキーまで黙って
+        # 通ってしまう。移行時は移行ガイドの対応表を見て書き換えてもらう。
+        # なお単位を省いた数値の解釈はwicked_pdfと同じくmm(`cli/units.rs`)。
         example = value.keys.first
         raise ArgumentError,
           "#{key}にHashは渡せません(pathとindexを取るのは:fontだけです)。" \

--- a/docs/po/en.po
+++ b/docs/po/en.po
@@ -6989,8 +6989,8 @@ msgid "マージンの既定値"
 msgstr "Default margins"
 
 #: src/migration/wkhtmltopdf.md:14
-msgid "左右10mm"
-msgstr "10mm left and right"
+msgid "四辺10mm"
+msgstr "10mm on all four sides"
 
 #: src/migration/wkhtmltopdf.md:14
 msgid "四辺1in(96px)"
@@ -7079,12 +7079,16 @@ msgstr ""
 
 #: src/migration/wkhtmltopdf.md:35
 msgid ""
-"wkhtmltopdfは左右10mm、sghtmltopdfは四辺1インチ(96px = 25.4mm)です。 指定なし"
-"で変換すると余白が変わるので、既存の見た目を保つには明示します。"
+"wkhtmltopdfは四辺10mm、sghtmltopdfは四辺1インチ(96px = 25.4mm)です。 "
+"wkhtmltopdfの`--extended-help`は左右にしか既定値を書いていませんが、実際には"
+"上下にも10mmが入ります。 指定なしで変換すると余白が変わるので、既存の見た目を"
+"保つには明示します。"
 msgstr ""
-"wkhtmltopdf uses 10mm on the left and right, sghtmltopdf 1 inch (96px, or "
-"25.4mm) on all four sides. Converting without saying anything therefore "
-"changes the margins, so state them to keep the existing look."
+"wkhtmltopdf uses 10mm on all four sides, sghtmltopdf 1 inch (96px, or "
+"25.4mm). wkhtmltopdf's `--extended-help` only documents a default for the "
+"left and right margins, but the binary applies 10mm to the top and bottom "
+"as well. Converting without saying anything therefore changes the margins, "
+"so state them to keep the existing look."
 
 #: src/migration/wkhtmltopdf.md:46
 msgid "# wkhtmltopdf\n"
@@ -7590,15 +7594,16 @@ msgstr "`-V, --version`"
 
 #: src/migration/wkhtmltopdf-options.md:58
 msgid ""
-"マージンの既定値: wkhtmltopdfは左右10mm・上下未指定だが、sghtmltopdfの現在の"
-"既定は四辺96px(＝1in＝25.4mm)。 既存の出力を変えないため既定値は変更しない。 "
-"移行時は`--margin-*`を明示すること。"
+"マージンの既定値: wkhtmltopdfは四辺10mm(`--extended-help`には左右の既定値しか"
+"載っていないが、実際は上下も10mm)だが、sghtmltopdfの現在の既定は四辺96px(＝"
+"1in＝25.4mm)。 既存の出力を変えないため既定値は変更しない。 移行時は`--margin-"
+"*`を明示すること。"
 msgstr ""
-"Default margins: wkhtmltopdf uses 10mm left and right and leaves top and "
-"bottom unset, while sghtmltopdf currently defaults to 96px, that is 1in or "
-"25.4mm, on all four sides. The default is not being changed, so that "
-"existing output stays as it is. State `--margin-*` explicitly when you move "
-"across."
+"Default margins: wkhtmltopdf uses 10mm on all four sides (`--extended-help` "
+"only lists a default for left and right, but top and bottom are 10mm too), "
+"while sghtmltopdf currently defaults to 96px, that is 1in or 25.4mm, on all "
+"four sides. The default is not being changed, so that existing output stays "
+"as it is. State `--margin-*` explicitly when you move across."
 
 #: src/migration/wkhtmltopdf-options.md:62
 msgid "Outline Options"
@@ -8494,11 +8499,24 @@ msgstr "Differences in the defaults"
 
 #: src/migration/wicked-pdf.md:119
 msgid ""
-"マージン: wkhtmltopdfは左右10mm。sghtmltopdfは四辺1in(96px)。 同じ見た目にし"
+"マージン: wkhtmltopdfは四辺10mm。sghtmltopdfは四辺1in(96px)。 同じ見た目にし"
 "たければ`margin_*`を明示する"
 msgstr ""
-"Margins: wkhtmltopdf uses 10mm left and right, sghtmltopdf 1in (96px) on all "
-"four sides. State `margin_*` explicitly to keep the same look"
+"Margins: wkhtmltopdf uses 10mm on all four sides, sghtmltopdf 1in (96px) on "
+"all four sides. State `margin_*` explicitly to keep the same look"
+
+#: src/migration/wicked-pdf.md:123
+msgid ""
+"`disable_local_file_access`との併用: `--allow`は読み取り範囲を狭めるだけで、"
+"許可を与えるものではない。wicked_pdfで`disable_local_file_access: true`と"
+"`allow: [dir]`を併用して「dirだけ読める」状態にしていた場合、そのまま持ち込む"
+"とローカル読み取りが全て止まる。`allow`だけを残すこと"
+msgstr ""
+"Combining with `disable_local_file_access`: `--allow` only narrows the range "
+"of local reads, it does not grant them. If you used "
+"`disable_local_file_access: true` together with `allow: [dir]` in wicked_pdf "
+"to mean \"only dir is readable\", carrying both across stops local reads "
+"entirely. Keep `allow` on its own."
 
 #: src/migration/wicked-pdf.md:121
 msgid ""

--- a/docs/src/migration/wicked-pdf.md
+++ b/docs/src/migration/wicked-pdf.md
@@ -116,11 +116,12 @@ PDFのレンダリングはHTTPサーバを介さないので、`/assets/…`の
 
 ## 既定値の違い
 
-* マージン: wkhtmltopdfは左右10mm。sghtmltopdfは四辺1in(96px)。
+* マージン: wkhtmltopdfは四辺10mm。sghtmltopdfは四辺1in(96px)。
   同じ見た目にしたければ`margin_*`を明示する
 * CLIオプションとCSSの`@page`: wkhtmltopdfはCLIが勝つが、sghtmltopdfは `@page` が勝つ(オプションは初期値)
 * ローカルファイルの参照範囲: Railsでは`--allow`の既定が`Rails.root`になる。アプリの外(例: `/usr/share/fonts`)のファイルを`<img>`や`@font-face`の`url()`で参照している場合は、`Sghtmltopdf.configure { |c| c.allow = [Rails.root.to_s, "/usr/share/fonts"] }`のように明示する。`--font`系(`gothic_font`など)で渡すフォントはこの制限を受けない
 * リモート取得: `http(s)`のアセット取得は既定で無効。必要なら`allow_remote_assets: true`
+* `disable_local_file_access`との併用: `--allow`は読み取り範囲を狭めるだけで、許可を与えるものではない。wicked_pdfで`disable_local_file_access: true`と`allow: [dir]`を併用して「dirだけ読める」状態にしていた場合、そのまま持ち込むとローカル読み取りが全て止まる。`allow`だけを残すこと
 
 ## フォント
 

--- a/docs/src/migration/wkhtmltopdf-options.md
+++ b/docs/src/migration/wkhtmltopdf-options.md
@@ -55,7 +55,7 @@ sghtmltopdfは入力を1つのHTMLに限定し、表紙・目次は`--cover <pat
 | `--use-xserver` | ❌ 非対応 | Xサーバに依存しない |
 | `-V, --version` | ✅ 対応 | |
 
-マージンの既定値: wkhtmltopdfは左右10mm・上下未指定だが、sghtmltopdfの現在の既定は四辺96px(＝1in＝25.4mm)。
+マージンの既定値: wkhtmltopdfは四辺10mm(`--extended-help`には左右の既定値しか載っていないが、実際は上下も10mm)だが、sghtmltopdfの現在の既定は四辺96px(＝1in＝25.4mm)。
 既存の出力を変えないため既定値は変更しない。
 移行時は`--margin-*`を明示すること。
 

--- a/docs/src/migration/wkhtmltopdf.md
+++ b/docs/src/migration/wkhtmltopdf.md
@@ -11,7 +11,7 @@ Railsでwicked_pdf経由で使っている場合は[wicked_pdfからの移行](w
 | | wkhtmltopdf | sghtmltopdf |
 |---|---|---|
 | CLIオプションとCSSの`@page` | CLIが勝つ | `@page`が勝つ(CLIは初期値) |
-| マージンの既定値 | 左右10mm | 四辺1in(96px) |
+| マージンの既定値 | 四辺10mm | 四辺1in(96px) |
 | 表紙・目次の指定 | 位置引数(`cover a.html toc`) | `--cover <PATH>` / `--toc` |
 | 複数HTMLの結合 | できる | できない(入力は1つ) |
 | ヘッダー/フッターのページ変数 | JavaScriptで差し込み | プレースホルダ置換(JSは実行しない) |
@@ -32,7 +32,8 @@ CLIで制御したい場合は、HTMLから`@page`の該当プロパティを外
 
 ### マージンの既定値
 
-wkhtmltopdfは左右10mm、sghtmltopdfは四辺1インチ(96px = 25.4mm)です。
+wkhtmltopdfは四辺10mm、sghtmltopdfは四辺1インチ(96px = 25.4mm)です。
+wkhtmltopdfの`--extended-help`は左右にしか既定値を書いていませんが、実際には上下にも10mmが入ります。
 指定なしで変換すると余白が変わるので、既存の見た目を保つには明示します。
 
 ```sh


### PR DESCRIPTION
First of all, **_thank you for such an awesome, useful, ambitious project!_** 🎉 

While implementing sghtmltopdf with claude, claude found that some of the documentation is wrong. Here is a PR to correct it. I am not sure if it's correct, I hope it is and that this PR isn't just noise!

Claude made the whole PR, and all the bellow text. Let me know if you want me to make a better summary, or if you just don't like the PR, or if you want AI-generated PRs to be done differently, or any other feedback! 🙏 

---

Three corrections found while migrating a production Rails app off `wicked_pdf` onto this gem. Thank you for building it — the in-process rendering and the pagination model are exactly what we wanted.

## 1. wkhtmltopdf's default margin is 10mm on all four sides

`migration/wkhtmltopdf-options.md` and `migration/wkhtmltopdf.md` say wkhtmltopdf uses 10mm left and right and leaves top and bottom unset. That reads directly off `--extended-help`, which prints `(default 10mm)` for `-L`/`-R` and nothing for `-T`/`-B` — but the binary applies 10mm to the top and bottom too.

Measured with wkhtmltopdf 0.12.6 (with patched qt), `pdftotext -bbox`, a `margin:0` body:

| page size | top | left | bottom of page 1 |
|---|---|---|---|
| A4 | 9.91mm | 10.05mm | ~10mm |
| Letter | 9.91mm | 10.05mm | 10.14mm |

This is worth getting right because the guide's own advice — state `--margin-*` explicitly when you move across — leads someone who trusts the table to set only left and right, and silently keep 1in top and bottom instead of the 10mm they had.

## 2. The Ruby binding says the bare-number unit is px

`bindings/ruby/lib/sghtmltopdf/options.rb` rejects nested hashes, and the comment gives the reason as the units differing: *wicked_pdfはmm・こちらはpx*.

They do not differ. `core/src/cli/units.rs` documents `単位省略はwkhtmltopdf互換でmm扱い`, and its own tests assert `parse_length_px("10") == 37.795` px, which is 10mm. Confirmed at runtime — `margin_top: 20`, `margin_top: "20mm"` and `margin_top: "0.79in"` all put the body at 20mm, while `margin_top: "20px"` puts it at 5.35mm.

I have left the behaviour alone and only corrected the stated reason, since rejecting nested keys is defensible on its own terms. If you would rather flatten them now that the units are known to match, that is a separate call and I am happy to write it.

## 3. `--allow` narrows local reads, it does not grant them

Not wrong anywhere, just unstated in the place it bites. Our `wicked_pdf` config was the pair `disable_local_file_access: true` + `allow: [dir]`, which in wicked_pdf means "only `dir` is readable". Carried across verbatim it blocks every local read, because `--allow` cannot reopen what `--disable-local-file-access` closed. Fails closed, so nothing dangerous, but it took a while to work out from the option table alone. Added a bullet to the `wicked_pdf` migration guide's list of default differences.

## About the translation catalog

Japanese sources and `docs/po/en.po` are edited together. `msgfmt -c` passes, and I verified each changed `msgid` still matches its paragraph exactly (paragraph line breaks joined on single spaces) so nothing falls back to the Japanese. I could not run `mdbook` locally, so it is worth putting this through the documented `xgettext`/`msgmerge` pass to normalise the wrapping and line references.

## Separately

The other thing we hit is that `@media` feature queries are never evaluated, so every `(min-width: …)` breakpoint matches. With Bootstrap 3 that selects `.container { width: 1170px }` on an A4 page and pushes the right-hand grid column off the paper. `core/src/style/stylesheet.rs` is explicit that this is deliberate for now, and a real fix looks like it needs the page box available at parse time (which `@page` can itself change), so I have not touched it. Happy to open a separate issue with the reduced repro if that is useful.