### PR TITLE
Fixed text-align: justify, whitespace: pre

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   whichever character happened to come first in the document. A font without its own
   `&nbsp;` glyph made every space in the document extract as U+00A0, breaking
   copy-paste and text search in the PDF.
+- Draw glyphs at the advance width the layout used. A PDF advances a glyph by its
+  single `/W` entry, which cannot express the two cases where the shaper reports a
+  different advance for the same glyph: the stretched word gaps of a justified line,
+  and a fixed-width space (`&thinsp;` and friends) that the font has no glyph for.
+  A `text-align: justify` line was drawn short of the right edge by the whole stretch
+  amount, and text following a substituted fixed-width space was drawn off its laid
+  out position. The difference is now made up with `TJ` adjustments.
+- Keep the leading whitespace of a `white-space: pre` element when it comes from a
+  whitespace-only text node, so `<pre>   <b>x</b>y</pre>` keeps its indentation
+  instead of rendering as `xy`.
 
 ### Added
 

--- a/core/src/layout/box_tree.rs
+++ b/core/src/layout/box_tree.rs
@@ -12,7 +12,7 @@ use crate::html::{Dom, NodeData, NodeId};
 use crate::pdf::{ImageAssetCache, PreparedImage};
 use crate::style::{
     CaptionSide, ComputedStyle, Display, LengthPercentage, LengthPercentageOrAuto,
-    ListStylePosition, ListStyleType, RgbaColor,
+    ListStylePosition, ListStyleType, RgbaColor, WhiteSpace,
 };
 
 use super::white_space;
@@ -462,16 +462,24 @@ fn build_children_boxes(
 /// `<span>one</span> <span>two</span>`のように、インライン要素同士の間にある
 /// 空白は単語間の空白として意味を持つ(行組みの段階で1個に畳み込まれる)ため、
 /// 捨てずにスパンとして残す必要がある。一方、直前にインライン内容が無い場合
-/// (ブロックの直後や親の先頭)は、その空白は行頭に来るだけで結果に影響しない
-/// ので足さない。空白だけが並んだ列から無名ブロックが作られないことは
-/// [`flush_pending_spans`]が保証する。
+/// (ブロックの直後や親の先頭)は、畳み込みが効くならその空白は行頭に来るだけで
+/// 結果に影響しないので足さない。空白だけが並んだ列から無名ボックスが
+/// 作られないことは[`flush_pending_spans`]が保証する。
+///
+/// ただし`white-space: pre`では行頭の空白もそのまま残る(インデントとして
+/// 意味を持つ)ため、この間引きをしてはいけない。`<pre>   <b>x</b>y</pre>`の
+/// ように空白のみのテキストノードで始まる場合に効く。
 fn push_collapsible_whitespace(
     dom: &Dom,
     styles: &HashMap<NodeId, Rc<ComputedStyle>>,
     node: NodeId,
     out: &mut Vec<InlineSpan>,
 ) {
-    if out.is_empty() {
+    // `white-space`は継承プロパティなので、テキストノード自身の計算スタイルに
+    // 親の値が入っている。
+    let preserves_leading_whitespace =
+        styles.get(&node).map(|s| s.white_space) == Some(WhiteSpace::Pre);
+    if out.is_empty() && !preserves_leading_whitespace {
         return;
     }
     // 元のテキストをそのまま渡す(`white-space: pre`の経路は空白の並びを
@@ -1364,6 +1372,23 @@ mod tests {
             spans[0].text, "one",
             "no span should precede the first word, got {spans:?}"
         );
+    }
+
+    #[test]
+    fn leading_whitespace_is_kept_when_white_space_preserves_it() {
+        // `white-space: pre`では行頭の空白もインデントとして意味を持つので、
+        // 空白のみのテキストノードで始まっていても捨ててはいけない
+        // (捨てていた頃は`<pre>   <b>x</b>y</pre>`が`xy`になっていた)。
+        let dom = html::parse(b"<pre>   <b>x</b>y</pre>");
+        let styles = compute_styles(&dom, &user_agent_stylesheet(), &Stylesheet::default());
+        let tree = build_box_tree(&dom, &styles);
+
+        let pre = find(&dom, dom.document(), "pre").expect("pre not found");
+        let pre_box = find_box(&tree, pre).expect("pre box not found");
+        let spans = find_inline_spans(pre_box).expect("expected inline content");
+
+        let text: String = spans.iter().map(|span| span.text.as_str()).collect();
+        assert_eq!(text, "   xy", "the indentation must survive, got {spans:?}");
     }
 
     #[test]

--- a/core/src/layout/inline.rs
+++ b/core/src/layout/inline.rs
@@ -2312,6 +2312,19 @@ mod tests {
     }
 
     #[test]
+    fn white_space_pre_preserves_leading_whitespace_before_an_inline_element() {
+        // 行頭の空白がインデントとして残る。空白のみのテキストノードで
+        // 始まっているので、以前は`box_tree`の段階で捨てられて`xy`になっていた。
+        let (_, spans, styles) = spans_for("   <b>x</b>y", "p { white-space: pre; }");
+        let fonts = dejavu_only();
+        let lines = layout_inline_content(&spans, &styles, &fonts, 500.0, 0.0, 0.0, None);
+
+        assert_eq!(lines.len(), 1);
+        let text: String = lines[0].runs.iter().map(|r| r.text.as_str()).collect();
+        assert_eq!(text, "   xy", "the indentation should be preserved");
+    }
+
+    #[test]
     fn white_space_pre_consecutive_newlines_produce_an_empty_line() {
         let (_, spans, styles) = spans_for("a&#10;&#10;b", "p { white-space: pre; }");
         let fonts = dejavu_only();

--- a/core/src/pdf/document.rs
+++ b/core/src/pdf/document.rs
@@ -46,7 +46,7 @@ use std::rc::Rc;
 use pdf_writer::types::{ActionType, AnnotationType, LineCapStyle, TextRenderingMode};
 use pdf_writer::{Content, Finish, Name, Pdf, Rect as PdfRect, Ref, TextStr};
 
-use crate::fonts::FontCollection;
+use crate::fonts::{Font, FontCollection};
 use crate::html::NodeId;
 use crate::img::resolve_against_base_href;
 use crate::layout::{
@@ -3000,6 +3000,77 @@ const ITALIC_SHEAR: f32 = 0.2126; // tan(12°)
 /// 疑似ボールド(塗り+縁取り)の線幅を、フォントサイズに対する比率で表す。
 const BOLD_STROKE_RATIO: f32 = 0.03;
 
+/// グリフの送り幅の食い違いを補正する下限(px)。これ未満はTJ配列を膨らませる
+/// だけで見た目に効かないため無視する。
+const ADVANCE_EPSILON: f32 = 0.01;
+
+/// ランのグリフ列を書き出す。送り幅が`/W`と食い違うグリフの後ろにはTJ補正を挟む。
+///
+/// PDFがグリフを進める幅はCIDFontの`/W`で決まり、これはグリフIDごとに1つしか
+/// 持てない。一方レイアウトはシェイパーが返す`x_advance`を使う。この2つは
+/// 一致するとは限らない。
+///
+/// * 単語間の空白は`merge_adjacent_runs`が「隙間ぶんのアドバンスを持つ空白
+///   グリフ」として復元する。`text-align: justify`が広げた隙間はspaceの字幅と
+///   一致しないため、補正が無いと両端揃えの行が伸ばした分だけ右端に届かない。
+/// * フォントが持たない固定幅スペース(`&thinsp;`等)は、シェイパーがspaceの
+///   グリフで代替しつつアドバンスだけ規定値(em/5等)へ差し替える。同じグリフを
+///   普通のspaceも使うため、`/W`はどちらか一方の幅しか表せない。
+///
+/// 差はTJ配列の補正値で埋める。TJの数値はテキスト空間の1/1000単位で、送り量から
+/// 減算される(正の値で詰まる)ので、広げたいときは負の値を入れる。
+/// `letter-spacing`は`Tc`で別に加算されるため、ここの差分計算には含めない。
+fn show_run_glyphs(
+    content: &mut RenderTarget<'_>,
+    run: &TextRun,
+    font: &Font,
+    remap: Option<&HashMap<u16, u16>>,
+) {
+    // `remaps`が`Some`(一括処理)ならサブセット後のグリフIDへ、`None`
+    // (ストリーミング処理)なら元のグリフIDのまま。
+    let cid_of = |glyph_id: u16| match remap {
+        Some(remap) => remap.get(&glyph_id).copied().unwrap_or(0),
+        None => glyph_id,
+    };
+
+    let units_per_em = font.units_per_em() as f32;
+    // フォントサイズ0のランは補正のしようがない(1/1000単位への換算ができない)。
+    if run.font_size <= 0.0 || units_per_em <= 0.0 {
+        let mut glyph_bytes = Vec::with_capacity(run.glyphs.len() * 2);
+        for glyph in &run.glyphs {
+            glyph_bytes.extend_from_slice(&cid_of(glyph.glyph_id).to_be_bytes());
+        }
+        content.show(pdf_writer::Str(&glyph_bytes));
+        return;
+    }
+
+    let mut positioned = content.show_positioned();
+    let mut items = positioned.items();
+    // 補正の要らないグリフはまとめて1つの文字列として出す(補正が1つも無ければ
+    // 要素1つのTJ配列になり、`Tj`と同じ大きさに収まる)。
+    let mut pending = Vec::with_capacity(run.glyphs.len() * 2);
+    for glyph in &run.glyphs {
+        pending.extend_from_slice(&cid_of(glyph.glyph_id).to_be_bytes());
+        let pdf_advance = font.glyph_hor_advance(glyph.glyph_id).unwrap_or(0) as f32
+            * run.font_size
+            / units_per_em;
+        let delta = glyph.x_advance - pdf_advance;
+        if delta.abs() < ADVANCE_EPSILON {
+            continue;
+        }
+        items.show(pdf_writer::Str(&pending));
+        pending.clear();
+        // 小数第2位までに丸める。両端揃えの文書では単語間のすべての隙間に補正が
+        // 入るため、`f32`をそのまま書くとコンテンツストリームがおよそ1割膨らむ。
+        // 1/1000単位の0.01は12ptで0.00012pxなので、見た目には効かない。
+        let adjustment = (-delta * 1000.0 / run.font_size * 100.0).round() / 100.0;
+        items.adjust(adjustment);
+    }
+    if !pending.is_empty() {
+        items.show(pdf_writer::Str(&pending));
+    }
+}
+
 fn render_line(
     content: &mut RenderTarget<'_>,
     line: &LineBox,
@@ -3051,6 +3122,7 @@ fn render_line(
     render_text_shadows(
         content,
         line,
+        fonts,
         settings,
         remaps,
         font_resource_names,
@@ -3099,14 +3171,9 @@ fn render_line(
         }
         previous_run_end = Some(run.x_offset + run.width);
 
-        let mut glyph_bytes = Vec::with_capacity(run.glyphs.len() * 2);
-        for glyph in &run.glyphs {
-            let cid = match remap {
-                Some(remap) => remap.get(&glyph.glyph_id).copied().unwrap_or(0),
-                None => glyph.glyph_id,
-            };
-            glyph_bytes.extend_from_slice(&cid.to_be_bytes());
-        }
+        let Some(font) = fonts.get(run.font_index) else {
+            continue;
+        };
 
         content.set_fill_rgb(
             run.color.red as f32 / 255.0,
@@ -3139,7 +3206,7 @@ fn render_line(
         // 明示的に設定し、前のランの値が
         // グラフィックステートに残らないようにする。
         content.set_char_spacing(run.letter_spacing);
-        content.show(pdf_writer::Str(&glyph_bytes));
+        show_run_glyphs(content, run, font, remap);
     }
 
     content.end_text();
@@ -3418,6 +3485,7 @@ const TEXT_SHADOW_BLUR_STEPS: usize = 2;
 fn render_text_shadows(
     content: &mut RenderTarget<'_>,
     line: &LineBox,
+    fonts: &FontCollection,
     settings: &PageSettings,
     remaps: Option<&[HashMap<u16, u16>]>,
     font_resource_names: &[String],
@@ -3441,15 +3509,10 @@ fn render_text_shadows(
         let Some(resource_name) = font_resource_names.get(run.font_index) else {
             continue;
         };
-
-        let mut glyph_bytes = Vec::with_capacity(run.glyphs.len() * 2);
-        for glyph in &run.glyphs {
-            let cid = match remap {
-                Some(remap) => remap.get(&glyph.glyph_id).copied().unwrap_or(0),
-                None => glyph.glyph_id,
-            };
-            glyph_bytes.extend_from_slice(&cid.to_be_bytes());
-        }
+        // 影は本体と同じグリフ列なので、送り幅の補正も同じでなければずれる。
+        let Some(font) = fonts.get(run.font_index) else {
+            continue;
+        };
 
         let x = settings.margin.left + line.rect.x + run.x_offset;
         let run_baseline_y = baseline_y + run.baseline_shift;
@@ -3482,7 +3545,7 @@ fn render_text_shadows(
                     run_baseline_y - shadow.offset_y - dy,
                 ]);
                 content.set_char_spacing(run.letter_spacing);
-                content.show(pdf_writer::Str(&glyph_bytes));
+                show_run_glyphs(content, run, font, remap);
                 content.end_text();
                 content.restore_state();
             }
@@ -5386,8 +5449,9 @@ mod tests {
             "hidden outer's red background should not be painted"
         );
         // innerのテキストは(何らかのグリフ描画として)出力されるはず。
+        // グリフ列は送り幅の補正を挟めるよう常に`TJ`で出す([`show_run_glyphs`])。
         assert!(
-            count_occurrences(&decompressed, b"Tj") > 0,
+            count_occurrences(&decompressed, b"TJ") > 0,
             "visible descendant's text should still be painted"
         );
     }

--- a/core/tests/glyph_advances.rs
+++ b/core/tests/glyph_advances.rs
@@ -1,0 +1,258 @@
+//! グリフの送り幅がレイアウトと描画で一致することのテスト。
+//!
+//! レイアウトはシェイパーが返す`x_advance`で位置を決めるが、PDFのビューアは
+//! CIDFontの`/W`(グリフIDごとに1つ)でグリフを送る。この2つが食い違う経路が
+//! あり、差はTJ配列の補正値で埋めている(`pdf::document::show_run_glyphs`)。
+//!
+//! ここでは「補正量の合計」が「レイアウト幅と`/W`由来の幅の差」に一致すること
+//! を、実際に生成したPDFのコンテンツストリームから確かめる。
+
+use std::collections::HashMap;
+use std::io::Read;
+
+use sghtmltopdf_core::fonts::{Font, FontCollection};
+use sghtmltopdf_core::html::{self, Dom, NodeData, NodeId};
+use sghtmltopdf_core::layout::{
+    build_box_tree, layout_document, paginate_document, LaidOutBox, LaidOutContent, PageSettings,
+};
+use sghtmltopdf_core::pdf::encode_pdf;
+use sghtmltopdf_core::style::{compute_styles, parse_stylesheet, user_agent_stylesheet};
+
+const DEJAVU: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fonts/DejaVuSans.ttf");
+/// `&thinsp;`(U+2009)等のグリフを持たないフォント。シェイパーがspaceのグリフで
+/// 代替しつつアドバンスだけ差し替えるため、`/W`との食い違いが起きる。
+const NOTO_CJK: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/tests/fonts/NotoSansCJK-Regular.ttc"
+);
+
+fn find_tag(dom: &Dom, id: NodeId, tag: &str) -> Option<NodeId> {
+    if let NodeData::Element { name, .. } = &dom.node(id).data {
+        if &*name.local == tag {
+            return Some(id);
+        }
+    }
+    dom.children(id).find_map(|child| find_tag(dom, child, tag))
+}
+
+fn find_laid_out(b: &LaidOutBox, target: NodeId) -> Option<&LaidOutBox> {
+    if b.node == Some(target) {
+        return Some(b);
+    }
+    if let LaidOutContent::Blocks(children) = &b.content {
+        return children.iter().find_map(|c| find_laid_out(c, target));
+    }
+    None
+}
+
+/// 最初の`<p>`について、レイアウトが使う送り幅の合計と、`/W`だけで送った場合の
+/// 合計の差(px)を返す。TJの補正が埋めるべき量そのもの。
+fn advance_gap_of_first_p(html_src: &str, css: &str, font_path: &str) -> f32 {
+    let dom = html::parse(html_src.as_bytes());
+    let styles = compute_styles(&dom, &user_agent_stylesheet(), &parse_stylesheet(css));
+    let font = Font::load(font_path).expect("should load test font");
+    let fonts = FontCollection::new(vec![Font::load(font_path).expect("should load test font")]);
+    let tree = build_box_tree(&dom, &styles);
+    let laid = layout_document(
+        &tree,
+        &styles,
+        &fonts,
+        PageSettings::default().content_width(),
+    );
+    let p = find_tag(&dom, dom.document(), "p").expect("p not found");
+    let p_box = find_laid_out(&laid, p).expect("p should be laid out");
+    let LaidOutContent::Inline(lines) = &p_box.content else {
+        panic!("expected inline content");
+    };
+
+    let units_per_em = font.units_per_em() as f32;
+    let mut gap = 0.0;
+    for line in lines {
+        for run in &line.runs {
+            for glyph in &run.glyphs {
+                let pdf_advance = font.glyph_hor_advance(glyph.glyph_id).unwrap_or(0) as f32
+                    * run.font_size
+                    / units_per_em;
+                gap += glyph.x_advance - pdf_advance;
+            }
+        }
+    }
+    gap
+}
+
+fn pdf_bytes(html_src: &str, css: &str, font_path: &str) -> Vec<u8> {
+    let dom = html::parse(html_src.as_bytes());
+    let styles = compute_styles(&dom, &user_agent_stylesheet(), &parse_stylesheet(css));
+    let fonts = FontCollection::new(vec![Font::load(font_path).expect("should load test font")]);
+    let settings = PageSettings::default();
+    let pages = paginate_document(&dom, &styles, &fonts, &settings);
+    encode_pdf(&pages, &styles, &HashMap::new(), &fonts, &settings)
+}
+
+/// コンテンツストリームはFlateDecodeで圧縮されているので、展開して連結する。
+fn decompressed_streams(pdf: &[u8]) -> Vec<u8> {
+    fn find(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+        haystack.windows(needle.len()).position(|w| w == needle)
+    }
+
+    let mut out = Vec::new();
+    let mut i = 0;
+    while let Some(pos) = find(&pdf[i..], b"stream\n") {
+        let start = i + pos + b"stream\n".len();
+        let Some(end_rel) = find(&pdf[start..], b"endstream") else {
+            break;
+        };
+        let end = start + end_rel;
+        let mut decoded = Vec::new();
+        if flate2::read::ZlibDecoder::new(&pdf[start..end])
+            .read_to_end(&mut decoded)
+            .is_ok()
+        {
+            out.extend_from_slice(&decoded);
+            out.push(b'\n');
+        }
+        i = end + b"endstream".len();
+    }
+    out
+}
+
+/// `[...] TJ`の配列に現れる補正値をすべて足す(単位はテキスト空間の1/1000)。
+///
+/// 文字列`(...)`の中はバイト列(エスケープあり)なので読み飛ばす。`TJ`以外の
+/// 演算子のオペランドを拾わないよう、`]`の直後が`TJ`である配列だけを数える。
+/// 展開したバイト列にはフォントファイルのストリームも混ざっており、そこに
+/// 現れた`[`から数え始めると手前の演算子のオペランドまで拾ってしまうため、
+/// 途中で`[`が出てきたらそこを配列の開始として数え直す。
+fn sum_tj_adjustments(stream: &[u8]) -> f32 {
+    fn take_number(buf: &mut String, out: &mut Vec<f32>) {
+        if !buf.is_empty() {
+            if let Ok(v) = buf.parse::<f32>() {
+                out.push(v);
+            }
+            buf.clear();
+        }
+    }
+
+    let mut total = 0.0;
+    let mut i = 0;
+    while i < stream.len() {
+        if stream[i] != b'[' {
+            i += 1;
+            continue;
+        }
+        let mut numbers = Vec::new();
+        let mut buf = String::new();
+        let mut in_string = false;
+        let mut escaped = false;
+        let mut j = i + 1;
+        while j < stream.len() {
+            let b = stream[j];
+            if in_string {
+                if escaped {
+                    escaped = false;
+                } else if b == b'\\' {
+                    escaped = true;
+                } else if b == b')' {
+                    in_string = false;
+                }
+                j += 1;
+                continue;
+            }
+            if b == b']' {
+                take_number(&mut buf, &mut numbers);
+                break;
+            }
+            if b == b'[' {
+                // 手前の`[`は配列の開始ではなかった。ここから数え直す。
+                numbers.clear();
+                buf.clear();
+            } else if b == b'(' {
+                take_number(&mut buf, &mut numbers);
+                in_string = true;
+            } else if b.is_ascii_digit() || b == b'-' || b == b'+' || b == b'.' {
+                buf.push(b as char);
+            } else {
+                take_number(&mut buf, &mut numbers);
+            }
+            j += 1;
+        }
+        // `]`の後ろの空白を飛ばして演算子を見る。
+        let mut k = j + 1;
+        while k < stream.len() && stream[k].is_ascii_whitespace() {
+            k += 1;
+        }
+        if stream[k..].starts_with(b"TJ") {
+            total += numbers.iter().sum::<f32>();
+        }
+        i = j + 1;
+    }
+    total
+}
+
+/// TJの補正量の合計(px)。TJの値は送り量から減算されるので符号を反転する。
+fn tj_correction_px(html_src: &str, css: &str, font_path: &str, font_size: f32) -> f32 {
+    let pdf = pdf_bytes(html_src, css, font_path);
+    let stream = decompressed_streams(&pdf);
+    -sum_tj_adjustments(&stream) / 1000.0 * font_size
+}
+
+const JUSTIFIED: &str = "<p>aaa bbb ccc ddd eee fff ggg hhh iii jjj kkk lll</p>";
+const JUSTIFY_CSS: &str = "body { margin: 0; } \
+                           p { margin: 0; text-align: justify; width: 300px; font-size: 16px; }";
+
+#[test]
+fn a_justified_line_is_drawn_as_wide_as_it_was_laid_out() {
+    // 単語間の隙間は`merge_adjacent_runs`が「隙間ぶんのアドバンスを持つ空白
+    // グリフ」として復元する。`text-align: justify`が広げた隙間はspaceの字幅と
+    // 一致しないため、TJの補正が無いと行が伸ばした分だけ右端に届かない。
+    let expected = advance_gap_of_first_p(JUSTIFIED, JUSTIFY_CSS, DEJAVU);
+    assert!(
+        expected > 1.0,
+        "the test document should actually be stretched, got {expected}px"
+    );
+
+    let corrected = tj_correction_px(JUSTIFIED, JUSTIFY_CSS, DEJAVU, 16.0);
+    assert!(
+        (corrected - expected).abs() < 0.01,
+        "TJ should make up the whole stretch: corrected={corrected}px expected={expected}px"
+    );
+}
+
+#[test]
+fn a_left_aligned_line_needs_no_correction() {
+    // 両端揃えでなければ隙間はspaceの字幅そのものなので、補正は出ない
+    // (通常の文書でTJ配列が無駄に長くならないことの確認でもある)。
+    let css = "body { margin: 0; } p { margin: 0; width: 300px; font-size: 16px; }";
+    let expected = advance_gap_of_first_p(JUSTIFIED, css, DEJAVU);
+    assert!(
+        expected.abs() < 0.01,
+        "no stretch is expected here, got {expected}px"
+    );
+
+    let corrected = tj_correction_px(JUSTIFIED, css, DEJAVU, 16.0);
+    assert!(
+        corrected.abs() < 0.01,
+        "there should be nothing to correct, got {corrected}px"
+    );
+}
+
+#[test]
+fn a_fixed_width_space_the_font_lacks_is_drawn_at_its_own_advance() {
+    // フォントが持たない固定幅スペースは、シェイパーがspaceのグリフで代替しつつ
+    // アドバンスだけ規定値(U+2009ならem/5)へ差し替える。`/W`は普通のspaceと共有
+    // なので、補正が無いと後続の文字がずれる。
+    let html_src = "<p>a\u{2009}b\u{2009}c</p>";
+    let css = "body { margin: 0; } p { margin: 0; font-size: 16px; }";
+
+    let expected = advance_gap_of_first_p(html_src, css, NOTO_CJK);
+    assert!(
+        expected.abs() > 0.1,
+        "the font should be missing U+2009 for this test to mean anything, got {expected}px"
+    );
+
+    let corrected = tj_correction_px(html_src, css, NOTO_CJK, 16.0);
+    assert!(
+        (corrected - expected).abs() < 0.01,
+        "TJ should absorb the difference: corrected={corrected}px expected={expected}px"
+    );
+}

--- a/core/tests/text_details.rs
+++ b/core/tests/text_details.rs
@@ -287,6 +287,8 @@ fn text_overflow_clip_leaves_the_line_untouched() {
 
 // ===== text-shadow =====
 
+// グリフ列は送り幅の補正を挟めるよう常に`TJ`で書き出すため、
+// テキスト描画の回数は`TJ`の数で数える。
 #[test]
 fn text_shadow_adds_extra_glyph_draws_to_the_content_stream() {
     let plain = decompressed_stream_bytes(&build_pdf("<p>shadowed</p>", "body { margin: 0; }"));
@@ -295,7 +297,7 @@ fn text_shadow_adds_extra_glyph_draws_to_the_content_stream() {
         "body { margin: 0; } p { text-shadow: 2px 2px red; }",
     ));
     assert!(
-        count_occurrences(&shadowed, b"Tj") > count_occurrences(&plain, b"Tj"),
+        count_occurrences(&shadowed, b"TJ") > count_occurrences(&plain, b"TJ"),
         "text-shadow should add extra text-showing operators"
     );
 }
@@ -311,7 +313,7 @@ fn a_blurred_text_shadow_draws_more_layers_than_a_sharp_one() {
         "body { margin: 0; } p { text-shadow: 2px 2px 4px red; }",
     ));
     assert!(
-        count_occurrences(&blurred, b"Tj") > count_occurrences(&sharp, b"Tj"),
+        count_occurrences(&blurred, b"TJ") > count_occurrences(&sharp, b"TJ"),
         "a blur radius should be approximated with extra layers"
     );
 }


### PR DESCRIPTION
Fixed a bug found while checking https://github.com/waka/sghtmltopdf/pull/6 .

### `text-align: justify` was not reaching the right edge

Added show_run_glyphs() to core/src/pdf/document.rs and replaced content.show() with show_positioned().
It compares the shaped advance and the /W-derived advance for each glyph and applies TJ correction only where there is a difference.
Glyphs that do not require correction are grouped together and output as a single string, resulting in a single-element TJ array in a normal document.

### `whitespace: pre` leading whitespace is dropped

Modified push_collapsible_whitespace to skip early return only when white-space retains whitespace.
Since white-space is an inherited property, the parent's value is also included in the text node's own compute style (non-element nodes of compute_recursive clone the parent style), so no signature change was necessary.