### PR TITLE
Support :color-mix()

### DIFF
--- a/core/src/style/color_mix.rs
+++ b/core/src/style/color_mix.rs
@@ -1,0 +1,321 @@
+//! `color-mix()`の混色計算(CSS Color 5 §3、補間の規則はCSS Color 4 §12)。
+//!
+//! 構文の読み取りは[`super::properties`]が行い、ここは「色空間・色相の回し方・
+//! 2色と重み」を受け取って混ぜるところだけを持つ。
+//!
+//! 出力先がPDFのDeviceRGBなので、結果は常にsRGBへ戻して返す。
+
+use palette::{FromColor, Hsl, Hwb, Lab, LinSrgb, Oklab, Oklch, Srgb, Xyz};
+
+/// 補間に使う色空間。
+///
+/// `display-p3`/`a98-rgb`/`prophoto-rgb`/`rec2020`は非対応。sRGBより広い
+/// 色域を扱えないため、受け付けても結果はsRGBへ丸められるだけで、指定した
+/// 意味にならない。仕様どおり無効な`<color-space>`として扱い、宣言ごと落とす。
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum Space {
+    Srgb,
+    SrgbLinear,
+    Lab,
+    Oklab,
+    Xyz,
+    Hsl,
+    Hwb,
+    Lch,
+    Oklch,
+}
+
+impl Space {
+    pub(super) fn parse(ident: &str) -> Option<Self> {
+        Some(match ident.to_ascii_lowercase().as_str() {
+            "srgb" => Self::Srgb,
+            "srgb-linear" => Self::SrgbLinear,
+            "lab" => Self::Lab,
+            "oklab" => Self::Oklab,
+            // CSSの`xyz`は`xyz-d65`の別名。
+            "xyz" | "xyz-d65" => Self::Xyz,
+            "hsl" => Self::Hsl,
+            "hwb" => Self::Hwb,
+            "lch" => Self::Lch,
+            "oklch" => Self::Oklch,
+            _ => return None,
+        })
+    }
+
+    /// 色相を持つ(極座標)色空間か。持つ場合は成分列の何番目が色相かを返す。
+    fn hue_index(self) -> Option<usize> {
+        match self {
+            // paletteの`Hsl`/`Hwb`は色相が先頭。
+            Self::Hsl | Self::Hwb => Some(0),
+            // `Lch`/`Oklch`は明度・彩度の後ろ。
+            Self::Lch | Self::Oklch => Some(2),
+            _ => None,
+        }
+    }
+
+    /// sRGBから、この色空間の成分列(色相は度)へ。
+    fn components_of(self, c: Srgb) -> [f32; 3] {
+        match self {
+            Self::Srgb => [c.red, c.green, c.blue],
+            Self::SrgbLinear => {
+                let v = LinSrgb::from_color(c);
+                [v.red, v.green, v.blue]
+            }
+            Self::Lab => {
+                let v = Lab::from_color(c);
+                [v.l, v.a, v.b]
+            }
+            Self::Oklab => {
+                let v = Oklab::from_color(c);
+                [v.l, v.a, v.b]
+            }
+            Self::Xyz => {
+                let v = Xyz::from_color(c);
+                [v.x, v.y, v.z]
+            }
+            Self::Hsl => {
+                let v = Hsl::from_color(c);
+                [v.hue.into_degrees(), v.saturation, v.lightness]
+            }
+            Self::Hwb => {
+                let v = Hwb::from_color(c);
+                [v.hue.into_degrees(), v.whiteness, v.blackness]
+            }
+            Self::Lch => {
+                let v = palette::Lch::from_color(c);
+                [v.l, v.chroma, v.hue.into_degrees()]
+            }
+            Self::Oklch => {
+                let v = Oklch::from_color(c);
+                [v.l, v.chroma, v.hue.into_degrees()]
+            }
+        }
+    }
+
+    /// この色空間の成分列からsRGBへ。
+    fn to_srgb(self, v: [f32; 3]) -> Srgb {
+        match self {
+            Self::Srgb => Srgb::new(v[0], v[1], v[2]),
+            Self::SrgbLinear => Srgb::from_color(LinSrgb::new(v[0], v[1], v[2])),
+            Self::Lab => Srgb::from_color(Lab::new(v[0], v[1], v[2])),
+            Self::Oklab => Srgb::from_color(Oklab::new(v[0], v[1], v[2])),
+            Self::Xyz => Srgb::from_color(Xyz::new(v[0], v[1], v[2])),
+            Self::Hsl => Srgb::from_color(Hsl::new(v[0], v[1], v[2])),
+            Self::Hwb => Srgb::from_color(Hwb::new(v[0], v[1], v[2])),
+            Self::Lch => Srgb::from_color(palette::Lch::new(v[0], v[1], v[2])),
+            Self::Oklch => Srgb::from_color(Oklch::new(v[0], v[1], v[2])),
+        }
+    }
+}
+
+/// 色相をどちら回りで補間するか(CSS Color 4 §12.4)。
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub(super) enum HueMethod {
+    /// 初期値。短い方の弧を通る。
+    #[default]
+    Shorter,
+    /// 長い方の弧を通る。
+    Longer,
+    /// 色相が増える向きに回る。
+    Increasing,
+    /// 色相が減る向きに回る。
+    Decreasing,
+}
+
+impl HueMethod {
+    pub(super) fn parse(ident: &str) -> Option<Self> {
+        Some(match ident.to_ascii_lowercase().as_str() {
+            "shorter" => Self::Shorter,
+            "longer" => Self::Longer,
+            "increasing" => Self::Increasing,
+            "decreasing" => Self::Decreasing,
+            _ => return None,
+        })
+    }
+
+    /// 補間前に色相の組を調整する。返り値をそのまま線形補間すると、
+    /// 指定した回り方になる。
+    fn adjust(self, h1: f32, h2: f32) -> (f32, f32) {
+        let (h1, h2) = (normalize_hue(h1), normalize_hue(h2));
+        let diff = h2 - h1;
+        match self {
+            Self::Shorter => {
+                if diff > 180.0 {
+                    (h1 + 360.0, h2)
+                } else if diff < -180.0 {
+                    (h1, h2 + 360.0)
+                } else {
+                    (h1, h2)
+                }
+            }
+            Self::Longer => {
+                if (0.0..180.0).contains(&diff) {
+                    (h1 + 360.0, h2)
+                } else if diff > -180.0 && diff <= 0.0 {
+                    (h1, h2 + 360.0)
+                } else {
+                    (h1, h2)
+                }
+            }
+            Self::Increasing => {
+                if h2 < h1 {
+                    (h1, h2 + 360.0)
+                } else {
+                    (h1, h2)
+                }
+            }
+            Self::Decreasing => {
+                if h1 < h2 {
+                    (h1 + 360.0, h2)
+                } else {
+                    (h1, h2)
+                }
+            }
+        }
+    }
+}
+
+/// 度を`[0, 360)`へ収める。
+fn normalize_hue(h: f32) -> f32 {
+    let h = h % 360.0;
+    if h < 0.0 {
+        h + 360.0
+    } else {
+        h
+    }
+}
+
+/// sRGBの0.0〜1.0で表した色とアルファ。
+pub(super) type UnitRgba = (f32, f32, f32, f32);
+
+/// `space`で2色を混ぜ、sRGBの0.0〜1.0で返す。`w1`+`w2`は1.0であること
+/// (重みの正規化は呼び出し側が済ませる)。
+///
+/// アルファは事前乗算してから補間する(CSS Color 4 §12.3)。色相だけは
+/// 乗算の対象外。
+pub(super) fn mix(
+    space: Space,
+    hue: HueMethod,
+    c1: UnitRgba,
+    w1: f32,
+    c2: UnitRgba,
+    w2: f32,
+) -> UnitRgba {
+    let alpha = c1.3 * w1 + c2.3 * w2;
+
+    let mut v1 = space.components_of(Srgb::new(c1.0, c1.1, c1.2));
+    let mut v2 = space.components_of(Srgb::new(c2.0, c2.1, c2.2));
+
+    let hue_index = space.hue_index();
+    if let Some(i) = hue_index {
+        let (h1, h2) = hue.adjust(v1[i], v2[i]);
+        v1[i] = h1;
+        v2[i] = h2;
+    }
+    for i in 0..3 {
+        if Some(i) == hue_index {
+            continue;
+        }
+        v1[i] *= c1.3;
+        v2[i] *= c2.3;
+    }
+
+    let mut mixed = [0.0f32; 3];
+    for i in 0..3 {
+        mixed[i] = v1[i] * w1 + v2[i] * w2;
+        if Some(i) != hue_index && alpha != 0.0 {
+            // 事前乗算を戻す。
+            mixed[i] /= alpha;
+        }
+    }
+
+    let srgb = space.to_srgb(mixed);
+    (srgb.red, srgb.green, srgb.blue, alpha)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const RED: UnitRgba = (1.0, 0.0, 0.0, 1.0);
+    const BLUE: UnitRgba = (0.0, 0.0, 1.0, 1.0);
+
+    fn to_u8(v: f32) -> u8 {
+        (v.clamp(0.0, 1.0) * 255.0).round() as u8
+    }
+
+    fn mixed_rgb(space: Space, hue: HueMethod, a: UnitRgba, b: UnitRgba) -> (u8, u8, u8) {
+        let (r, g, bl, _) = mix(space, hue, a, 0.5, b, 0.5);
+        (to_u8(r), to_u8(g), to_u8(bl))
+    }
+
+    #[test]
+    fn srgb_midpoint_is_the_arithmetic_mean() {
+        assert_eq!(
+            mixed_rgb(Space::Srgb, HueMethod::Shorter, RED, BLUE),
+            (128, 0, 128)
+        );
+    }
+
+    /// `hsl`は色相環を回るので、赤(0度)と青(240度)の中間は短い方の弧を通って
+    /// 300度(マゼンタ)になる。算術平均の120度(緑)にはならない。
+    #[test]
+    fn a_polar_space_takes_the_shorter_arc_by_default() {
+        assert_eq!(
+            mixed_rgb(Space::Hsl, HueMethod::Shorter, RED, BLUE),
+            (255, 0, 255)
+        );
+    }
+
+    /// `longer hue`なら反対回りで、中間は120度(緑)になる。
+    #[test]
+    fn longer_hue_takes_the_other_arc() {
+        assert_eq!(
+            mixed_rgb(Space::Hsl, HueMethod::Longer, RED, BLUE),
+            (0, 255, 0)
+        );
+    }
+
+    #[test]
+    fn increasing_and_decreasing_hue_pick_a_direction() {
+        // 0度から240度へ増える向き = 120度(緑)。
+        assert_eq!(
+            mixed_rgb(Space::Hsl, HueMethod::Increasing, RED, BLUE),
+            (0, 255, 0)
+        );
+        // 減る向き = 300度(マゼンタ)。
+        assert_eq!(
+            mixed_rgb(Space::Hsl, HueMethod::Decreasing, RED, BLUE),
+            (255, 0, 255)
+        );
+    }
+
+    /// アルファが違う色を混ぜるときは事前乗算する。透明度の高い方の色味が
+    /// 薄く出るのが正しい(単純平均だと濃く出すぎる)。
+    #[test]
+    fn alpha_is_premultiplied_before_interpolating() {
+        let half_red = (1.0, 0.0, 0.0, 0.5);
+        let (r, g, b, a) = mix(Space::Srgb, HueMethod::Shorter, half_red, 0.5, BLUE, 0.5);
+        assert_eq!((to_u8(r), to_u8(g), to_u8(b)), (85, 0, 170));
+        assert!((a - 0.75).abs() < 1e-6, "alpha={a}");
+    }
+
+    #[test]
+    fn lab_midpoint_of_white_and_black_is_perceptual_grey() {
+        let white = (1.0, 1.0, 1.0, 1.0);
+        let black = (0.0, 0.0, 0.0, 1.0);
+        // L=50の灰色。sRGBの算術平均(128)より暗い。
+        assert_eq!(
+            mixed_rgb(Space::Lab, HueMethod::Shorter, white, black),
+            (119, 119, 119)
+        );
+    }
+
+    #[test]
+    fn unknown_color_spaces_are_rejected() {
+        assert!(Space::parse("display-p3").is_none());
+        assert!(Space::parse("rec2020").is_none());
+        assert_eq!(Space::parse("OKLCH"), Some(Space::Oklch));
+        assert_eq!(Space::parse("xyz-d65"), Some(Space::Xyz));
+    }
+}

--- a/core/src/style/mod.rs
+++ b/core/src/style/mod.rs
@@ -1,6 +1,7 @@
 //! CSSパース・セレクタマッチング・カスケード(cssparser/selectors)。
 
 mod cascade;
+mod color_mix;
 mod computed;
 mod custom_properties;
 mod element_ref;

--- a/core/src/style/properties.rs
+++ b/core/src/style/properties.rs
@@ -3,6 +3,8 @@
 use cssparser::{match_ignore_ascii_case, CowRcStr, ParseError, Parser, Token};
 use palette::{FromColor, Lab, Lch, Oklab, Oklch, Srgb};
 
+use super::color_mix::{self, HueMethod, Space as ColorSpace};
+
 use super::values::{
     AlignContent, AlignItems, AlignSelf, AspectRatio, BackgroundAttachment, BackgroundRepeat,
     BorderCollapse, BorderStyle, BoxSizing, BreakBetween, BreakInside, CaptionSide, Clear, Color,
@@ -1413,9 +1415,25 @@ fn parse_length_unit<'i>(
     }
 }
 
+/// `color-mix()`の入れ子の上限。無効な深さでスタックを食い潰さないための歯止め
+/// (`MAX_IMPORT_DEPTH`と同じ考え方)。
+const MAX_COLOR_MIX_DEPTH: u32 = 16;
+
 /// `lab`/`lch`/`oklab`/`oklch`は`cssparser-color`がsRGB変換関数を
 /// 公開していないため、`palette`クレートで変換する。
 fn parse_color<'i>(input: &mut Parser<'i, '_>) -> Result<Color, ParseError<'i, ()>> {
+    parse_color_at_depth(input, 0)
+}
+
+fn parse_color_at_depth<'i>(
+    input: &mut Parser<'i, '_>,
+    depth: u32,
+) -> Result<Color, ParseError<'i, ()>> {
+    // `cssparser-color`は`color-mix()`を扱わない(より良い`calc()`対応が要る、
+    // として対象外にしている)ので、先に自前で試す。
+    if let Ok(mixed) = input.try_parse(|input| parse_color_mix(input, depth)) {
+        return Ok(mixed);
+    }
     let color = cssparser_color::Color::parse(input).map_err(|_| input.new_custom_error(()))?;
     match color {
         cssparser_color::Color::CurrentColor => Ok(Color::CurrentColor),
@@ -1494,6 +1512,128 @@ fn parse_color<'i>(input: &mut Parser<'i, '_>) -> Result<Color, ParseError<'i, (
             ))
         }
         _ => Err(input.new_custom_error(())),
+    }
+}
+
+/// `color-mix(in <color-space> [<hue-interpolation-method>]?, <color> <percentage>?, <color> <percentage>?)`。
+///
+/// `currentcolor`をオペランドに含む形は非対応。`currentcolor`はカスケードの後
+/// (その要素の`color`が決まってから)解決するのに対し、混色はここで済ませて
+/// しまうため、この時点では値が分からない。仕様どおり無効な色として扱い、
+/// 宣言ごと落とす。
+fn parse_color_mix<'i>(
+    input: &mut Parser<'i, '_>,
+    depth: u32,
+) -> Result<Color, ParseError<'i, ()>> {
+    if depth >= MAX_COLOR_MIX_DEPTH {
+        return Err(input.new_custom_error(()));
+    }
+    if input.expect_function_matching("color-mix").is_err() {
+        return Err(input.new_custom_error(()));
+    }
+    input.parse_nested_block(|input| {
+        if input.expect_ident_matching("in").is_err() {
+            return Err(input.new_custom_error(()));
+        }
+        let space = match input.expect_ident() {
+            Ok(ident) => ColorSpace::parse(ident).ok_or(()),
+            Err(_) => Err(()),
+        }
+        .map_err(|_| input.new_custom_error(()))?;
+
+        // `<hue-interpolation-method>`は極座標の色空間でのみ意味を持つ。
+        // 構文としては`shorter hue`のように2つのidentが続く。
+        let hue_method = input
+            .try_parse(|input| {
+                let method = match input.expect_ident() {
+                    Ok(ident) => HueMethod::parse(ident).ok_or(()),
+                    Err(_) => Err(()),
+                }?;
+                input.expect_ident_matching("hue").map_err(|_| ())?;
+                Ok::<_, ()>(method)
+            })
+            .unwrap_or_default();
+
+        input
+            .expect_comma()
+            .map_err(|_| input.new_custom_error(()))?;
+        let (first, first_percentage) = parse_color_mix_operand(input, depth)?;
+        input
+            .expect_comma()
+            .map_err(|_| input.new_custom_error(()))?;
+        let (second, second_percentage) = parse_color_mix_operand(input, depth)?;
+
+        let (w1, w2, alpha_multiplier) = normalize_mix_weights(first_percentage, second_percentage)
+            .ok_or_else(|| input.new_custom_error(()))?;
+
+        let (red, green, blue, alpha) = color_mix::mix(space, hue_method, first, w1, second, w2);
+        Ok(rgba_from_unit_floats(
+            red,
+            green,
+            blue,
+            alpha * alpha_multiplier,
+        ))
+    })
+}
+
+/// `<color> <percentage>?`(順序はどちらでもよい)。
+#[allow(clippy::type_complexity)]
+fn parse_color_mix_operand<'i>(
+    input: &mut Parser<'i, '_>,
+    depth: u32,
+) -> Result<(color_mix::UnitRgba, Option<f32>), ParseError<'i, ()>> {
+    let leading = input.try_parse(parse_mix_percentage).ok();
+    let color = parse_color_at_depth(input, depth + 1)?;
+    let percentage = match leading {
+        Some(p) => Some(p),
+        None => input.try_parse(parse_mix_percentage).ok(),
+    };
+
+    let Color::Rgba {
+        red,
+        green,
+        blue,
+        alpha,
+    } = color
+    else {
+        // `currentcolor`。上記のとおりここでは解決できない。
+        return Err(input.new_custom_error(()));
+    };
+    Ok((
+        (
+            red as f32 / 255.0,
+            green as f32 / 255.0,
+            blue as f32 / 255.0,
+            alpha,
+        ),
+        percentage,
+    ))
+}
+
+fn parse_mix_percentage<'i>(input: &mut Parser<'i, '_>) -> Result<f32, ParseError<'i, ()>> {
+    match input.expect_percentage() {
+        // 負のパーセンテージは無効。
+        Ok(p) if p >= 0.0 => Ok(p),
+        _ => Err(input.new_custom_error(())),
+    }
+}
+
+/// 2つの重みを正規化する(CSS Color 5 §3.2)。返り値は`(第1の重み, 第2の重み,
+/// 結果のアルファに掛ける係数)`。両方が0%なら無効。
+fn normalize_mix_weights(first: Option<f32>, second: Option<f32>) -> Option<(f32, f32, f32)> {
+    match (first, second) {
+        (None, None) => Some((0.5, 0.5, 1.0)),
+        (Some(p), None) => Some((p, 1.0 - p, 1.0)),
+        (None, Some(p)) => Some((1.0 - p, p, 1.0)),
+        (Some(a), Some(b)) => {
+            let sum = a + b;
+            if sum <= 0.0 {
+                return None;
+            }
+            // 合計が100%に満たない場合は、足りないぶんだけ結果を透明にする。
+            let alpha_multiplier = if sum < 1.0 { sum } else { 1.0 };
+            Some((a / sum, b / sum, alpha_multiplier))
+        }
     }
 }
 

--- a/core/tests/color_mix.rs
+++ b/core/tests/color_mix.rs
@@ -1,0 +1,188 @@
+//! `color-mix()`のE2Eテスト。
+//!
+//! 期待値はブラウザ(Chrome)の計算値に合わせてある。混色そのものの単体テストは
+//! `core/src/style/color_mix.rs`にあり、ここではCSSの構文からカスケードを経て
+//! 計算スタイルに落ちるところまでを見る。
+
+use sghtmltopdf_core::html::{self, Dom, NodeData, NodeId};
+use sghtmltopdf_core::style::{compute_styles, parse_stylesheet, user_agent_stylesheet};
+
+fn first_div(dom: &Dom, id: NodeId) -> Option<NodeId> {
+    if let NodeData::Element { name, .. } = &dom.node(id).data {
+        if &*name.local == "div" {
+            return Some(id);
+        }
+    }
+    dom.children(id).find_map(|c| first_div(dom, c))
+}
+
+/// `div`の`color`を`(r, g, b, alpha)`で返す。
+fn color_of(value: &str) -> (u8, u8, u8, f32) {
+    color_of_with(&format!("div {{ color: {value} }}"))
+}
+
+fn color_of_with(css: &str) -> (u8, u8, u8, f32) {
+    let dom = html::parse(b"<body><div>x</div></body>");
+    let styles = compute_styles(&dom, &user_agent_stylesheet(), &parse_stylesheet(css));
+    let div = first_div(&dom, dom.document()).expect("div がない");
+    let c = styles.get(&div).expect("style がない").color;
+    (c.red, c.green, c.blue, c.alpha)
+}
+
+/// 宣言が落ちたときの色(継承した初期値)。
+const DROPPED: (u8, u8, u8, f32) = (0, 0, 0, 1.0);
+
+#[test]
+fn mixes_in_srgb() {
+    assert_eq!(
+        color_of("color-mix(in srgb, red, blue)"),
+        (128, 0, 128, 1.0)
+    );
+}
+
+#[test]
+fn a_percentage_shifts_the_balance() {
+    assert_eq!(
+        color_of("color-mix(in srgb, red 25%, blue)"),
+        (64, 0, 191, 1.0)
+    );
+    // 片方だけ書いた場合、もう片方は残りぶんになる。
+    assert_eq!(
+        color_of("color-mix(in srgb, red, blue 25%)"),
+        (191, 0, 64, 1.0)
+    );
+}
+
+/// パーセンテージは色の前に書いてもよい。
+#[test]
+fn a_percentage_may_come_before_the_color() {
+    assert_eq!(
+        color_of("color-mix(in srgb, 25% red, blue)"),
+        (64, 0, 191, 1.0)
+    );
+}
+
+/// 合計が100%を超える場合は比率だけが意味を持つ。
+#[test]
+fn weights_over_one_hundred_percent_are_normalised() {
+    assert_eq!(
+        color_of("color-mix(in srgb, red 50%, blue 150%)"),
+        color_of("color-mix(in srgb, red 25%, blue 75%)")
+    );
+}
+
+/// 合計が100%に満たない場合は、足りないぶんだけ結果が透明になる。
+#[test]
+fn weights_under_one_hundred_percent_make_the_result_transparent() {
+    assert_eq!(
+        color_of("color-mix(in srgb, red 25%, blue 25%)"),
+        (128, 0, 128, 0.5)
+    );
+}
+
+#[test]
+fn both_weights_at_zero_is_invalid() {
+    assert_eq!(color_of("color-mix(in srgb, red 0%, blue 0%)"), DROPPED);
+}
+
+/// 知覚的に均等な色空間では、sRGBの算術平均とは違う色になる。
+#[test]
+fn perceptual_spaces_give_a_different_midpoint() {
+    let srgb = color_of("color-mix(in srgb, white, black)");
+    let lab = color_of("color-mix(in lab, white, black)");
+    assert_eq!(srgb, (128, 128, 128, 1.0));
+    assert_eq!(lab, (119, 119, 119, 1.0));
+}
+
+#[test]
+fn supports_the_polar_spaces() {
+    // 赤(0度)と青(240度)の中間は、短い方の弧を通って300度(マゼンタ)。
+    assert_eq!(color_of("color-mix(in hsl, red, blue)"), (255, 0, 255, 1.0));
+    assert_eq!(
+        color_of("color-mix(in hsl longer hue, red, blue)"),
+        (0, 255, 0, 1.0)
+    );
+}
+
+#[test]
+fn alpha_is_premultiplied() {
+    assert_eq!(
+        color_of("color-mix(in srgb, rgba(255, 0, 0, 0.5), blue)"),
+        (85, 0, 170, 0.75)
+    );
+}
+
+#[test]
+fn color_mix_can_be_nested() {
+    // 内側は紫(128, 0, 128)。それと白の中間。
+    assert_eq!(
+        color_of("color-mix(in srgb, color-mix(in srgb, red, blue), white)"),
+        (192, 128, 192, 1.0)
+    );
+}
+
+#[test]
+fn works_for_other_color_properties() {
+    let css = "div { background-color: color-mix(in srgb, red, blue) }";
+    let dom = html::parse(b"<body><div>x</div></body>");
+    let styles = compute_styles(&dom, &user_agent_stylesheet(), &parse_stylesheet(css));
+    let div = first_div(&dom, dom.document()).unwrap();
+    let bg = styles.get(&div).unwrap().background_color;
+    assert_eq!((bg.red, bg.green, bg.blue), (128, 0, 128));
+}
+
+// ===== 無効な形 =====
+
+/// sRGBより広い色域の空間は、出力先がDeviceRGBでは意味を持たないため非対応。
+#[test]
+fn wide_gamut_spaces_are_not_supported() {
+    for space in ["display-p3", "a98-rgb", "prophoto-rgb", "rec2020"] {
+        assert_eq!(
+            color_of(&format!("color-mix(in {space}, red, blue)")),
+            DROPPED,
+            "{space}"
+        );
+    }
+}
+
+#[test]
+fn an_unknown_color_space_is_invalid() {
+    assert_eq!(color_of("color-mix(in bogus, red, blue)"), DROPPED);
+}
+
+/// `currentcolor`はカスケードの後に解決するため、この時点では混ぜられない。
+#[test]
+fn currentcolor_as_an_operand_is_not_supported() {
+    assert_eq!(color_of("color-mix(in srgb, currentcolor, blue)"), DROPPED);
+}
+
+#[test]
+fn malformed_syntax_is_invalid() {
+    for value in [
+        "color-mix(red, blue)",                     // `in <space>`がない
+        "color-mix(in srgb, red)",                  // 色が1つしかない
+        "color-mix(in srgb red, blue)",             // カンマがない
+        "color-mix(in srgb, red -10%, blue)",       // 負のパーセンテージ
+        "color-mix(in oklch bogus hue, red, blue)", // 未知の色相補間
+    ] {
+        assert_eq!(color_of(value), DROPPED, "{value}");
+    }
+}
+
+/// 宣言が落ちても、同じルール内の他の宣言や後続のルールは生き残る。
+#[test]
+fn an_invalid_color_mix_only_drops_its_own_declaration() {
+    let css = "div { color: color-mix(in bogus, red, blue); background-color: red }";
+    let dom = html::parse(b"<body><div>x</div></body>");
+    let styles = compute_styles(&dom, &user_agent_stylesheet(), &parse_stylesheet(css));
+    let div = first_div(&dom, dom.document()).unwrap();
+    let style = styles.get(&div).unwrap();
+    assert_eq!(
+        (
+            style.background_color.red,
+            style.background_color.green,
+            style.background_color.blue
+        ),
+        (255, 0, 0)
+    );
+}

--- a/docs/po/en.po
+++ b/docs/po/en.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: sghtmltopdf\n"
-"POT-Creation-Date: 2026-08-16T18:15:07+09:00\n"
+"POT-Creation-Date: 2026-08-16T19:53:45+09:00\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -2267,8 +2267,8 @@ msgid ""
 "`:last-of-type`・`:only-of-type`・`:nth-last-child()`・`:nth-last-of-"
 "type()`・`:has(~ ...)`"
 msgstr ""
-"`:last-of-type`, `:only-of-type`, `:nth-last-child()`, `:nth-last-of-type()`, "
-"`:has(~ ...)`"
+"`:last-of-type`, `:only-of-type`, `:nth-last-child()`, `:nth-last-of-"
+"type()`, `:has(~ ...)`"
 
 #: src/usage/cli/streaming.md:31
 msgid "結果が変わる(余分にマッチする、または取りこぼす)"
@@ -2284,8 +2284,8 @@ msgstr ""
 "An element directly under `<body>` has its style settled the moment its next "
 "sibling appears. Only selectors that need to know whether more elements of "
 "the same kind follow are therefore undecidable. Rewrite rules such as "
-"\"remove the rule on the last row only\" by adding a class and writing "
-"`.last { … }` instead."
+"\"remove the rule on the last row only\" by adding a class and writing `."
+"last { … }` instead."
 
 #: src/usage/cli/streaming.md:37
 msgid ""
@@ -2293,10 +2293,9 @@ msgid ""
 "child`など)はバッチと同じ結果になります。 詳細は[セレクタ](../../supports/"
 "selectors.md#ストリーミングモード固有の制約)を参照してください。"
 msgstr ""
-"Every other sibling selector — `+`, `~`, `:first-child`, `:nth-child()`, "
-"`:last-child` and so on — gives the same result as batch mode. See "
-"[Selectors](../../supports/selectors.md#ストリーミングモード固有の制約) for "
-"the details."
+"Every other sibling selector — `+`, `~`, `:first-child`, `:nth-child()`, `:"
+"last-child` and so on — gives the same result as batch mode. See [Selectors]"
+"(../../supports/selectors.md#ストリーミングモード固有の制約) for the details."
 
 #: src/usage/cli/streaming.md:40
 msgid "使えるもの"
@@ -3071,7 +3070,7 @@ msgstr "Precompiled gems are distributed, so no Rust toolchain is needed."
 #: src/supports/selectors.md:15 src/supports/selectors.md:27
 #: src/supports/selectors.md:46 src/supports/selectors.md:57
 #: src/supports/selectors.md:76 src/supports/selectors.md:89
-#: src/supports/selectors.md:104
+#: src/supports/selectors.md:120
 msgid "対応"
 msgstr "Supported"
 
@@ -3922,7 +3921,7 @@ msgstr "Property"
 #: src/supports/properties.md:176 src/supports/properties.md:211
 #: src/supports/properties.md:230 src/supports/selectors.md:15
 #: src/supports/selectors.md:27 src/supports/selectors.md:46
-#: src/supports/selectors.md:76 src/supports/selectors.md:104
+#: src/supports/selectors.md:76 src/supports/selectors.md:120
 #: src/migration/wkhtmltopdf-options.md:29
 #: src/migration/wkhtmltopdf-options.md:67
 #: src/migration/wkhtmltopdf-options.md:76
@@ -3963,9 +3962,9 @@ msgstr "`display`"
 #: src/supports/properties.md:187 src/supports/selectors.md:37
 #: src/supports/selectors.md:48 src/supports/selectors.md:49
 #: src/supports/selectors.md:78 src/supports/selectors.md:80
-#: src/supports/selectors.md:82 src/supports/selectors.md:106
-#: src/supports/selectors.md:107 src/supports/selectors.md:108
-#: src/supports/selectors.md:109
+#: src/supports/selectors.md:82 src/supports/selectors.md:122
+#: src/supports/selectors.md:123 src/supports/selectors.md:124
+#: src/supports/selectors.md:125
 msgid "⚠️"
 msgstr "⚠️"
 
@@ -4149,7 +4148,7 @@ msgstr "`margin`"
 #: src/supports/selectors.md:81 src/supports/selectors.md:83
 #: src/supports/selectors.md:91 src/supports/selectors.md:92
 #: src/supports/selectors.md:93 src/supports/selectors.md:94
-#: src/supports/selectors.md:96 src/supports/selectors.md:110
+#: src/supports/selectors.md:96 src/supports/selectors.md:126
 msgid "✅"
 msgstr "✅"
 
@@ -4309,8 +4308,8 @@ msgstr "`outline-offset`"
 #: src/supports/selectors.md:50 src/supports/selectors.md:51
 #: src/supports/selectors.md:63 src/supports/selectors.md:79
 #: src/supports/selectors.md:84 src/supports/selectors.md:85
-#: src/supports/selectors.md:97 src/supports/selectors.md:98
-#: src/supports/selectors.md:111 src/supports/selectors.md:112
+#: src/supports/selectors.md:97 src/supports/selectors.md:99
+#: src/supports/selectors.md:127 src/supports/selectors.md:128
 msgid "❌"
 msgstr "❌"
 
@@ -5653,7 +5652,8 @@ msgstr "`:nth-child()`, `:nth-last-child()`"
 
 #: src/supports/selectors.md:31
 msgid "ストリーミングモードでは`:nth-last-child()`の結果が変わる(下記参照)"
-msgstr "In streaming mode `:nth-last-child()` gives a different result; see below"
+msgstr ""
+"In streaming mode `:nth-last-child()` gives a different result; see below"
 
 #: src/supports/selectors.md:32
 msgid ""
@@ -5964,25 +5964,90 @@ msgstr "`currentcolor`, `transparent`"
 msgid "`color()`(`color(display-p3 ...)`等)"
 msgstr "`color()`, such as `color(display-p3 ...)`"
 
-#: src/supports/selectors.md:98
-msgid "`color-mix()` / 相対色構文(`rgb(from ...)`)"
-msgstr "`color-mix()`, and the relative colour syntax `rgb(from ...)`"
+#: src/supports/selectors.md:98 src/supports/selectors.md:103
+msgid "`color-mix()`"
+msgstr "`color-mix()`"
 
-#: src/supports/selectors.md:100
+#: src/supports/selectors.md:98
+msgid "⚠️ (下記)"
+msgstr "⚠️ (see below)"
+
+#: src/supports/selectors.md:99
+msgid "相対色構文(`rgb(from ...)`)"
+msgstr "The relative colour syntax `rgb(from ...)`"
+
+#: src/supports/selectors.md:101
 msgid "アルファ付きの色は塗り・背景ともPDFのExtGStateで透過描画する。"
 msgstr ""
 "Colours with alpha are drawn through a PDF ExtGState, for both fills and "
 "backgrounds."
 
-#: src/supports/selectors.md:102 src/supports/selectors.md:104
+#: src/supports/selectors.md:105
+msgid ""
+"`color-mix(in <色空間> [<色相の回し方> hue]?, <色> <割合>?, <色> <割合>?)`に"
+"対応する。 割合の正規化(合計が100%を超えるときは比率だけが効き、満たないとき"
+"は足りないぶんだけ結果が透明になる)と、アルファの事前乗算も仕様どおり行う。"
+msgstr ""
+"`color-mix(in <colorspace> [<hue-interpolation-method> hue]?, <color> "
+"<percentage>?, <color> <percentage>?)` is supported. Weights are normalised "
+"as the spec requires — over 100% only the ratio matters, under 100% the "
+"result becomes transparent by the shortfall — and alpha is premultiplied "
+"before interpolating."
+
+#: src/supports/selectors.md:108
+msgid ""
+"色空間: `srgb` / `srgb-linear` / `lab` / `oklab` / `xyz`(`xyz-d65`) / "
+"`hsl` / `hwb` / `lch` / `oklch`"
+msgstr ""
+"Colour spaces: `srgb`, `srgb-linear`, `lab`, `oklab`, `xyz` (`xyz-d65`), "
+"`hsl`, `hwb`, `lch` and `oklch`"
+
+#: src/supports/selectors.md:109
+msgid "色相の回し方: `shorter`(既定) / `longer` / `increasing` / `decreasing`"
+msgstr ""
+"Hue interpolation: `shorter` (the default), `longer`, `increasing` and "
+"`decreasing`"
+
+#: src/supports/selectors.md:110
+msgid "入れ子にできる(深さ16まで)"
+msgstr "It can be nested (up to 16 levels)"
+
+#: src/supports/selectors.md:112
+msgid "以下は非対応で、書くとその宣言だけが無視される。"
+msgstr "The following are not supported; using one drops that declaration alone."
+
+#: src/supports/selectors.md:114
+msgid ""
+"`display-p3` / `a98-rgb` / `prophoto-rgb` / `rec2020`。出力先がPDFのDeviceRGB"
+"なので、受け付けてもsRGBへ丸められるだけで指定した意味にならない"
+msgstr ""
+"`display-p3`, `a98-rgb`, `prophoto-rgb` and `rec2020`. The output is PDF "
+"DeviceRGB, so accepting them would only round the result back to sRGB and "
+"the request would not mean what it says"
+
+#: src/supports/selectors.md:115
+msgid ""
+"オペランドの`currentcolor`。`currentcolor`はカスケードの後(その要素の`color`"
+"が決まってから)解決するのに対し、混色はパース時に済ませるため、この時点では値"
+"が分からない"
+msgstr ""
+"`currentcolor` as an operand. `currentcolor` is resolved after the cascade, "
+"once the element's own `color` is known, whereas the mixing happens at parse "
+"time, so the value is not available yet"
+
+#: src/supports/selectors.md:116
+msgid "`xyz-d50`(白色点の変換が要るため)"
+msgstr "`xyz-d50` (it would need a white point conversion)"
+
+#: src/supports/selectors.md:118 src/supports/selectors.md:120
 msgid "at-rule"
 msgstr "At-rules"
 
-#: src/supports/selectors.md:106
+#: src/supports/selectors.md:122
 msgid "`@media`"
 msgstr "`@media`"
 
-#: src/supports/selectors.md:106
+#: src/supports/selectors.md:122
 msgid ""
 "メディアタイプのみを評価する。`screen`(および`not screen`以外の否定)はブロッ"
 "クごと無視し、`print`/`all`/タイプ省略は適用する。`(min-width: ...)`のような"
@@ -5993,11 +6058,11 @@ msgstr ""
 "type are applied. Feature queries such as `(min-width: ...)` are skipped "
 "without being evaluated, so the contents apply as long as the type matches"
 
-#: src/supports/selectors.md:107
+#: src/supports/selectors.md:123
 msgid "`@page`"
 msgstr "`@page`"
 
-#: src/supports/selectors.md:107
+#: src/supports/selectors.md:123
 msgid ""
 "`size`(キーワード/`<length>{1,2}`/`landscape`/`portrait`)と`margin`系に対応。"
 "`:first`/`:left`/`:right`擬似クラス単体に対応し、名前付きページ(`@page "
@@ -6008,11 +6073,11 @@ msgstr ""
 "left`, and `:right` are supported on their own; named pages such as `@page "
 "intro`, `:blank`, and compound pseudo-classes such as `:first:left` are not"
 
-#: src/supports/selectors.md:108
+#: src/supports/selectors.md:124
 msgid "`@page`内のmargin box"
 msgstr "The margin boxes inside `@page`"
 
-#: src/supports/selectors.md:108
+#: src/supports/selectors.md:124
 msgid ""
 "`@top-left-corner`/`@top-left`/`@top-center`/`@top-right`…の16種すべて。"
 "`content`のテキスト描画のみで、背景色・枠線等の装飾は非対応。`counter(page)`/"
@@ -6025,11 +6090,11 @@ msgstr ""
 "with `counter(page)` and `counter(pages)`, though `counter(pages)` is "
 "unavailable in streaming mode"
 
-#: src/supports/selectors.md:109 src/supports/fonts.md:44
+#: src/supports/selectors.md:125 src/supports/fonts.md:44
 msgid "`@font-face`"
 msgstr "`@font-face`"
 
-#: src/supports/selectors.md:109
+#: src/supports/selectors.md:125
 msgid ""
 "`font-family`/`src`/`unicode-range`/`font-weight`/`font-style`ディスクリプタ"
 "に対応(`src`の`local()`・`format()`/`tech()`付き`url()`も受理)。`font-"
@@ -6041,11 +6106,11 @@ msgstr ""
 "or `tech()` inside `src`. Other descriptors such as `font-display` are "
 "ignored. Font files may be TTF or OTF only; WOFF and WOFF2 are not supported"
 
-#: src/supports/selectors.md:110
+#: src/supports/selectors.md:126
 msgid "`@import`"
 msgstr "`@import`"
 
-#: src/supports/selectors.md:110
+#: src/supports/selectors.md:126
 msgid ""
 "ネスト(深さ上限16、超過分はその1件だけ無視)・循環参照の検出に対応。`@import "
 "url(...) screen;`のようなメディアクエリ条件は評価せず常に取り込む"
@@ -6054,15 +6119,15 @@ msgstr ""
 "alone is ignored, and cycles are detected. A media condition such as "
 "`@import url(...) screen;` is not evaluated; the file is always imported"
 
-#: src/supports/selectors.md:111
+#: src/supports/selectors.md:127
 msgid "`@charset`"
 msgstr "`@charset`"
 
-#: src/supports/selectors.md:111
+#: src/supports/selectors.md:127
 msgid "入力はUTF-8前提"
 msgstr "The input is assumed to be UTF-8"
 
-#: src/supports/selectors.md:112
+#: src/supports/selectors.md:128
 msgid ""
 "`@supports` / `@keyframes` / `@namespace` / `@counter-style` / `@layer` / "
 "`@container` / `@property`"
@@ -6070,15 +6135,15 @@ msgstr ""
 "`@supports`, `@keyframes`, `@namespace`, `@counter-style`, `@layer`, "
 "`@container`, `@property`"
 
-#: src/supports/selectors.md:112
+#: src/supports/selectors.md:128
 msgid "ブロックごと無視される"
 msgstr "The whole block is ignored"
 
-#: src/supports/selectors.md:114
+#: src/supports/selectors.md:130
 msgid "ストリーミングモード固有の制約"
 msgstr "Restrictions specific to streaming mode"
 
-#: src/supports/selectors.md:116
+#: src/supports/selectors.md:132
 msgid ""
 "`Mode::Batch`(一括処理)ではDOM全体が揃っているため下記の制約は無い。 `Mode::"
 "Streaming`でのみ以下が適用される。"
@@ -6086,7 +6151,7 @@ msgstr ""
 "In `Mode::Batch` the whole DOM is available, so none of this applies. The "
 "following holds only in `Mode::Streaming`."
 
-#: src/supports/selectors.md:119
+#: src/supports/selectors.md:135
 msgid ""
 "`<body>`直下のトップレベル要素は、次の兄弟が現れた時点で確定として処理しま"
 "す。 そのため「この先に同じ型の要素が続くか」が要るセレクタだけ、`<body>`直下"
@@ -6099,7 +6164,7 @@ msgstr ""
 "for those top-level elements — inside one of them the subtree is complete, "
 "so nothing changes."
 
-#: src/supports/selectors.md:122
+#: src/supports/selectors.md:138
 msgid ""
 "`:last-of-type`/`:only-of-type`/`:nth-last-child()`/`:nth-last-of-type()`/`:"
 "has(~ ...)`は、余分にマッチしたり取りこぼしたりします。 これらを使うと警告が"
@@ -6109,7 +6174,7 @@ msgstr ""
 "and `:has(~ ...)` match too much or miss altogether. Using any of them "
 "prints a warning"
 
-#: src/supports/selectors.md:124
+#: src/supports/selectors.md:140
 msgid ""
 "`:last-child`・`:empty`・`:has()`の子孫/直後の兄弟は、確定の条件と一致するの"
 "でバッチと同じ結果になります"
@@ -6118,7 +6183,7 @@ msgstr ""
 "next sibling, on the other hand, line up with what settling already "
 "guarantees, so they give the same result as batch mode"
 
-#: src/supports/selectors.md:125
+#: src/supports/selectors.md:141
 msgid ""
 "`+`/`~`・`:first-child`/`:nth-child()`/`:first-of-type`/`:nth-of-type()`/`:"
 "only-child`もバッチと同じ結果になります。 これらを使っている文書では、処理済"
@@ -6132,7 +6197,7 @@ msgstr ""
 "descendants released, so the element itself stays visible as a sibling (what "
 "remains is one node per top-level element, so almost as much is still freed)"
 
-#: src/supports/selectors.md:128
+#: src/supports/selectors.md:144
 msgid ""
 "`<body>`開始後の`<style>`タグはエラー: `EngineError::"
 "UnsupportedInStreamingMode`を返す。 黙って見た目が崩れるのを避けるため、"
@@ -6142,11 +6207,11 @@ msgstr ""
 "UnsupportedInStreamingMode`. Keep all `<style>` in `<head>`, so that the "
 "layout does not quietly fall apart"
 
-#: src/supports/selectors.md:130
+#: src/supports/selectors.md:146
 msgid "`position: absolute`/`fixed`は無視される"
 msgstr "`position: absolute` and `fixed` are ignored"
 
-#: src/supports/selectors.md:131
+#: src/supports/selectors.md:147
 msgid "`counter(pages)`(総ページ数)は使えない"
 msgstr "`counter(pages)`, the total page count, is unavailable"
 
@@ -8950,25 +9015,31 @@ msgid "グラデーション(`linear-gradient()`等)と複数背景"
 msgstr "Gradients such as `linear-gradient()`, and multiple backgrounds"
 
 #: src/appendix/limitations.md:51
+msgid "相対色構文(`rgb(from ...)`)と`color()`(`color-mix()`は対応済み)"
+msgstr ""
+"The relative colour syntax (`rgb(from ...)`) and `color()` (`color-mix()` is "
+"supported)"
+
+#: src/appendix/limitations.md:52
 msgid "アニメーション・トランジション・`filter`(静的な出力のため)"
 msgstr "Animations, transitions, and `filter`, since the output is static"
 
-#: src/appendix/limitations.md:52
+#: src/appendix/limitations.md:53
 msgid "`position: sticky`、`display: inline-flex`/`inline-grid`、subgrid"
 msgstr ""
 "`position: sticky`, `display: inline-flex` and `inline-grid`, and subgrid"
 
-#: src/appendix/limitations.md:53
+#: src/appendix/limitations.md:54
 msgid "`::first-line`、`::marker`(`:is()`/`:where()`/`:has()`は対応済み)"
 msgstr ""
 "`::first-line` and `::marker` (`:is()`, `:where()` and `:has()` are "
 "supported)"
 
-#: src/appendix/limitations.md:55
+#: src/appendix/limitations.md:56
 msgid "空白文字の扱い"
 msgstr "How whitespace is treated"
 
-#: src/appendix/limitations.md:57
+#: src/appendix/limitations.md:58
 msgid ""
 "畳み込みの対象はCSS Text 3が定める空白(space・tab・改行)だけです。 `&nbsp;"
 "`(U+00A0)やthin space(U+2009)などは畳み込まれない普通の文字として、 フォント"
@@ -8984,7 +9055,7 @@ msgstr ""
 "space, figure space or word joiner (this holds under `word-break: break-all` "
 "as well)."
 
-#: src/appendix/limitations.md:63
+#: src/appendix/limitations.md:64
 msgid ""
 "`<wbr>`(と、それと同じ意味を持つU+200B ZERO WIDTH SPACE)は「ここで改行してよ"
 "い」という 指定として扱います。幅は増えず、PDFのテキスト層にも文字は残りませ"
@@ -8995,11 +9066,11 @@ msgstr ""
 "character in the PDF text layer (text extraction runs the two sides together "
 "even with a `<wbr>` between them)."
 
-#: src/appendix/limitations.md:67
+#: src/appendix/limitations.md:68
 msgid "この範囲での既知の制限は以下です。"
 msgstr "Within that scope, the known limitations are:"
 
-#: src/appendix/limitations.md:69
+#: src/appendix/limitations.md:70
 msgid ""
 "`text-align: justify`が行を伸ばす際、`&nbsp;`は伸縮の対象になりません(通常の"
 "空白のみ)"
@@ -9007,22 +9078,22 @@ msgstr ""
 "When `text-align: justify` stretches a line, `&nbsp;` is not one of the gaps "
 "it stretches (only ordinary spaces are)"
 
-#: src/appendix/limitations.md:70
+#: src/appendix/limitations.md:71
 msgid "U+2028/U+2029は本来の強制改行ではなく、通常の空白と同じ扱いになります"
 msgstr ""
 "U+2028 and U+2029 are treated as ordinary whitespace rather than as the "
 "forced breaks they are meant to be"
 
-#: src/appendix/limitations.md:71
+#: src/appendix/limitations.md:72
 msgid "行末に来た空白の「ぶら下がり」(hanging)は行いません"
 msgstr ""
 "Whitespace that lands at the end of a line is not hung outside the line box"
 
-#: src/appendix/limitations.md:73
+#: src/appendix/limitations.md:74
 msgid "ストリーミングモード固有の制限"
 msgstr "Limitations specific to streaming mode"
 
-#: src/appendix/limitations.md:75
+#: src/appendix/limitations.md:76
 msgid ""
 "`--streaming`を使う場合は、総ページ数(`counter(pages)`・`[topage]`)や目次(`--"
 "toc`)などが使えなくなります。 詳細は[ストリーミングモード](../usage/cli/"
@@ -9032,11 +9103,11 @@ msgstr ""
 "`[topage]`, and the table of contents, `--toc`, become unavailable. See "
 "[Streaming mode](../usage/cli/streaming.md) for the details."
 
-#: src/appendix/limitations.md:78
+#: src/appendix/limitations.md:79
 msgid "今後について"
 msgstr "Looking ahead"
 
-#: src/appendix/limitations.md:80
+#: src/appendix/limitations.md:81
 msgid ""
 "JavaScriptエンジンの組み込みは、必要性が出てきた段階での検討事項として残して"
 "あります。 上記のうちPDFのアウトラインなど、設計上の非目標ではないものは将来"

--- a/docs/po/messages.pot
+++ b/docs/po/messages.pot
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: sghtmltopdf\n"
-"POT-Creation-Date: 2026-08-16T18:15:07+09:00\n"
+"POT-Creation-Date: 2026-08-16T19:53:45+09:00\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -2458,7 +2458,7 @@ msgstr ""
 #: src/supports/selectors.md:15 src/supports/selectors.md:27
 #: src/supports/selectors.md:46 src/supports/selectors.md:57
 #: src/supports/selectors.md:76 src/supports/selectors.md:89
-#: src/supports/selectors.md:104
+#: src/supports/selectors.md:120
 msgid "対応"
 msgstr ""
 
@@ -3144,7 +3144,7 @@ msgstr ""
 #: src/supports/properties.md:176 src/supports/properties.md:211
 #: src/supports/properties.md:230 src/supports/selectors.md:15
 #: src/supports/selectors.md:27 src/supports/selectors.md:46
-#: src/supports/selectors.md:76 src/supports/selectors.md:104
+#: src/supports/selectors.md:76 src/supports/selectors.md:120
 #: src/migration/wkhtmltopdf-options.md:29
 #: src/migration/wkhtmltopdf-options.md:67
 #: src/migration/wkhtmltopdf-options.md:76
@@ -3185,9 +3185,9 @@ msgstr ""
 #: src/supports/properties.md:187 src/supports/selectors.md:37
 #: src/supports/selectors.md:48 src/supports/selectors.md:49
 #: src/supports/selectors.md:78 src/supports/selectors.md:80
-#: src/supports/selectors.md:82 src/supports/selectors.md:106
-#: src/supports/selectors.md:107 src/supports/selectors.md:108
-#: src/supports/selectors.md:109
+#: src/supports/selectors.md:82 src/supports/selectors.md:122
+#: src/supports/selectors.md:123 src/supports/selectors.md:124
+#: src/supports/selectors.md:125
 msgid "⚠️"
 msgstr ""
 
@@ -3324,7 +3324,7 @@ msgstr ""
 #: src/supports/selectors.md:81 src/supports/selectors.md:83
 #: src/supports/selectors.md:91 src/supports/selectors.md:92
 #: src/supports/selectors.md:93 src/supports/selectors.md:94
-#: src/supports/selectors.md:96 src/supports/selectors.md:110
+#: src/supports/selectors.md:96 src/supports/selectors.md:126
 msgid "✅"
 msgstr ""
 
@@ -3451,8 +3451,8 @@ msgstr ""
 #: src/supports/selectors.md:50 src/supports/selectors.md:51
 #: src/supports/selectors.md:63 src/supports/selectors.md:79
 #: src/supports/selectors.md:84 src/supports/selectors.md:85
-#: src/supports/selectors.md:97 src/supports/selectors.md:98
-#: src/supports/selectors.md:111 src/supports/selectors.md:112
+#: src/supports/selectors.md:97 src/supports/selectors.md:99
+#: src/supports/selectors.md:127 src/supports/selectors.md:128
 msgid "❌"
 msgstr ""
 
@@ -4733,127 +4733,174 @@ msgstr ""
 msgid "`color()`(`color(display-p3 ...)`等)"
 msgstr ""
 
-#: src/supports/selectors.md:98
-msgid "`color-mix()` / 相対色構文(`rgb(from ...)`)"
+#: src/supports/selectors.md:98 src/supports/selectors.md:103
+msgid "`color-mix()`"
 msgstr ""
 
-#: src/supports/selectors.md:100
+#: src/supports/selectors.md:98
+msgid "⚠️ (下記)"
+msgstr ""
+
+#: src/supports/selectors.md:99
+msgid "相対色構文(`rgb(from ...)`)"
+msgstr ""
+
+#: src/supports/selectors.md:101
 msgid "アルファ付きの色は塗り・背景ともPDFのExtGStateで透過描画する。"
 msgstr ""
 
-#: src/supports/selectors.md:102 src/supports/selectors.md:104
+#: src/supports/selectors.md:105
+msgid ""
+"`color-mix(in <色空間> [<色相の回し方> hue]?, <色> <割合>?, <色> <割合>?)`に対応する。 "
+"割合の正規化(合計が100%を超えるときは比率だけが効き、満たないときは足りないぶんだけ結果が透明になる)と、アルファの事前乗算も仕様どおり行う。"
+msgstr ""
+
+#: src/supports/selectors.md:108
+msgid ""
+"色空間: `srgb` / `srgb-linear` / `lab` / `oklab` / `xyz`(`xyz-d65`) / `hsl` / "
+"`hwb` / `lch` / `oklch`"
+msgstr ""
+
+#: src/supports/selectors.md:109
+msgid "色相の回し方: `shorter`(既定) / `longer` / `increasing` / `decreasing`"
+msgstr ""
+
+#: src/supports/selectors.md:110
+msgid "入れ子にできる(深さ16まで)"
+msgstr ""
+
+#: src/supports/selectors.md:112
+msgid "以下は非対応で、書くとその宣言だけが無視される。"
+msgstr ""
+
+#: src/supports/selectors.md:114
+msgid ""
+"`display-p3` / `a98-rgb` / `prophoto-rgb` / "
+"`rec2020`。出力先がPDFのDeviceRGBなので、受け付けてもsRGBへ丸められるだけで指定した意味にならない"
+msgstr ""
+
+#: src/supports/selectors.md:115
+msgid ""
+"オペランドの`currentcolor`。`currentcolor`はカスケードの後(その要素の`color`が決まってから)解決するのに対し、混色はパース時に済ませるため、この時点では値が分からない"
+msgstr ""
+
+#: src/supports/selectors.md:116
+msgid "`xyz-d50`(白色点の変換が要るため)"
+msgstr ""
+
+#: src/supports/selectors.md:118 src/supports/selectors.md:120
 msgid "at-rule"
 msgstr ""
 
-#: src/supports/selectors.md:106
+#: src/supports/selectors.md:122
 msgid "`@media`"
 msgstr ""
 
-#: src/supports/selectors.md:106
+#: src/supports/selectors.md:122
 msgid ""
 "メディアタイプのみを評価する。`screen`(および`not "
 "screen`以外の否定)はブロックごと無視し、`print`/`all`/タイプ省略は適用する。`(min-width: "
 "...)`のような特性クエリは評価せず読み飛ばす(=タイプさえ合致すれば中身が適用される)"
 msgstr ""
 
-#: src/supports/selectors.md:107
+#: src/supports/selectors.md:123
 msgid "`@page`"
 msgstr ""
 
-#: src/supports/selectors.md:107
+#: src/supports/selectors.md:123
 msgid ""
 "`size`(キーワード/`<length>{1,2}`/`landscape`/`portrait`)と`margin`系に対応。`:first`/`:left`/`:right`擬似クラス単体に対応し、名前付きページ(`@page "
 "intro`)・`:blank`・複合擬似クラス(`:first:left`)は非対応"
 msgstr ""
 
-#: src/supports/selectors.md:108
+#: src/supports/selectors.md:124
 msgid "`@page`内のmargin box"
 msgstr ""
 
-#: src/supports/selectors.md:108
+#: src/supports/selectors.md:124
 msgid ""
 "`@top-left-corner`/`@top-left`/`@top-center`/`@top-right`…の16種すべて。`content`のテキスト描画のみで、背景色・枠線等の装飾は非対応。`counter(page)`/`counter(pages)`でページ番号を出力できる(`counter(pages)`はストリーミングモードでは非対応)"
 msgstr ""
 
-#: src/supports/selectors.md:109 src/supports/fonts.md:44
+#: src/supports/selectors.md:125 src/supports/fonts.md:44
 msgid "`@font-face`"
 msgstr ""
 
-#: src/supports/selectors.md:109
+#: src/supports/selectors.md:125
 msgid ""
 "`font-family`/`src`/`unicode-range`/`font-weight`/`font-style`ディスクリプタに対応(`src`の`local()`・`format()`/`tech()`付き`url()`も受理)。`font-display`等その他のディスクリプタは無視。フォントファイルはTTF/OTFのみで、WOFF/WOFF2は非対応"
 msgstr ""
 
-#: src/supports/selectors.md:110
+#: src/supports/selectors.md:126
 msgid "`@import`"
 msgstr ""
 
-#: src/supports/selectors.md:110
+#: src/supports/selectors.md:126
 msgid ""
 "ネスト(深さ上限16、超過分はその1件だけ無視)・循環参照の検出に対応。`@import url(...) "
 "screen;`のようなメディアクエリ条件は評価せず常に取り込む"
 msgstr ""
 
-#: src/supports/selectors.md:111
+#: src/supports/selectors.md:127
 msgid "`@charset`"
 msgstr ""
 
-#: src/supports/selectors.md:111
+#: src/supports/selectors.md:127
 msgid "入力はUTF-8前提"
 msgstr ""
 
-#: src/supports/selectors.md:112
+#: src/supports/selectors.md:128
 msgid ""
 "`@supports` / `@keyframes` / `@namespace` / `@counter-style` / `@layer` / "
 "`@container` / `@property`"
 msgstr ""
 
-#: src/supports/selectors.md:112
+#: src/supports/selectors.md:128
 msgid "ブロックごと無視される"
 msgstr ""
 
-#: src/supports/selectors.md:114
+#: src/supports/selectors.md:130
 msgid "ストリーミングモード固有の制約"
 msgstr ""
 
-#: src/supports/selectors.md:116
+#: src/supports/selectors.md:132
 msgid "`Mode::Batch`(一括処理)ではDOM全体が揃っているため下記の制約は無い。 `Mode::Streaming`でのみ以下が適用される。"
 msgstr ""
 
-#: src/supports/selectors.md:119
+#: src/supports/selectors.md:135
 msgid ""
 "`<body>`直下のトップレベル要素は、次の兄弟が現れた時点で確定として処理します。 "
 "そのため「この先に同じ型の要素が続くか」が要るセレクタだけ、`<body>`直下の要素に限って結果が変わります(その要素の内側は部分木が揃っているので変わりません)。"
 msgstr ""
 
-#: src/supports/selectors.md:122
+#: src/supports/selectors.md:138
 msgid ""
 "`:last-of-type`/`:only-of-type`/`:nth-last-child()`/`:nth-last-of-type()`/`:has(~ "
 "...)`は、余分にマッチしたり取りこぼしたりします。 これらを使うと警告が出ます"
 msgstr ""
 
-#: src/supports/selectors.md:124
+#: src/supports/selectors.md:140
 msgid "`:last-child`・`:empty`・`:has()`の子孫/直後の兄弟は、確定の条件と一致するのでバッチと同じ結果になります"
 msgstr ""
 
-#: src/supports/selectors.md:125
+#: src/supports/selectors.md:141
 msgid ""
 "`+`/`~`・`:first-child`/`:nth-child()`/`:first-of-type`/`:nth-of-type()`/`:only-child`もバッチと同じ結果になります。 "
 "これらを使っている文書では、処理済みのトップレベル要素を子孫だけ解放し、要素そのものを兄弟として残すためです "
 "(残るのはトップレベル要素1個につき1ノードなので、解放できる量はほぼ変わりません)"
 msgstr ""
 
-#: src/supports/selectors.md:128
+#: src/supports/selectors.md:144
 msgid ""
 "`<body>`開始後の`<style>`タグはエラー: `EngineError::UnsupportedInStreamingMode`を返す。 "
 "黙って見た目が崩れるのを避けるため、`<style>`は`<head>`に集約する"
 msgstr ""
 
-#: src/supports/selectors.md:130
+#: src/supports/selectors.md:146
 msgid "`position: absolute`/`fixed`は無視される"
 msgstr ""
 
-#: src/supports/selectors.md:131
+#: src/supports/selectors.md:147
 msgid "`counter(pages)`(総ページ数)は使えない"
 msgstr ""
 
@@ -7163,22 +7210,26 @@ msgid "グラデーション(`linear-gradient()`等)と複数背景"
 msgstr ""
 
 #: src/appendix/limitations.md:51
-msgid "アニメーション・トランジション・`filter`(静的な出力のため)"
+msgid "相対色構文(`rgb(from ...)`)と`color()`(`color-mix()`は対応済み)"
 msgstr ""
 
 #: src/appendix/limitations.md:52
-msgid "`position: sticky`、`display: inline-flex`/`inline-grid`、subgrid"
+msgid "アニメーション・トランジション・`filter`(静的な出力のため)"
 msgstr ""
 
 #: src/appendix/limitations.md:53
+msgid "`position: sticky`、`display: inline-flex`/`inline-grid`、subgrid"
+msgstr ""
+
+#: src/appendix/limitations.md:54
 msgid "`::first-line`、`::marker`(`:is()`/`:where()`/`:has()`は対応済み)"
 msgstr ""
 
-#: src/appendix/limitations.md:55
+#: src/appendix/limitations.md:56
 msgid "空白文字の扱い"
 msgstr ""
 
-#: src/appendix/limitations.md:57
+#: src/appendix/limitations.md:58
 msgid ""
 "畳み込みの対象はCSS Text 3が定める空白(space・tab・改行)だけです。 `&nbsp;`(U+00A0)やthin "
 "space(U+2009)などは畳み込まれない普通の文字として、 フォント本来の字幅で描かれます。改行してよい位置はUAX #14の行分割クラスに従い、 "
@@ -7186,43 +7237,43 @@ msgid ""
 "(`word-break: break-all`を指定した場合も同様です)。"
 msgstr ""
 
-#: src/appendix/limitations.md:63
+#: src/appendix/limitations.md:64
 msgid ""
 "`<wbr>`(と、それと同じ意味を持つU+200B ZERO WIDTH SPACE)は「ここで改行してよい」という "
 "指定として扱います。幅は増えず、PDFのテキスト層にも文字は残りません (`<wbr>`を挟んでも抽出結果は繋がったままです)。"
 msgstr ""
 
-#: src/appendix/limitations.md:67
+#: src/appendix/limitations.md:68
 msgid "この範囲での既知の制限は以下です。"
 msgstr ""
 
-#: src/appendix/limitations.md:69
+#: src/appendix/limitations.md:70
 msgid "`text-align: justify`が行を伸ばす際、`&nbsp;`は伸縮の対象になりません(通常の空白のみ)"
 msgstr ""
 
-#: src/appendix/limitations.md:70
+#: src/appendix/limitations.md:71
 msgid "U+2028/U+2029は本来の強制改行ではなく、通常の空白と同じ扱いになります"
 msgstr ""
 
-#: src/appendix/limitations.md:71
+#: src/appendix/limitations.md:72
 msgid "行末に来た空白の「ぶら下がり」(hanging)は行いません"
 msgstr ""
 
-#: src/appendix/limitations.md:73
+#: src/appendix/limitations.md:74
 msgid "ストリーミングモード固有の制限"
 msgstr ""
 
-#: src/appendix/limitations.md:75
+#: src/appendix/limitations.md:76
 msgid ""
 "`--streaming`を使う場合は、総ページ数(`counter(pages)`・`[topage]`)や目次(`--toc`)などが使えなくなります。 "
 "詳細は[ストリーミングモード](../usage/cli/streaming.md)を参照してください。"
 msgstr ""
 
-#: src/appendix/limitations.md:78
+#: src/appendix/limitations.md:79
 msgid "今後について"
 msgstr ""
 
-#: src/appendix/limitations.md:80
+#: src/appendix/limitations.md:81
 msgid ""
 "JavaScriptエンジンの組み込みは、必要性が出てきた段階での検討事項として残してあります。 "
 "上記のうちPDFのアウトラインなど、設計上の非目標ではないものは将来対応する可能性があります。"

--- a/docs/src/appendix/limitations.md
+++ b/docs/src/appendix/limitations.md
@@ -48,6 +48,7 @@
 * 縦書き(`writing-mode`/`text-orientation`)と論理プロパティ(`margin-inline`等)、`direction`による右横書き
 * 多段組み(`columns`/`column-count`)
 * グラデーション(`linear-gradient()`等)と複数背景
+* 相対色構文(`rgb(from ...)`)と`color()`(`color-mix()`は対応済み)
 * アニメーション・トランジション・`filter`(静的な出力のため)
 * `position: sticky`、`display: inline-flex`/`inline-grid`、subgrid
 * `::first-line`、`::marker`(`:is()`/`:where()`/`:has()`は対応済み)

--- a/docs/src/supports/selectors.md
+++ b/docs/src/supports/selectors.md
@@ -95,9 +95,25 @@
 | `lab()` / `lch()` / `oklab()` / `oklch()` | ✅ (sRGBへ変換して描画) |
 | `currentcolor` / `transparent` | ✅ |
 | `color()`(`color(display-p3 ...)`等) | ❌ |
-| `color-mix()` / 相対色構文(`rgb(from ...)`) | ❌ |
+| `color-mix()` | ⚠️ (下記) |
+| 相対色構文(`rgb(from ...)`) | ❌ |
 
 アルファ付きの色は塗り・背景ともPDFのExtGStateで透過描画する。
+
+#### `color-mix()`
+
+`color-mix(in <色空間> [<色相の回し方> hue]?, <色> <割合>?, <色> <割合>?)`に対応する。
+割合の正規化(合計が100%を超えるときは比率だけが効き、満たないときは足りないぶんだけ結果が透明になる)と、アルファの事前乗算も仕様どおり行う。
+
+* 色空間: `srgb` / `srgb-linear` / `lab` / `oklab` / `xyz`(`xyz-d65`) / `hsl` / `hwb` / `lch` / `oklch`
+* 色相の回し方: `shorter`(既定) / `longer` / `increasing` / `decreasing`
+* 入れ子にできる(深さ16まで)
+
+以下は非対応で、書くとその宣言だけが無視される。
+
+* `display-p3` / `a98-rgb` / `prophoto-rgb` / `rec2020`。出力先がPDFのDeviceRGBなので、受け付けてもsRGBへ丸められるだけで指定した意味にならない
+* オペランドの`currentcolor`。`currentcolor`はカスケードの後(その要素の`color`が決まってから)解決するのに対し、混色はパース時に済ませるため、この時点では値が分からない
+* `xyz-d50`(白色点の変換が要るため)
 
 ## at-rule
 


### PR DESCRIPTION
### Implemented

A new color mixing calculation function has been added to core/src/style/color_mix.rs.

Supported range:
- Color space: srgb / srgb-linear / lab / oklab / xyz(xyz-d65) / hsl / hwb / lch / oklch
- Hue rotation method: shorter (default) / longer / increasing / decreasing
- Percentages can be written before or after the color
  - Normalization (if the total is greater than 100%, only the percentage is affected; if it is less than 100%, the result becomes transparent by the amount that is missing) is also as per the specifications.
- Alpha is pre-multiplied and then interpolated. Only hue is not subject to multiplication

### Notes

Forms containing `currentcolor` as an operand are treated as invalid colors and the declaration is dropped.
This is because `currentcolor` is resolved after the element's color is determined after cascading, whereas color mixing is done during parsing, so the value cannot be obtained at that point.