### PR TITLE
Fix whitespace handling between inline elements, classify Unicode spaces per CSS/UAX #14, support <wbr>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Keep the whitespace between two inline elements, so `<span>one</span> <span>two</span>`
+  renders as `one two` instead of `onetwo` (#3).
+
 ## 0.1.1
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   zero-width break opportunity inside a word.
 - Treat a cell holding only `&nbsp;` as non-empty, so `empty-cells: hide` no longer
   strips the borders of a `<td>&nbsp;</td>`.
+- Do not let a glyph shared by several characters lose its `/ToUnicode` mapping to
+  whichever character happened to come first in the document. A font without its own
+  `&nbsp;` glyph made every space in the document extract as U+00A0, breaking
+  copy-paste and text search in the PDF.
+
+### Added
+
+- Support `<wbr>`, and U+200B ZERO WIDTH SPACE, as a line break opportunity. Neither
+  adds width nor leaves a character in the PDF text layer.
 
 ## 0.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Keep the whitespace between two inline elements, so `<span>one</span> <span>two</span>`
   renders as `one two` instead of `onetwo` (#3).
+- Collapse only the whitespace CSS Text 3 says is collapsible (space, tab, newline).
+  `&nbsp;` and the other Unicode spaces are no longer collapsed into a single space
+  and keep their own advance width, so `&nbsp;&nbsp;&nbsp;` is three spaces wide and
+  thin/hair/em spaces are no longer all rendered as one plain space.
+- Do not wrap around `&nbsp;`, narrow no-break space, figure space or word joiner
+  (UAX #14 glue), including under `word-break: break-all`. Thin space and friends
+  offer a wrap opportunity after them, and U+200B ZERO WIDTH SPACE now provides a
+  zero-width break opportunity inside a word.
+- Treat a cell holding only `&nbsp;` as non-empty, so `empty-cells: hide` no longer
+  strips the borders of a `<td>&nbsp;</td>`.
 
 ## 0.1.1
 

--- a/core/src/layout/box_tree.rs
+++ b/core/src/layout/box_tree.rs
@@ -223,10 +223,14 @@ impl Default for InlineContext {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ChildKind {
-    /// `display: none`、空白のみのテキストなど、ボックスを生成しない。
+    /// `display: none`など、ボックスを生成しない。
     None,
     Block,
     Inline,
+    /// 空白のみのテキストノード。インライン内容の間に挟まっている場合だけ
+    /// 意味を持つ(単語間の空白として畳み込まれる)。ブロックの間や
+    /// インライン内容の前後では捨てる(CSS2.1 9.2.2.1)。
+    Whitespace,
 }
 
 pub fn build_box_tree(dom: &Dom, styles: &HashMap<NodeId, Rc<ComputedStyle>>) -> LayoutBox {
@@ -295,8 +299,12 @@ pub(crate) fn build_box_for_element(
         let mut spans = Vec::new();
         push_before_content(styles, node, &mut spans);
         for &child in &child_ids {
-            if child_kind(dom, styles, child) == ChildKind::Inline {
-                collect_spans(dom, styles, child, &mut spans);
+            match child_kind(dom, styles, child) {
+                ChildKind::Inline => collect_spans(dom, styles, child, &mut spans),
+                ChildKind::Whitespace => {
+                    push_collapsible_whitespace(dom, styles, child, &mut spans)
+                }
+                ChildKind::Block | ChildKind::None => {}
             }
         }
         push_after_content(styles, node, &mut spans);
@@ -437,11 +445,36 @@ fn build_children_boxes(
                 }
             }
             ChildKind::Inline => collect_spans(dom, styles, child, &mut pending_spans),
+            ChildKind::Whitespace => {
+                push_collapsible_whitespace(dom, styles, child, &mut pending_spans)
+            }
         }
     }
     flush_pending_spans(&mut pending_spans, &mut result);
 
     result
+}
+
+/// 空白のみのテキストノード(`ChildKind::Whitespace`)をスパン列に足す。
+///
+/// `<span>one</span> <span>two</span>`のように、インライン要素同士の間にある
+/// 空白は単語間の空白として意味を持つ(行組みの段階で1個に畳み込まれる)ため、
+/// 捨てずにスパンとして残す必要がある。一方、直前にインライン内容が無い場合
+/// (ブロックの直後や親の先頭)は、その空白は行頭に来るだけで結果に影響しない
+/// ので足さない。空白だけが並んだ列から無名ブロックが作られないことは
+/// [`flush_pending_spans`]が保証する。
+fn push_collapsible_whitespace(
+    dom: &Dom,
+    styles: &HashMap<NodeId, Rc<ComputedStyle>>,
+    node: NodeId,
+    out: &mut Vec<InlineSpan>,
+) {
+    if out.is_empty() {
+        return;
+    }
+    // 元のテキストをそのまま渡す(`white-space: pre`の経路は空白の並びを
+    // そのまま使うため、ここで1個に潰してはいけない)。
+    collect_spans(dom, styles, node, out);
 }
 
 /// `node`の計算スタイルが`::first-letter`にマッチしていれば(`first_letter_style`
@@ -743,8 +776,12 @@ fn build_inline_block_box(
         push_before_content(styles, node, &mut spans);
         push_form_control_content(dom, styles, node, &mut spans);
         for &child in &child_ids {
-            if child_kind(dom, styles, child) == ChildKind::Inline {
-                collect_spans(dom, styles, child, &mut spans);
+            match child_kind(dom, styles, child) {
+                ChildKind::Inline => collect_spans(dom, styles, child, &mut spans),
+                ChildKind::Whitespace => {
+                    push_collapsible_whitespace(dom, styles, child, &mut spans)
+                }
+                ChildKind::Block | ChildKind::None => {}
             }
         }
         push_after_content(styles, node, &mut spans);
@@ -1000,7 +1037,7 @@ fn child_kind(dom: &Dom, styles: &HashMap<NodeId, Rc<ComputedStyle>>, node: Node
         }
         NodeData::Text { contents } => {
             if contents.trim().is_empty() {
-                ChildKind::None
+                ChildKind::Whitespace
             } else {
                 ChildKind::Inline
             }
@@ -1239,6 +1276,93 @@ mod tests {
         // 別のNodeIdを持つ(=別の計算スタイルを引ける)。
         assert_ne!(spans[0].node, spans[1].node);
         assert_eq!(dom.children(b).next(), Some(spans[1].node));
+    }
+
+    /// `<p>`(最初のもの)のスパン列のテキストを連結して返す。
+    fn first_p_text(html_src: &[u8]) -> String {
+        let dom = html::parse(html_src);
+        let styles = compute_styles(&dom, &user_agent_stylesheet(), &Stylesheet::default());
+        let tree = build_box_tree(&dom, &styles);
+        let p = find(&dom, dom.document(), "p").expect("p not found");
+        let p_box = find_box(&tree, p).expect("p box not found");
+        find_inline_spans(p_box)
+            .expect("expected inline content")
+            .iter()
+            .map(|span| span.text.as_str())
+            .collect()
+    }
+
+    #[test]
+    fn whitespace_between_two_inline_elements_is_kept() {
+        // 回帰テスト(issue #3): 空白のみのテキストノードを一律で捨てていたため、
+        // インライン要素同士の間の単語間空白が消えて`onetwo`になっていた。
+        assert_eq!(
+            first_p_text(br#"<p><span>one</span> <span>two</span></p>"#),
+            "one two"
+        );
+    }
+
+    #[test]
+    fn whitespace_between_inline_elements_is_kept_across_a_whole_run() {
+        // 3つ以上並んだ場合も、間の空白がすべて残る。
+        assert_eq!(
+            first_p_text(br#"<p><b>one</b> <i>two</i> <span>three</span></p>"#),
+            "one two three"
+        );
+    }
+
+    #[test]
+    fn a_newline_between_two_inline_elements_is_kept() {
+        // 整形されたマークアップでよくある改行も、単語間の空白として残る
+        // (1個の空白へ畳み込むのは行組み側`layout::inline`の仕事)。
+        assert_eq!(
+            first_p_text(b"<p><span>one</span>\n  <span>two</span></p>"),
+            "one\n  two"
+        );
+    }
+
+    #[test]
+    fn a_non_breaking_space_between_two_inline_elements_is_kept() {
+        // `&nbsp;`は`char::is_whitespace`が真になるため「空白のみのテキスト
+        // ノード」として一緒に捨てられていた。
+        assert_eq!(
+            first_p_text("<p><span>one</span>\u{a0}<span>two</span></p>".as_bytes()),
+            "one\u{a0}two"
+        );
+    }
+
+    #[test]
+    fn whitespace_before_the_first_inline_child_creates_no_span() {
+        // 行頭に来るだけで結果に影響しない空白はスパンを作らない
+        // (整形されたマークアップでスパンが無駄に増えないように)。末尾側は
+        // 行組みが無視するので残っていてよい(`white-space: pre`では意味を持つ)。
+        let dom = html::parse(b"<p>\n  <span>one</span>\n</p>");
+        let styles = compute_styles(&dom, &user_agent_stylesheet(), &Stylesheet::default());
+        let tree = build_box_tree(&dom, &styles);
+
+        let p = find(&dom, dom.document(), "p").expect("p not found");
+        let p_box = find_box(&tree, p).expect("p box not found");
+        let spans = find_inline_spans(p_box).expect("expected inline content");
+
+        assert_eq!(
+            spans[0].text, "one",
+            "no span should precede the first word, got {spans:?}"
+        );
+    }
+
+    #[test]
+    fn whitespace_between_block_siblings_creates_no_anonymous_box() {
+        // ブロックの間の空白は従来どおりボックスを生成しない(CSS2.1 9.2.2.1)。
+        let dom = html::parse(b"<div>\n  <p>a</p>\n  <p>b</p>\n</div>");
+        let styles = compute_styles(&dom, &user_agent_stylesheet(), &Stylesheet::default());
+        let tree = build_box_tree(&dom, &styles);
+
+        let div = find(&dom, dom.document(), "div").expect("div not found");
+        let div_box = find_box(&tree, div).expect("div box not found");
+        let BoxContent::Blocks(children) = &div_box.content else {
+            panic!("expected block children, got {:?}", div_box.content);
+        };
+        assert_eq!(children.len(), 2, "the two <p> only, got {children:?}");
     }
 
     #[test]

--- a/core/src/layout/box_tree.rs
+++ b/core/src/layout/box_tree.rs
@@ -1093,6 +1093,18 @@ fn collect_spans_in_context(
                 out.push(InlineSpan::forced_break(node));
                 return;
             }
+            // `<wbr>`は子を持たない「ここで改行してよい」マーカー
+            // (HTML仕様: line break opportunity)。ZWSPを1つ置くだけで、幅ゼロの
+            // 改行機会という同じ意味になる(`layout::white_space`が改行機会と
+            // して扱う)。ブラウザの実装も同様。
+            if &*name.local == "wbr" {
+                out.push(InlineSpan::text_in_inline_context(
+                    node,
+                    white_space::ZERO_WIDTH_SPACE.to_string(),
+                    context,
+                ));
+                return;
+            }
             // インラインの`<img>`(置換要素)も1つの箱として行に参加する。
             // 中身は`resolve_images`が後から`BoxContent::Image`へ差し替える。
             if &*name.local == "img" {
@@ -1352,6 +1364,24 @@ mod tests {
             spans[0].text, "one",
             "no span should precede the first word, got {spans:?}"
         );
+    }
+
+    #[test]
+    fn wbr_becomes_a_zero_width_space() {
+        // `<wbr>`は「ここで改行してよい」だけを表す要素。ZWSPを1つ置いて
+        // `layout::white_space`の改行機会の規則に載せる。
+        let dom = html::parse(br#"<p>aaa<wbr>bbb</p>"#);
+        let styles = compute_styles(&dom, &user_agent_stylesheet(), &Stylesheet::default());
+        let tree = build_box_tree(&dom, &styles);
+
+        let p = find(&dom, dom.document(), "p").expect("p not found");
+        let p_box = find_box(&tree, p).expect("p box not found");
+        let spans = find_inline_spans(p_box).expect("expected inline content");
+
+        let text: String = spans.iter().map(|span| span.text.as_str()).collect();
+        assert_eq!(text, "aaa\u{200b}bbb");
+        // `<br>`とは違い強制改行ではない(改行「機会」を足すだけ)。
+        assert!(spans.iter().all(|span| !span.is_forced_break));
     }
 
     #[test]

--- a/core/src/layout/box_tree.rs
+++ b/core/src/layout/box_tree.rs
@@ -15,6 +15,8 @@ use crate::style::{
     ListStylePosition, ListStyleType, RgbaColor,
 };
 
+use super::white_space;
+
 #[derive(Debug, Clone)]
 pub struct LayoutBox {
     /// 対応するDOM要素。無名ボックスの場合は`None`。
@@ -995,7 +997,7 @@ fn flush_pending_spans(pending: &mut Vec<InlineSpan>, result: &mut Vec<LayoutBox
     // `text`が空でも意味のある内容なので、1つでもあれば無名ブロックを作る
     let has_meaningful_content = pending
         .iter()
-        .any(|span| span.atomic.is_some() || !span.text.trim().is_empty());
+        .any(|span| span.atomic.is_some() || !white_space::is_collapsible_only(&span.text));
     if has_meaningful_content {
         let mut spans = std::mem::take(pending);
         spans.shrink_to_fit();
@@ -1036,7 +1038,9 @@ fn child_kind(dom: &Dom, styles: &HashMap<NodeId, Rc<ComputedStyle>>, node: Node
             }
         }
         NodeData::Text { contents } => {
-            if contents.trim().is_empty() {
+            // `&nbsp;`だけのテキストノードは「空白のみ」ではない(畳み込まれない
+            // 内容を持つ)ので、`str::trim`ではなくCSSの分類で判定する。
+            if white_space::is_collapsible_only(contents) {
                 ChildKind::Whitespace
             } else {
                 ChildKind::Inline

--- a/core/src/layout/inline.rs
+++ b/core/src/layout/inline.rs
@@ -15,6 +15,7 @@ use super::block::LaidOutBox;
 use super::box_tree::{BoxContent, InlineSpan, LayoutBox};
 use super::float_ctx::FloatContext;
 use super::geometry::Rect;
+use super::white_space;
 
 /// `display: inline-block`のプレースホルダ文字(U+FFFC OBJECT REPLACEMENT
 /// CHARACTER)。実際には描画されず、行組みが箱の位置を保つためだけに使う。
@@ -872,10 +873,14 @@ fn apply_text_transform(ch: char, transform: TextTransform, is_word_start: bool)
     }
 }
 
-/// `char::is_whitespace`基準で`str::split_whitespace`相当に単語分割しつつ、
+/// 畳み込み対象の空白([`white_space::is_collapsible`])で単語分割しつつ、
 /// `<br>`由来の強制改行を[`InlineItem::ForcedBreak`]として出現順に挟み込む。
 /// 連続する空白は畳み込み、先頭・末尾の空白は無視する(強制改行は
 /// 空白ではあるが畳み込まれず、常に1つのアイテムとして残る)。
+///
+/// `&nbsp;`やthin spaceは単語区切りにはならず、単語の一部として
+/// [`split_word_into_runs`]へ渡る(畳み込まれず、フォント本来の字幅で描かれ、
+/// 改行の可否は[`is_break_boundary`]が決める)。
 fn split_into_items(chars: &[StyledChar]) -> Vec<InlineItem<'_>> {
     let mut items = Vec::new();
     let mut word_start = 0usize;
@@ -899,7 +904,7 @@ fn split_into_items(chars: &[StyledChar]) -> Vec<InlineItem<'_>> {
             word_start = i + 1;
             continue;
         }
-        if !sc.ch.is_whitespace() {
+        if !white_space::is_collapsible(sc.ch) {
             continue;
         }
         if word_start < i {
@@ -1218,6 +1223,16 @@ fn split_run_at_width(run: &TextRun, max_width: f32) -> (Option<TextRun>, Option
 /// 改行可能とみなす簡略判定(UAX#14の全面実装ではない)。`break-all`はすべての
 /// 文字境界、`keep-all`はCJK境界でも改行しない。
 fn is_break_boundary(prev: char, next: char, word_break: WordBreak) -> bool {
+    // `&nbsp;`等(UAX #14のGL・WJ)は前後の改行を禁止する。これは`word-break`
+    // より優先する: 「10&nbsp;kg」を分断しないために置かれた文字なので、
+    // `break-all`でも守るのが利用者の意図に合う(ブラウザも同様)。
+    if white_space::is_non_breaking(prev) || white_space::is_non_breaking(next) {
+        return false;
+    }
+    // thin space等(BA)とZWSP(ZW)の直後は改行してよい。
+    if white_space::allows_break_after(prev) {
+        return true;
+    }
     match word_break {
         WordBreak::BreakAll => true,
         WordBreak::KeepAll => false,

--- a/core/src/layout/inline.rs
+++ b/core/src/layout/inline.rs
@@ -102,6 +102,9 @@ pub struct TextRun {
     /// このランの直前がsoft hyphen由来の改行機会かどうか。ここで行が
     /// 分かれたら、前の行の末尾にハイフンを表示する。
     pub(super) hyphen_before: bool,
+    /// このランの直前が改行機会かどうか(soft hyphen・ZWSP・`<wbr>`)。
+    /// ハイフンを出すかどうかは`hyphen_before`が別に持つ。
+    pub(super) break_before: bool,
     /// このランに適用された`vertical-align`の計算値(行の高さ確定後に
     /// `top`/`bottom`を後追いで解決するため、レイアウト中だけ使う)。
     pub(super) vertical_align: VerticalAlign,
@@ -151,6 +154,14 @@ struct StyledChar {
     /// 描画されないため文字列からは取り除き、改行機会としてこのフラグに
     /// 変換する。ここで行が分かれた場合は行末にハイフンを表示する。
     hyphen_before: bool,
+    /// この文字の直前が改行機会かどうか(soft hyphenとZWSP・`<wbr>`)。
+    ///
+    /// `hyphen_before`と分けているのは、ハイフンを表示するかどうかが違うため。
+    /// ZWSPは「幅ゼロの改行機会」でしかないので、グリフを1つも出さずにこの
+    /// フラグへ畳む。文字として残すと、フォントがZWSPのグリフを持たない場合に
+    /// spaceのグリフで代替され、`/ToUnicode`で普通の空白と衝突してPDFの
+    /// テキスト抽出が壊れる(空白がU+200Bとして取り出される)。
+    break_before: bool,
 }
 
 /// 通常フロー(`white-space: normal`/`nowrap`)の行組みの入力単位。
@@ -769,6 +780,14 @@ fn flatten_spans(
     let mut span_links: Vec<Option<Rc<str>>> = Vec::with_capacity(spans.len());
     // spanを跨いでも語頭判定を継続する(先頭は語頭扱い)。
     let mut prev_is_boundary = true;
+    // 直前にsoft hyphenがあったか。
+    //
+    // 改行機会は「次に来る文字」へ持ち越すため、spanの外で持つ必要がある。
+    // `<wbr>`は要素なので必ず単独のspanになり、span内に閉じた変数では
+    // 次のspanへ渡らない(`<span>foo&shy;</span><span>bar</span>`も同様)。
+    let mut hyphen_pending = false;
+    // 直前に改行機会(soft hyphen・ZWSP)があったか。
+    let mut break_pending = false;
 
     for span in spans {
         // スパンごとに背景色などを差し替えるため、共有スタイルから所有スタイルを作る。
@@ -797,20 +816,28 @@ fn flatten_spans(
                 style_index,
                 atomic_span: Some(style_index),
                 is_forced_break: false,
-                hyphen_before: false,
+                hyphen_before: hyphen_pending,
+                break_before: break_pending,
             });
+            hyphen_pending = false;
+            break_pending = false;
             prev_is_boundary = false;
             continue;
         }
 
         let hyphens = span_styles[style_index].hyphens;
-        // 直前にsoft hyphenがあったか。
-        let mut hyphen_pending = false;
         for ch in span.text.chars() {
             // soft hyphen(U+00AD)自身は描画しない。`hyphens: manual`(初期値)
             // なら改行機会として次の文字へ引き継ぎ、`none`なら単に捨てる。
             if ch == SOFT_HYPHEN {
                 hyphen_pending = hyphens == Hyphens::Manual;
+                break_pending |= hyphen_pending;
+                continue;
+            }
+            // ZWSP(`<wbr>`の実体)も描画しない。幅ゼロの改行機会でしかないため、
+            // グリフを出さずにフラグへ畳む(詳細は`StyledChar::break_before`)。
+            if ch == white_space::ZERO_WIDTH_SPACE {
+                break_pending = true;
                 continue;
             }
             let is_word_start = prev_is_boundary;
@@ -821,8 +848,10 @@ fn flatten_spans(
                 atomic_span: None,
                 is_forced_break: span.is_forced_break,
                 hyphen_before: hyphen_pending,
+                break_before: break_pending,
             });
             hyphen_pending = false;
+            break_pending = false;
             prev_is_boundary = ch.is_whitespace();
         }
     }
@@ -950,16 +979,20 @@ fn split_word_into_runs(
     let mut last_char: Option<char> = None;
     // 現在組み立て中のランの直前がsoft hyphen由来の改行機会かどうか。
     let mut current_hyphen_before = false;
+    // 同じく、直前が改行機会(soft hyphen・ZWSP)かどうか。
+    let mut current_break_before = false;
 
     let flush = |runs: &mut Vec<TextRun>,
                  current: Option<(usize, usize)>,
                  text: &str,
-                 hyphen_before: bool| {
+                 hyphen_before: bool,
+                 break_before: bool| {
         if let Some((style_index, fi)) = current {
             let mut run = shape_run(text, fi, fonts, &span_styles[style_index]);
             run.link = span_links.get(style_index).cloned().flatten();
             run.style_index = style_index;
             run.hyphen_before = hyphen_before;
+            run.break_before = break_before;
             runs.push(run);
         }
     };
@@ -979,7 +1012,7 @@ fn split_word_into_runs(
             (Some((style_index, fi)), Some(prev_ch)) => {
                 style_index == sc.style_index
                     && fi == font_index
-                    && !sc.hyphen_before
+                    && !sc.break_before
                     && !is_break_boundary(prev_ch, sc.ch, word_break)
             }
             _ => false,
@@ -988,14 +1021,27 @@ fn split_word_into_runs(
         if continues_current {
             current_text.push(sc.ch);
         } else {
-            flush(&mut runs, current, &current_text, current_hyphen_before);
+            flush(
+                &mut runs,
+                current,
+                &current_text,
+                current_hyphen_before,
+                current_break_before,
+            );
             current_text = sc.ch.to_string();
             current = Some((sc.style_index, font_index));
             current_hyphen_before = sc.hyphen_before;
+            current_break_before = sc.break_before;
         }
         last_char = Some(sc.ch);
     }
-    flush(&mut runs, current, &current_text, current_hyphen_before);
+    flush(
+        &mut runs,
+        current,
+        &current_text,
+        current_hyphen_before,
+        current_break_before,
+    );
 
     runs
 }
@@ -1009,8 +1055,8 @@ fn group_into_chunks(runs: Vec<TextRun>, word_break: WordBreak) -> Vec<Vec<TextR
     for run in runs {
         let starts_new_chunk = match chunks.last().and_then(|chunk| chunk.last()) {
             None => true,
-            // soft hyphenも改行機会。
-            Some(_) if run.hyphen_before => true,
+            // soft hyphen・ZWSP(`<wbr>`)も改行機会。
+            Some(_) if run.break_before => true,
             Some(prev) => is_break_boundary(
                 prev.text.chars().last().unwrap_or(' '),
                 run.text.chars().next().unwrap_or(' '),
@@ -1214,6 +1260,7 @@ fn split_run_at_width(run: &TextRun, max_width: f32) -> (Option<TextRun>, Option
     tail.x_offset = 0.0;
     // 後半は「単語の途中で切られた」だけなので、ハイフンは表示しない。
     tail.hyphen_before = false;
+    tail.break_before = false;
 
     (Some(head), Some(tail))
 }
@@ -1430,10 +1477,12 @@ pub(super) fn shape_run(
         text_shadow: (!style.text_shadow.is_empty())
             .then(|| Rc::from(style.text_shadow.as_slice())),
         emphasis,
-        // `style_index`/`hyphen_before`は呼び出し側(`split_word_into_runs`)が
-        // 設定する。単体で使う経路(`shape_standalone_line`等)では既定値でよい。
+        // `style_index`/`hyphen_before`/`break_before`は呼び出し側
+        // (`split_word_into_runs`)が設定する。単体で使う経路
+        // (`shape_standalone_line`等)では既定値でよい。
         style_index: 0,
         hyphen_before: false,
+        break_before: false,
     }
 }
 

--- a/core/src/layout/mod.rs
+++ b/core/src/layout/mod.rs
@@ -10,6 +10,7 @@ mod inline;
 mod page;
 mod paginate;
 mod table;
+mod white_space;
 
 pub(crate) use block::{
     has_visible_decoration, resolve_border, resolve_lpa_or_zero, resolve_padding,
@@ -32,3 +33,4 @@ pub use paginate::{
     paginate, paginate_document, paginate_document_streaming, paginate_document_with_absolutes,
     paginate_streaming, Page, StreamingPaginator,
 };
+pub(crate) use white_space::is_collapsible_only;

--- a/core/src/layout/white_space.rs
+++ b/core/src/layout/white_space.rs
@@ -1,0 +1,119 @@
+//! 空白文字の分類。
+//!
+//! Unicodeには`char::is_whitespace`(White_Spaceプロパティ)が真になる文字が
+//! 多数あるが、CSSの行組みではそれらを一律に扱ってはいけない。分類は2軸ある。
+//!
+//! 1. **畳み込むか** — CSS Text 3 §4.1が畳み込みの対象とするのは
+//!    space (U+0020)・tab (U+0009)・segment break (U+000A)だけで、それ以外の
+//!    Zs(`&nbsp;`やthin spaceなど)は「畳み込まれない普通の文字」として扱う。
+//!    Blinkの`Character::IsCollapsibleSpace`(space/LF/tab/CR)、Geckoの
+//!    `nsTextFrameUtils::IsSpaceOrTab`(space/tab、改行は別処理)も同じ範囲。
+//!    畳み込まない文字は行組みの単語区切りにはならず、そのままシェイピングへ
+//!    渡してフォント本来の字幅で描く(`&nbsp;`3個は空白3個分の幅になる)。
+//!
+//! 2. **その位置で改行してよいか** — UAX #14の行分割クラスによる。
+//!    `&nbsp;`(GL)や図形用スペース(GL)は前後で改行してはならず、
+//!    thin space等(BA)とZWSP(ZW)は直後で改行してよい。
+//!
+//! グリフを持たないフォントでも字幅が壊れないのは、シェイパー(harfrust)が
+//! HarfBuzzのspace fallback(`_hb_ot_shape_fallback_spaces`)を実装しており、
+//! 該当グリフが無ければspaceのグリフで代替して`em/2`・`em/5`といった規定の
+//! アドバンスを設定してくれるため。こちら側で幅を用意する必要はない。
+//!
+//! 既知の簡略化: U+000B・U+0085・U+2028・U+2029は本来「強制改行」だが、
+//! グリフを持たないフォントで.notdefが出るのを避けるため、ここでは畳み込む
+//! 空白(=単語区切り)として扱う(従来の挙動のまま)。
+
+/// 畳み込みの対象になる空白かどうか(CSS Text 3の"collapsible white space")。
+///
+/// `white-space: normal`ではこの文字の並びが1個の単語間スペースになり、行頭・
+/// 行末では捨てられる。ここに含まれない空白文字(`&nbsp;`等)は普通の文字。
+pub(crate) fn is_collapsible(ch: char) -> bool {
+    matches!(
+        ch,
+        '\u{20}'      // SPACE
+        | '\u{9}'     // TAB
+        | '\u{a}'     // LF(HTMLのsegment break)
+        | '\u{d}'     // CR(パーサでLFへ正規化されるが防御的に)
+        | '\u{c}'     // FF(HTMLのASCII whitespace)
+        | '\u{b}'     // VT
+        | '\u{85}'    // NEL
+        | '\u{2028}'  // LINE SEPARATOR
+        | '\u{2029}' // PARAGRAPH SEPARATOR
+    )
+}
+
+/// 文字列が畳み込み対象の空白だけでできているか(=そこにボックスを作らなく
+/// てよいか)。`str::trim`と違い、`&nbsp;`だけの文字列は「空白のみ」ではない
+/// (内容を持つ)と判定する。
+pub(crate) fn is_collapsible_only(text: &str) -> bool {
+    text.chars().all(is_collapsible)
+}
+
+/// 前後で改行してはならない空白かどうか(UAX #14のGL・WJ)。
+///
+/// `&nbsp;`はまさにこのために使われる文字なので、`word-break: break-all`より
+/// 優先して効かせる(ブラウザも「10&nbsp;kg」を分断しない)。
+pub(crate) fn is_non_breaking(ch: char) -> bool {
+    matches!(
+        ch,
+        '\u{a0}'      // NO-BREAK SPACE (GL)
+        | '\u{2007}'  // FIGURE SPACE (GL、数字の桁揃え用)
+        | '\u{202f}'  // NARROW NO-BREAK SPACE (GL)
+        | '\u{2060}'  // WORD JOINER (WJ)
+        | '\u{feff}' // ZERO WIDTH NO-BREAK SPACE (WJ)
+    )
+}
+
+/// 直後で改行してよい空白かどうか(UAX #14のBA・ZW)。
+///
+/// 幅を持つ整形用スペース(thin space等)と、幅を持たないZWSPの両方を含む。
+/// U+3000 IDEOGRAPHIC SPACEは`inline::is_cjk`が既に改行機会として扱うため
+/// (かつ`word-break: keep-all`の対象であるべきなため)ここには含めない。
+pub(crate) fn allows_break_after(ch: char) -> bool {
+    matches!(
+        ch,
+        '\u{1680}'          // OGHAM SPACE MARK (BA)
+        | '\u{2000}'..='\u{2006}' // EN QUAD〜SIX-PER-EM SPACE (BA)
+        | '\u{2008}'..='\u{200a}' // PUNCTUATION/THIN/HAIR SPACE (BA)
+        | '\u{200b}'        // ZERO WIDTH SPACE (ZW)
+        | '\u{205f}' // MEDIUM MATHEMATICAL SPACE (BA)
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn only_the_css_collapsible_set_collapses() {
+        for ch in [' ', '\t', '\n', '\r'] {
+            assert!(is_collapsible(ch), "{ch:?} should collapse");
+        }
+        // `char::is_whitespace`は真だが、CSS上は普通の文字。
+        for ch in ['\u{a0}', '\u{2009}', '\u{3000}', '\u{202f}', '\u{2007}'] {
+            assert!(ch.is_whitespace(), "{ch:?} is Unicode white space");
+            assert!(!is_collapsible(ch), "{ch:?} must not collapse");
+        }
+    }
+
+    #[test]
+    fn a_nbsp_only_string_is_not_whitespace_only() {
+        assert!(is_collapsible_only(" \n\t "));
+        assert!(is_collapsible_only(""));
+        assert!(!is_collapsible_only("\u{a0}"));
+        assert!(!is_collapsible_only(" \u{2009} "));
+    }
+
+    #[test]
+    fn glue_and_break_after_classes_do_not_overlap() {
+        for ch in ['\u{a0}', '\u{2007}', '\u{202f}', '\u{2060}', '\u{feff}'] {
+            assert!(is_non_breaking(ch));
+            assert!(!allows_break_after(ch));
+        }
+        for ch in ['\u{2002}', '\u{2009}', '\u{200a}', '\u{200b}', '\u{205f}'] {
+            assert!(allows_break_after(ch));
+            assert!(!is_non_breaking(ch));
+        }
+    }
+}

--- a/core/src/layout/white_space.rs
+++ b/core/src/layout/white_space.rs
@@ -24,6 +24,9 @@
 //! グリフを持たないフォントで.notdefが出るのを避けるため、ここでは畳み込む
 //! 空白(=単語区切り)として扱う(従来の挙動のまま)。
 
+/// 幅を持たない改行機会(UAX #14のZWクラス)。`<wbr>`の実体でもある。
+pub(crate) const ZERO_WIDTH_SPACE: char = '\u{200b}';
+
 /// 畳み込みの対象になる空白かどうか(CSS Text 3の"collapsible white space")。
 ///
 /// `white-space: normal`ではこの文字の並びが1個の単語間スペースになり、行頭・
@@ -65,9 +68,11 @@ pub(crate) fn is_non_breaking(ch: char) -> bool {
     )
 }
 
-/// 直後で改行してよい空白かどうか(UAX #14のBA・ZW)。
+/// 直後で改行してよい空白かどうか(UAX #14のBA)。
 ///
-/// 幅を持つ整形用スペース(thin space等)と、幅を持たないZWSPの両方を含む。
+/// 幅を持つ整形用スペース(thin space等)が対象。ZWSP(ZW)はここには現れない:
+/// グリフを出さずに改行機会のフラグへ畳むため、`inline::flatten_spans`が
+/// 文字の段階で取り除いている。
 /// U+3000 IDEOGRAPHIC SPACEは`inline::is_cjk`が既に改行機会として扱うため
 /// (かつ`word-break: keep-all`の対象であるべきなため)ここには含めない。
 pub(crate) fn allows_break_after(ch: char) -> bool {
@@ -76,7 +81,6 @@ pub(crate) fn allows_break_after(ch: char) -> bool {
         '\u{1680}'          // OGHAM SPACE MARK (BA)
         | '\u{2000}'..='\u{2006}' // EN QUAD〜SIX-PER-EM SPACE (BA)
         | '\u{2008}'..='\u{200a}' // PUNCTUATION/THIN/HAIR SPACE (BA)
-        | '\u{200b}'        // ZERO WIDTH SPACE (ZW)
         | '\u{205f}' // MEDIUM MATHEMATICAL SPACE (BA)
     )
 }
@@ -111,9 +115,13 @@ mod tests {
             assert!(is_non_breaking(ch));
             assert!(!allows_break_after(ch));
         }
-        for ch in ['\u{2002}', '\u{2009}', '\u{200a}', '\u{200b}', '\u{205f}'] {
+        for ch in ['\u{2002}', '\u{2009}', '\u{200a}', '\u{205f}'] {
             assert!(allows_break_after(ch));
             assert!(!is_non_breaking(ch));
         }
+        // ZWSPは文字として残らない(`inline::flatten_spans`が取り除く)ので
+        // どちらの表にも載せない。
+        assert!(!allows_break_after(ZERO_WIDTH_SPACE));
+        assert!(!is_non_breaking(ZERO_WIDTH_SPACE));
     }
 }

--- a/core/src/pdf/document.rs
+++ b/core/src/pdf/document.rs
@@ -1586,9 +1586,13 @@ fn paint_order<'a>(
 /// (内容として意味を持つため)。
 fn laid_content_is_empty(content: &LaidOutContent) -> bool {
     match content {
-        LaidOutContent::Inline(lines) => lines
-            .iter()
-            .all(|line| line.runs.iter().all(|run| run.text.trim().is_empty())),
+        // `<td>&nbsp;</td>`は「空のセル」ではない(枠を出すための定番の書き方)。
+        // `str::trim`は`&nbsp;`も落としてしまうためCSSの分類で判定する。
+        LaidOutContent::Inline(lines) => lines.iter().all(|line| {
+            line.runs
+                .iter()
+                .all(|run| crate::layout::is_collapsible_only(&run.text))
+        }),
         LaidOutContent::Blocks(children) => {
             children.is_empty() || children.iter().all(|c| laid_content_is_empty(&c.content))
         }
@@ -4863,6 +4867,26 @@ mod tests {
             hidden < shown,
             "hiding the empty cell should remove its border/background fills \
              (shown={shown}, hidden={hidden})"
+        );
+    }
+
+    #[test]
+    fn a_cell_holding_only_a_no_break_space_does_not_count_as_empty() {
+        // `<td>&nbsp;</td>`は枠を出すための定番の書き方。`&nbsp;`は畳み込まれない
+        // 内容を持つので、`empty-cells: hide`で消してはいけない
+        // (`str::trim`で空判定していた頃は空セル扱いになっていた)。
+        let css = "td { border: 1px solid black; background-color: rgb(200,200,200); } \
+                   table { empty-cells: hide; }";
+
+        let truly_empty =
+            fill_operator_count(r#"<table><tr><td>Apple</td><td></td></tr></table>"#, css);
+        let with_nbsp =
+            fill_operator_count("<table><tr><td>Apple</td><td>\u{a0}</td></tr></table>", css);
+
+        assert!(
+            with_nbsp > truly_empty,
+            "a cell with &nbsp; should keep its decoration \
+             (nbsp={with_nbsp}, empty={truly_empty})"
         );
     }
 

--- a/core/src/pdf/font.rs
+++ b/core/src/pdf/font.rs
@@ -24,6 +24,7 @@
 //! `pdf-writer`は圧縮を自前で行わないため、サブセット後のフォントバイト列は
 //! `flate2`でzlib(`/FlateDecode`)圧縮してから埋め込む。
 
+use std::collections::btree_map::Entry;
 use std::collections::BTreeMap;
 use std::io::Write;
 
@@ -62,12 +63,26 @@ impl FontUsage {
     ///
     /// 1文字とは限らないのは合字のため(`fl`が1グリフになる等)。1文字しか
     /// 持たせないと、PDFのテキスト抽出・検索で"float"が"foat"になる。
+    ///
+    /// 複数の文字が同じグリフを共有することもある。フォントが`&nbsp;`の
+    /// グリフを持たない場合、シェイパーはspaceのグリフで代替する(HarfBuzzの
+    /// space fallback)ため、そのグリフは文書内でU+0020とU+00A0の両方を表す。
+    /// 先勝ちのままだと、文書中で`&nbsp;`が先に現れただけで以後すべての空白が
+    /// U+00A0として抽出され、テキスト検索やコピーが壊れる。衝突したときは
+    /// 普通のspaceを優先する。
     pub fn record(&mut self, font: &Font, glyph_id: u16, text: &str) {
-        self.glyphs.entry(glyph_id).or_insert_with(|| {
-            let advance = font.glyph_hor_advance(glyph_id).unwrap_or(0) as f32;
-            let width_1000 = advance * 1000.0 / font.units_per_em() as f32;
-            (width_1000, text.to_string())
-        });
+        match self.glyphs.entry(glyph_id) {
+            Entry::Vacant(slot) => {
+                let advance = font.glyph_hor_advance(glyph_id).unwrap_or(0) as f32;
+                let width_1000 = advance * 1000.0 / font.units_per_em() as f32;
+                slot.insert((width_1000, text.to_string()));
+            }
+            Entry::Occupied(mut slot) => {
+                if text == " " && slot.get().1 != " " {
+                    slot.get_mut().1 = text.to_string();
+                }
+            }
+        }
     }
 }
 
@@ -351,6 +366,41 @@ mod tests {
             data.len(),
             compressed.len()
         );
+    }
+
+    const TEST_FONT: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fonts/DejaVuSans.ttf");
+
+    /// `&nbsp;`のグリフを持たないフォントでは、シェイパーがspaceのグリフで
+    /// 代替するため1つのグリフが両方を表す。その場合でも`/ToUnicode`は
+    /// 普通のspaceを指すようにする(そうしないと文書中の空白すべてが
+    /// U+00A0として抽出され、テキスト検索やコピーが壊れる)。
+    #[test]
+    fn a_glyph_shared_by_a_space_and_a_no_break_space_maps_to_the_space() {
+        let font = Font::load(TEST_FONT).expect("should load bundled test font");
+        let space_glyph = 3;
+
+        // `&nbsp;`が先に現れた場合でもspaceが勝つ。
+        let mut nbsp_first = FontUsage::default();
+        nbsp_first.record(&font, space_glyph, "\u{a0}");
+        nbsp_first.record(&font, space_glyph, " ");
+        assert_eq!(nbsp_first.glyphs[&space_glyph].1, " ");
+
+        // 逆順でもspaceのまま(`&nbsp;`で上書きしない)。
+        let mut space_first = FontUsage::default();
+        space_first.record(&font, space_glyph, " ");
+        space_first.record(&font, space_glyph, "\u{a0}");
+        assert_eq!(space_first.glyphs[&space_glyph].1, " ");
+    }
+
+    #[test]
+    fn a_ligature_cluster_keeps_the_text_it_was_first_recorded_with() {
+        // 合字は複数文字を1グリフで表す。空白の優先は合字の記録を壊さない。
+        let font = Font::load(TEST_FONT).expect("should load bundled test font");
+        let mut usage = FontUsage::default();
+        usage.record(&font, 100, "fl");
+        usage.record(&font, 100, "fl");
+
+        assert_eq!(usage.glyphs[&100].1, "fl");
     }
 
     #[test]

--- a/core/tests/typography.rs
+++ b/core/tests/typography.rs
@@ -315,6 +315,67 @@ fn text_transform_uppercase_applies_end_to_end() {
     assert_eq!(page_count, 1);
 }
 
+/// 最初の`<p>`が組んだ1行の幅と、その行のラン数を返す。
+fn first_p_line(html_src: &str, css: &str) -> (f32, usize) {
+    let (dom, laid) = layout(html_src, css);
+    let p = find_tag(&dom, dom.document(), "p").expect("p not found");
+    let p_box = find_laid_out(&laid, p).expect("p box not found");
+    let LaidOutContent::Inline(lines) = &p_box.content else {
+        panic!("expected inline content");
+    };
+    assert_eq!(lines.len(), 1, "expected a single line, got {lines:?}");
+    (lines[0].rect.width, lines[0].runs.len())
+}
+
+#[test]
+fn whitespace_between_inline_elements_still_separates_the_words_end_to_end() {
+    // 回帰テスト(issue #3): インライン要素同士の間の空白が捨てられ、
+    // `<span>one</span> <span>two</span>`が`onetwo`と組まれていた。単語間の
+    // 空白はランのx方向オフセットとして現れるため、行幅で検証する。
+    let css = "body { margin: 0; } p { margin: 0; }";
+    let (separate, separate_runs) = first_p_line("<p><span>one</span> <span>two</span></p>", css);
+    let (plain, _) = first_p_line("<p>one two</p>", css);
+    let (joined, _) = first_p_line("<p>onetwo</p>", css);
+
+    assert_eq!(separate_runs, 2, "one run per <span>");
+    assert!(
+        (separate - plain).abs() < 0.01,
+        "should be as wide as the same text without elements: {separate} vs {plain}"
+    );
+    assert!(
+        separate > joined + 1.0,
+        "the word gap must be there: {separate} vs {joined} without a space"
+    );
+}
+
+#[test]
+fn trailing_whitespace_after_an_inline_element_does_not_widen_the_line_end_to_end() {
+    // 末尾の空白はスパンとして残るが、行の幅には影響してはいけない
+    // (`text-align: right`/`justify`がずれるため)。
+    let css = "body { margin: 0; } p { margin: 0; }";
+    let (with_whitespace, _) = first_p_line("<p><span>one</span>\n</p>", css);
+    let (without, _) = first_p_line("<p><span>one</span></p>", css);
+
+    assert_eq!(
+        with_whitespace, without,
+        "trailing whitespace must not add width"
+    );
+}
+
+#[test]
+fn a_non_breaking_space_between_inline_elements_still_separates_the_words_end_to_end() {
+    // 同じく issue #3。`&nbsp;`も`char::is_whitespace`が真になるため、空白のみの
+    // テキストノードとして一緒に捨てられていた。
+    let css = "body { margin: 0; } p { margin: 0; }";
+    let (nbsp, _) = first_p_line("<p><span>one</span>\u{a0}<span>two</span></p>", css);
+    let (joined, _) = first_p_line("<p>onetwo</p>", css);
+
+    assert!(
+        nbsp > joined + 1.0,
+        "&nbsp; must separate the words: {nbsp} vs {joined} without a space"
+    );
+}
+
 #[test]
 fn combined_typography_properties_render_a_valid_pdf_end_to_end() {
     // justify + line-height + text-indent + letter-spacing + white-space: pre

--- a/core/tests/unicode_spaces.rs
+++ b/core/tests/unicode_spaces.rs
@@ -9,11 +9,14 @@
 //! - 改行してよい位置はUAX #14の行分割クラスに従う(`&nbsp;`は不可、
 //!   thin space・ZWSPは直後で可)。
 
+use std::collections::HashMap;
+
 use sghtmltopdf_core::fonts::{Font, FontCollection};
 use sghtmltopdf_core::html::{self, Dom, NodeData, NodeId};
 use sghtmltopdf_core::layout::{
-    build_box_tree, layout_document, LaidOutBox, LaidOutContent, PageSettings,
+    build_box_tree, layout_document, paginate_document, LaidOutBox, LaidOutContent, PageSettings,
 };
+use sghtmltopdf_core::pdf::encode_pdf;
 use sghtmltopdf_core::style::{compute_styles, parse_stylesheet, user_agent_stylesheet};
 
 const FONT_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fonts/DejaVuSans.ttf");
@@ -198,6 +201,133 @@ fn a_no_break_space_stays_glued_even_under_word_break_break_all() {
     assert!(
         lines.iter().any(|(_, text)| text.contains("0\u{a0}k")),
         "the characters around the &nbsp; must stay on one line, got {lines:?}"
+    );
+}
+
+// ===== `<wbr>` =====
+
+#[test]
+fn wbr_offers_a_wrap_opportunity_inside_a_long_word() {
+    // HTML仕様の"line break opportunity"。長い識別子やURLを狙った位置で
+    // 折り返すために使われる。
+    let broken = narrow_lines("<p>aaaaaa<wbr>bbbbbb</p>");
+    let unbroken = narrow_lines("<p>aaaaaabbbbbb</p>");
+
+    assert_eq!(broken.len(), 2, "<wbr> should break, got {broken:?}");
+    assert_eq!(broken[0].1, "aaaaaa");
+    assert_eq!(broken[1].1, "bbbbbb");
+    assert_eq!(
+        unbroken.len(),
+        1,
+        "without <wbr> the long word overflows instead, got {unbroken:?}"
+    );
+}
+
+#[test]
+fn wbr_adds_no_width_when_the_line_does_not_wrap() {
+    assert_eq!(
+        width_of("<p>aaa<wbr>bbb</p>"),
+        width_of("<p>aaabbb</p>"),
+        "<wbr> must not change the width of a line that fits"
+    );
+}
+
+#[test]
+fn wbr_only_offers_a_break_it_does_not_force_one() {
+    // `<br>`との違い。収まるうちは1行のまま。
+    let lines = p_lines("<p>aaa<wbr>bbb</p>", "body { margin: 0; } p { margin: 0; }");
+    assert_eq!(lines.len(), 1, "<wbr> is not a forced break, got {lines:?}");
+}
+
+#[test]
+fn wbr_survives_word_break_keep_all() {
+    // `word-break: keep-all`は「単語内で改行しない」指定だが、`<wbr>`は
+    // 明示的に置かれた改行機会なので効き続ける(ZWクラスはUAX #14でも
+    // 単語の切れ目とは独立に扱われる)。
+    let lines = p_lines(
+        "<p>aaaaaa<wbr>bbbbbb</p>",
+        "body { margin: 0; } p { margin: 0; width: 40px; word-break: keep-all; }",
+    );
+
+    assert_eq!(lines.len(), 2, "<wbr> should still break, got {lines:?}");
+}
+
+/// PDFのストリームをすべて展開して連結する(`/ToUnicode`
+/// CMapを覗くため。`typography.rs`と同じ手順)。
+fn decompressed_streams(html_src: &str) -> Vec<u8> {
+    let dom = html::parse(html_src.as_bytes());
+    let styles = compute_styles(
+        &dom,
+        &user_agent_stylesheet(),
+        &parse_stylesheet("body { margin: 0; }"),
+    );
+    let fonts = FontCollection::new(vec![
+        Font::load(FONT_PATH).expect("should load bundled test font")
+    ]);
+    let settings = PageSettings::default();
+    let pages = paginate_document(&dom, &styles, &fonts, &settings);
+    let bytes = encode_pdf(&pages, &styles, &HashMap::new(), &fonts, &settings);
+
+    fn find(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+        haystack.windows(needle.len()).position(|w| w == needle)
+    }
+    let mut out = Vec::new();
+    let mut i = 0;
+    while let Some(pos) = find(&bytes[i..], b"stream\n") {
+        let start = i + pos + b"stream\n".len();
+        let Some(end_rel) = find(&bytes[start..], b"endstream") else {
+            break;
+        };
+        let end = start + end_rel;
+        let mut decoder = flate2::read::ZlibDecoder::new(&bytes[start..end]);
+        let mut decompressed = Vec::new();
+        if std::io::Read::read_to_end(&mut decoder, &mut decompressed).is_ok() {
+            out.extend_from_slice(&decompressed);
+        }
+        i = end + b"endstream".len();
+    }
+    out
+}
+
+#[test]
+fn wbr_leaves_no_character_in_the_laid_out_text() {
+    // `<wbr>`は改行機会であって文字ではない。ZWSPを文字として流すと、
+    // フォントがZWSPのグリフを持たない場合にspaceのグリフで代替されるため、
+    // PDFのテキスト層に幽霊の空白が入る(抽出すると`inline word`になる)。
+    for html_src in [
+        "<p>inline<wbr>word</p>",
+        "<p>a<wbr>b<wbr>c</p>",
+        "<p>\u{200b}text</p>",
+    ] {
+        let lines = p_lines(html_src, "body { margin: 0; } p { margin: 0; }");
+        assert!(
+            lines.iter().all(|(_, text)| !text.contains('\u{200b}')),
+            "no run may carry a U+200B for {html_src}, got {lines:?}"
+        );
+    }
+    assert_eq!(
+        p_lines("<p>inline<wbr>word</p>", "body { margin: 0; }")[0].1,
+        "inlineword",
+        "the text either side of a <wbr> is contiguous"
+    );
+}
+
+#[test]
+fn wbr_leaves_nothing_behind_in_the_pdf_text_layer() {
+    // 回帰テスト: `<wbr>`をZWSPの「文字」として流していた頃は、フォントが
+    // ZWSPのグリフを持たないためspaceのグリフで代替され、`/ToUnicode`が
+    // そのグリフをU+200Bに割り当てていた。結果、文書中のすべての空白が
+    // U+200Bとして抽出され、コピー&ペーストとテキスト検索が壊れていた。
+    let pdf = decompressed_streams("<p>inline<wbr>word stays</p>");
+    let text = String::from_utf8_lossy(&pdf);
+
+    assert!(
+        !text.contains("<200B>"),
+        "<wbr> must not reach the /ToUnicode CMap"
+    );
+    assert!(
+        text.contains("<0020>"),
+        "the space glyph must still map to U+0020, got:\n{text}"
     );
 }
 

--- a/core/tests/unicode_spaces.rs
+++ b/core/tests/unicode_spaces.rs
@@ -1,0 +1,214 @@
+//! `&nbsp;`をはじめとするUnicodeの空白文字のE2Eテスト。
+//!
+//! `typography.rs`と同じ方針で、実際のパイプライン(HTMLパース→スタイル
+//! カスケード→レイアウト)を通して検証する。判定の基準は
+//! `layout::white_space`と同じ2軸:
+//!
+//! - 畳み込まれるのはCSS Text 3の対象(space/tab/改行)だけで、それ以外の
+//!   空白は普通の文字としてフォント本来の字幅で描かれる。
+//! - 改行してよい位置はUAX #14の行分割クラスに従う(`&nbsp;`は不可、
+//!   thin space・ZWSPは直後で可)。
+
+use sghtmltopdf_core::fonts::{Font, FontCollection};
+use sghtmltopdf_core::html::{self, Dom, NodeData, NodeId};
+use sghtmltopdf_core::layout::{
+    build_box_tree, layout_document, LaidOutBox, LaidOutContent, PageSettings,
+};
+use sghtmltopdf_core::style::{compute_styles, parse_stylesheet, user_agent_stylesheet};
+
+const FONT_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fonts/DejaVuSans.ttf");
+
+fn find_tag(dom: &Dom, id: NodeId, tag: &str) -> Option<NodeId> {
+    if let NodeData::Element { name, .. } = &dom.node(id).data {
+        if &*name.local == tag {
+            return Some(id);
+        }
+    }
+    dom.children(id).find_map(|child| find_tag(dom, child, tag))
+}
+
+fn find_laid_out(b: &LaidOutBox, target: NodeId) -> Option<&LaidOutBox> {
+    if b.node == Some(target) {
+        return Some(b);
+    }
+    if let LaidOutContent::Blocks(children) = &b.content {
+        return children.iter().find_map(|c| find_laid_out(c, target));
+    }
+    None
+}
+
+/// 最初の`<p>`が組んだ行を`(幅, テキスト)`の並びで返す。
+fn p_lines(html_src: &str, css: &str) -> Vec<(f32, String)> {
+    let dom = html::parse(html_src.as_bytes());
+    let styles = compute_styles(&dom, &user_agent_stylesheet(), &parse_stylesheet(css));
+    let fonts = FontCollection::new(vec![
+        Font::load(FONT_PATH).expect("should load bundled test font")
+    ]);
+    let tree = build_box_tree(&dom, &styles);
+    let laid = layout_document(
+        &tree,
+        &styles,
+        &fonts,
+        PageSettings::default().content_width(),
+    );
+    let p = find_tag(&dom, dom.document(), "p").expect("p not found");
+    let p_box = find_laid_out(&laid, p).expect("p should be laid out");
+    let LaidOutContent::Inline(lines) = &p_box.content else {
+        panic!("expected inline content");
+    };
+    lines
+        .iter()
+        .map(|line| {
+            (
+                line.rect.width,
+                line.runs.iter().map(|r| r.text.as_str()).collect(),
+            )
+        })
+        .collect()
+}
+
+/// 折り返さない幅で1行に組んだときの幅。
+fn width_of(html_src: &str) -> f32 {
+    let lines = p_lines(html_src, "body { margin: 0; } p { margin: 0; }");
+    assert_eq!(lines.len(), 1, "expected a single line, got {lines:?}");
+    lines[0].0
+}
+
+/// 40px幅の`<p>`に組んだときの行数(改行機会の有無を見るため)。
+fn narrow_lines(html_src: &str) -> Vec<(f32, String)> {
+    p_lines(
+        html_src,
+        "body { margin: 0; } p { margin: 0; width: 40px; }",
+    )
+}
+
+// ===== 畳み込み =====
+
+#[test]
+fn runs_of_ordinary_spaces_still_collapse_into_one() {
+    assert_eq!(
+        width_of("<p>a   b</p>"),
+        width_of("<p>a b</p>"),
+        "space/tab/newline are the only collapsible characters"
+    );
+    assert_eq!(width_of("<p>a \t\n b</p>"), width_of("<p>a b</p>"));
+}
+
+#[test]
+fn a_run_of_no_break_spaces_does_not_collapse() {
+    // `&nbsp;&nbsp;&nbsp;`は空白3個分の幅を占める(桁揃えに使われる)。
+    // 畳み込んでいた頃は普通の空白1個と同じ幅になっていた。
+    let one_space = width_of("<p>a b</p>");
+    let three_nbsp = width_of("<p>a\u{a0}\u{a0}\u{a0}b</p>");
+
+    assert!(
+        three_nbsp > one_space + 1.0,
+        "three &nbsp; must be wider than a single space ({three_nbsp} vs {one_space})"
+    );
+}
+
+#[test]
+fn a_no_break_space_is_as_wide_as_a_space() {
+    // DejaVu Sansでは`&nbsp;`とspaceのアドバンスが等しい。フォントがグリフを
+    // 持たない場合もシェイパーのspace fallbackが同じ幅を割り当てる。
+    assert_eq!(width_of("<p>a\u{a0}b</p>"), width_of("<p>a b</p>"));
+}
+
+#[test]
+fn fixed_width_spaces_keep_their_own_advance() {
+    // 整形用スペースは「空白1個」に均されず、それぞれの字幅で描かれる。
+    let none = width_of("<p>ab</p>");
+    let hair = width_of("<p>a\u{200a}b</p>");
+    let thin = width_of("<p>a\u{2009}b</p>");
+    let space = width_of("<p>a b</p>");
+    let em = width_of("<p>a\u{2003}b</p>");
+
+    assert!(
+        none < hair && hair < thin && thin < space && space < em,
+        "expected none < hair < thin < space < em, got \
+         {none} / {hair} / {thin} / {space} / {em}"
+    );
+}
+
+#[test]
+fn a_zero_width_space_takes_no_room() {
+    assert_eq!(
+        width_of("<p>a\u{200b}b</p>"),
+        width_of("<p>ab</p>"),
+        "U+200B must not add width"
+    );
+}
+
+// ===== 改行機会(UAX #14) =====
+
+#[test]
+fn a_no_break_space_does_not_offer_a_wrap_opportunity() {
+    // 「10 kg」は折り返せるが、「10&nbsp;kg」は1行に留まる(はみ出してでも
+    // 分断しない)。`&nbsp;`はまさにこれのために置かれる文字。
+    assert_eq!(narrow_lines("<p>10 kg</p>").len(), 2);
+
+    let glued = narrow_lines("<p>10\u{a0}kg</p>");
+    assert_eq!(glued.len(), 1, "&nbsp; must not break, got {glued:?}");
+    assert_eq!(glued[0].1, "10\u{a0}kg");
+}
+
+#[test]
+fn the_other_non_breaking_spaces_do_not_wrap_either() {
+    for (name, ch) in [
+        ("NARROW NO-BREAK SPACE", '\u{202f}'),
+        ("FIGURE SPACE", '\u{2007}'),
+        ("WORD JOINER", '\u{2060}'),
+    ] {
+        let lines = narrow_lines(&format!("<p>10{ch}kg</p>"));
+        assert_eq!(lines.len(), 1, "{name} must not break, got {lines:?}");
+    }
+}
+
+#[test]
+fn a_thin_space_offers_a_wrap_opportunity() {
+    // UAX #14でBAクラスの空白は直後で改行してよい。
+    let lines = narrow_lines("<p>10\u{2009}kg</p>");
+    assert_eq!(lines.len(), 2, "thin space should break, got {lines:?}");
+    assert_eq!(lines[1].1, "kg", "the break belongs after the space");
+}
+
+#[test]
+fn a_zero_width_space_offers_a_wrap_opportunity_inside_a_word() {
+    // ZWSPは幅を持たないまま改行機会だけを足す(`<wbr>`相当の使い方)。
+    let broken = narrow_lines("<p>aaaaaa\u{200b}bbbbbb</p>");
+    let unbroken = narrow_lines("<p>aaaaaabbbbbb</p>");
+
+    assert_eq!(broken.len(), 2, "U+200B should break, got {broken:?}");
+    assert_eq!(
+        unbroken.len(),
+        1,
+        "without U+200B the long word overflows instead, got {unbroken:?}"
+    );
+}
+
+#[test]
+fn a_no_break_space_stays_glued_even_under_word_break_break_all() {
+    // `word-break: break-all`はどこでも改行してよいが、`&nbsp;`のために置かれた
+    // 結合はそれより優先する(ブラウザも同じ扱い)。
+    let lines = p_lines(
+        "<p>10\u{a0}kg</p>",
+        "body { margin: 0; } p { margin: 0; width: 40px; word-break: break-all; }",
+    );
+
+    assert!(
+        lines.iter().any(|(_, text)| text.contains("0\u{a0}k")),
+        "the characters around the &nbsp; must stay on one line, got {lines:?}"
+    );
+}
+
+// ===== ボックス生成 =====
+
+#[test]
+fn a_paragraph_holding_only_a_no_break_space_still_produces_a_line() {
+    // 空白のみのテキストならボックスを作らないが、`&nbsp;`は内容なので行になる。
+    let blank = p_lines("<p> \n </p>", "body { margin: 0; }");
+    let nbsp = p_lines("<p>\u{a0}</p>", "body { margin: 0; }");
+
+    assert!(blank.is_empty(), "collapsible whitespace makes no line");
+    assert_eq!(nbsp.len(), 1, "&nbsp; is content and makes a line");
+}

--- a/docs/src/appendix/limitations.md
+++ b/docs/src/appendix/limitations.md
@@ -51,6 +51,20 @@
 * `position: sticky`、`display: inline-flex`/`inline-grid`、subgrid
 * `:is()`/`:where()`/`:has()`、`::first-line`、`::marker`
 
+## 空白文字の扱い
+
+畳み込みの対象はCSS Text 3が定める空白(space・tab・改行)だけです。
+`&nbsp;`(U+00A0)やthin space(U+2009)などは畳み込まれない普通の文字として、
+フォント本来の字幅で描かれます。改行してよい位置はUAX #14の行分割クラスに従い、
+`&nbsp;`・narrow no-break space・figure space・word joinerの前後では改行しません
+(`word-break: break-all`を指定した場合も同様です)。
+
+この範囲での既知の制限は以下です。
+
+* `text-align: justify`が行を伸ばす際、`&nbsp;`は伸縮の対象になりません(通常の空白のみ)
+* U+2028/U+2029は本来の強制改行ではなく、通常の空白と同じ扱いになります
+* 行末に来た空白の「ぶら下がり」(hanging)は行いません
+
 ## ストリーミングモード固有の制限
 
 `--streaming`を使う場合は、総ページ数(`counter(pages)`・`[topage]`)や目次(`--toc`)などが使えなくなります。

--- a/docs/src/appendix/limitations.md
+++ b/docs/src/appendix/limitations.md
@@ -59,6 +59,10 @@
 `&nbsp;`・narrow no-break space・figure space・word joinerの前後では改行しません
 (`word-break: break-all`を指定した場合も同様です)。
 
+`<wbr>`(と、それと同じ意味を持つU+200B ZERO WIDTH SPACE)は「ここで改行してよい」という
+指定として扱います。幅は増えず、PDFのテキスト層にも文字は残りません
+(`<wbr>`を挟んでも抽出結果は繋がったままです)。
+
 この範囲での既知の制限は以下です。
 
 * `text-align: justify`が行を伸ばす際、`&nbsp;`は伸縮の対象になりません(通常の空白のみ)


### PR DESCRIPTION
Fixes #3.

> **Disclosure:** as with the issue, this patch was written by an LLM (Claude, via Claude Code) on my instruction, and I've reviewed it before opening. Every measurement below was produced by running the code, not inferred from reading it. Happy to rework or drop any part of it — there's no CONTRIBUTING policy in the repo, so please tell me if this isn't the kind of contribution you want.

Four commits, each standing on its own: the first fixes exactly what the issue reports, the second fixes the wider class of bug I found while writing tests for it, and the last two are `<wbr>` support plus a text-layer bug that adding it uncovered. Happy to drop any of them.

## 1. Keep the whitespace between two inline elements

`child_kind` classified every whitespace-only text node as "generates no box". Dropping whitespace between blocks is correct (CSS 2.1 9.2.2.1), but the rule was applied without looking at the context, so the space in `<span>one</span> <span>two</span>` was discarded before line breaking ever saw it.

`ChildKind::Whitespace` is added and the decision moves to the three call sites, which know what surrounds the node: keep the whitespace as a span when inline content precedes it, drop it between blocks and at the start of a run as before. Collapsing runs of whitespace into a single gap stays where it already was, in `layout::inline`.

Verified against the repro from the issue, via the CLI and `pdftotext`:

| markup | before | after |
|---|---|---|
| `<span>one</span> <span>two</span>` | `onetwo` | `one two` |
| `<span>one</span>&amp;nbsp;<span>two</span>` | `onetwo` | `one two` |
| `<b>bold</b> <i>italic</i>` | `bolditalic` | `bold italic` |
| `<span>one</span> <span>two</span> <span>three</span> <span>four</span>` | `onetwothreefour` | `one two three four` |
| `one <span>two</span>`, `<span>one </span><span>two</span>` | already correct | unchanged |

## 2. Classify whitespace the way CSS and UAX #14 do

While testing the above I found `&nbsp;` was reaching the line breaker through `char::is_whitespace`, which is the Unicode `White_Space` property and much broader than what CSS collapses. `&nbsp;`, thin space, em space and ideographic space were all collapsed into one word gap and drawn as a single plain space.

I followed the browsers here, which make two distinctions the code did not:

**Collapsible or not.** Blink's `Character::IsCollapsibleSpace` is space/LF/tab/CR; Gecko's `nsTextFrameUtils::IsSpaceOrTab` is space/tab with newlines handled separately; CSS Text 3 §4.1 agrees and explicitly leaves every other `Zs` out of the collapsible set. (Blink's `TreatAsSpace`, which *does* include `&nbsp;`, is a shaping fast path rather than a collapsing rule.) Everything non-collapsible now reaches the shaper as an ordinary character and keeps its own advance.

No width table was needed for that, because harfrust already ports HarfBuzz's `_hb_ot_shape_fallback_spaces`: a font with no glyph for U+2009 gets the space glyph at em/5, figure space gets digit width, and so on. That's what made this worth doing rather than special-casing `&nbsp;`.

**Breakable or not.** UAX #14 line break classes. GL/WJ (`&nbsp;`, narrow no-break space, figure space, word joiner) forbid a break on either side; BA (thin, hair, em, punctuation space) and ZW (U+200B) allow one after. This reuses the intra-word break-opportunity hook the CJK path already had, so there's no new machinery in the line breaker.

One judgment call to flag: **no-break glue wins over `word-break: break-all`.** Someone typing `&nbsp;` is asking for those two things to stay together, and break-all is a policy about ordinary text. Browsers behave this way. There's a test pinning it, and it's easy to invert if you disagree.

The same predicate is used for the anonymous-box rules and for `empty-cells`, which is what fixes `<td>&nbsp;</td>` losing its borders — `str::trim` had been treating such a cell as empty.

Measured before/after, DejaVu Sans, px:

| | before | after |
|---|---|---|
| `a&amp;nbsp;&amp;nbsp;&amp;nbsp;b` | 25.0 (one space) | 35.2 (three) |
| `a   b` (ordinary spaces) | 25.0 | 25.0 — still collapses |
| hair / thin / space / em | all 25.0 | 21.6 / 23.2 / 25.0 / 36.0 |
| `a&#x200b;b` | 25.0 | 20.0 (zero width) |
| `10&amp;nbsp;kg` in a 40px column | wrapped between `10` and `kg` | stays on one line |
| `10&#x2009;kg` in a 40px column | wrapped | wraps after the space |
| `<td>&amp;nbsp;</td>` + `empty-cells: hide` | borders stripped | borders kept |

## Known simplifications

Written up in `docs/src/appendix/limitations.md` rather than left implicit:

* `text-align: justify` does not stretch `&nbsp;` (Blink does expand at word separators including NBSP).
* U+2028/U+2029 stay ordinary spaces rather than becoming forced breaks. Making them real breaks is easy, but a font without those glyphs would draw `.notdef`, so it deserves its own change.
* End-of-line whitespace does not hang.

## 3. `/ToUnicode` mapping of a shared glyph

Pre-existing and independent of the rest, but I ran into it and it seemed worth fixing while here.

`FontUsage::record` was first-write-wins per glyph id. That is fine until two characters shape to the same glyph, which they do: a font with no glyph of its own for `&nbsp;` gets the space glyph substituted by the shaper, so one glyph stands for both U+0020 and U+00A0. The mapping then depended on which character appeared first in the document — so a document whose first use of that glyph was an `&nbsp;` had **every space in it extract as U+00A0**, breaking copy-paste and text search.

A plain space now wins when a glyph is shared. Only a space can displace an existing mapping, so ligature clusters keep the text they were recorded with.

## 4. `<wbr>`

`<wbr>` is `display: inline` in the UA stylesheet and has no children, so it contributed nothing and offered no break at all. It now emits a U+200B, as browsers do, and rides on the UAX #14 handling from commit 2.

Carrying that ZWSP as an actual character does not work, and this is the part worth reviewing: fonts with no glyph for U+200B get the space glyph substituted, so a `<wbr>` drew a zero-advance space and put a **phantom character in the PDF text layer** — `inline<wbr>word` extracted as `inline word`. Verified with `pdftotext`, and before commit 3 it also mis-mapped every other space in the document.

So ZWSP is stripped in `flatten_spans` and folded into a break-opportunity flag, exactly the way soft hyphen already was. `hyphen_before` keeps its meaning (draw a hyphen if the line breaks here) and a new `break_before` carries the break opportunity.

Both pending flags had to move out of the per-span loop as part of this. `<wbr>` is an element and therefore always its own span, so a flag scoped to a single span never reached the character it applies to — the same latent bug applied to `<span>foo&shy;</span><span>bar</span>`.

## Tests

* 7 unit tests in `box_tree.rs` for parts 1 and 4, covering each case from the issue plus newline-separated elements. I checked they fail without the fix.
* 17 E2E tests in `core/tests/unicode_spaces.rs`, going through the real pipeline and asserting widths, wrap points and the `/ToUnicode` CMap.
* 3 unit tests on the classifier, 1 on `empty-cells`, 2 on the glyph-sharing fix (all checked against the old code so they aren't vacuous).
* For `<wbr>` specifically, one test asserts the break happens and a separate one asserts no character survives into the laid-out runs. I had written only the first kind at one point and it passed while the text layer was quietly corrupt, so both are there deliberately.
* Guard tests pinning what must *not* change: whitespace between block siblings still creates no anonymous box, and trailing whitespace does not widen a line — that one would silently have shifted every `text-align: right` and `justify` line.

Full suite passes (1222), `cargo clippy --all-targets -- -D warnings` and `cargo fmt --check` clean. In-code comments are in Japanese to match the surrounding files; commit messages and this description are in English, let me know if you'd prefer otherwise.
