### PR TITLE
Disabled default behavior where Taffy rounds the final layout result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- Stop rounding flex and grid item sizes to whole pixels (#15). taffy rounds its final
+  layout to integers so that a rasteriser does not leave gaps or overlaps between boxes;
+  the output here is PDF, which has no such constraint, and the rounding truncated the
+  measured max-content width so that text which fit was wrapped onto a second line. Which
+  way the fraction rounded depended on the exact string, so the same row wrapped for one
+  value and not for another (`1 USD = 0.9143 EUR` wrapped, `1 USD 0.9143 EUR` did not).
+
 ## 0.2.0 - 2026-08-16
 
 ### Added

--- a/core/examples/spike_image_png_decode.rs
+++ b/core/examples/spike_image_png_decode.rs
@@ -51,7 +51,7 @@ fn main() {
             let pixel_count = (width * height) as usize;
             let mut rgb = Vec::with_capacity(pixel_count * 3);
             let mut alpha = Vec::with_capacity(pixel_count);
-            for px in buf.chunks_exact(4) {
+            for px in buf.as_chunks::<4>().0 {
                 rgb.extend_from_slice(&px[0..3]);
                 alpha.push(px[3]);
             }
@@ -65,7 +65,7 @@ fn main() {
             let pixel_count = (width * height) as usize;
             let mut rgb = Vec::with_capacity(pixel_count * 3);
             let mut alpha = Vec::with_capacity(pixel_count);
-            for px in buf.chunks_exact(2) {
+            for px in buf.as_chunks::<2>().0 {
                 rgb.extend_from_slice(&[px[0], px[0], px[0]]);
                 alpha.push(px[1]);
             }

--- a/core/examples/spike_image_webp_decode.rs
+++ b/core/examples/spike_image_webp_decode.rs
@@ -50,7 +50,7 @@ fn main() {
             let pixel_count = (width * height) as usize;
             let mut rgb = Vec::with_capacity(pixel_count * 3);
             let mut alpha = Vec::with_capacity(pixel_count);
-            for px in buf.chunks_exact(4) {
+            for px in buf.as_chunks::<4>().0 {
                 rgb.extend_from_slice(&px[0..3]);
                 alpha.push(px[3]);
             }

--- a/core/src/layout/flex.rs
+++ b/core/src/layout/flex.rs
@@ -108,6 +108,11 @@ pub(super) fn layout_taffy_subtree(
     }
 
     let mut tree: tf::TaffyTree<usize> = tf::TaffyTree::new();
+    // taffyは既定で最終レイアウトを整数へ丸める。整数ピクセルのラスタライズで
+    // 隙間や重なりを出さないための処理だが、出力先がPDF(浮動小数座標)のこちらでは
+    // 利点が無く、採寸で得た自然幅が切り捨てられてアイテムが内容より狭くなり、
+    // 収まるはずのテキストが折り返される。丸めは行わない。
+    tree.disable_rounding();
 
     // `box_style`は`ComputedStyle`(1KB超)を複製するので、アイテムごとに1回だけ
     // 作って以降は使い回す(採寸コールバックは1アイテムにつき何度も呼ばれる)。

--- a/core/src/layout/paginate.rs
+++ b/core/src/layout/paginate.rs
@@ -292,12 +292,12 @@ impl StreamingPaginator {
     }
 
     /// これ以上アイテムが無いことを伝え、残っている全ページを返す。
-    pub fn finish(mut self) -> Vec<Page> {
+    pub fn finish(self) -> Vec<Page> {
         debug_assert!(
             self.buffer.active_min_page.is_empty(),
             "finishはすべてのplace_split呼び出しを抜けた後に呼ばれるはず"
         );
-        self.buffer.buffer.drain(..).collect()
+        self.buffer.buffer
     }
 }
 

--- a/core/src/pdf/img.rs
+++ b/core/src/pdf/img.rs
@@ -510,7 +510,7 @@ pub fn to_grayscale_plane(plane: &ImagePlane) -> (ImagePlane, bool) {
     };
 
     let mut gray = Vec::with_capacity(raw.len() / 3);
-    for px in raw.chunks_exact(3) {
+    for px in raw.as_chunks::<3>().0 {
         let y = 0.2126 * px[0] as f32 + 0.7152 * px[1] as f32 + 0.0722 * px[2] as f32;
         gray.push(y.round().clamp(0.0, 255.0) as u8);
     }

--- a/core/tests/flexbox.rs
+++ b/core/tests/flexbox.rs
@@ -482,3 +482,63 @@ fn a_flex_inside_a_flex_item_does_not_collapse_to_zero() {
         item.layout.content
     );
 }
+
+// ===== 採寸した自然幅を丸めない =====
+
+/// 与えられたノードのレイアウト済み行数を返す。
+fn line_count(b: &LaidOutBox) -> usize {
+    match &b.content {
+        LaidOutContent::Inline(lines) => lines.len(),
+        _ => panic!("インラインの内容を持つ箱ではない"),
+    }
+}
+
+#[test]
+fn a_flex_item_is_not_rounded_below_the_width_its_text_needs() {
+    // 回帰テスト: taffyが既定で最終レイアウトを整数へ丸めるため、採寸で得た
+    // 自然幅が切り捨てられ、内容より狭いアイテムになって収まるはずの行が
+    // 折り返されていた。丸めの向きは端数次第なので、同じ書式の文字列でも
+    // 特定の内容だけ折り返す、という形で表面化する。
+    //
+    // 下の2つはDejaVuSans 14pxで自然幅146.16pxと129.98px。丸めると前者だけが
+    // 146へ切り捨てられて0.16px足りなくなり、`EUR`が2行目へ落ちていた。
+    for value in ["1 USD = 0.9143 EUR", "1 USD 0.9143 EUR"] {
+        let (dom, laid) = layout(
+            &format!(
+                r#"<div class="row"><span class="k">Exchange rate</span><span class="v">{value}</span></div>"#
+            ),
+            "body { margin: 0; font-size: 14px; } \
+             .row { display: flex; justify-content: space-between; gap: 24px; } \
+             .k { white-space: nowrap; } \
+             .v { text-align: right; }",
+        );
+        let mut spans = Vec::new();
+        find_all_tags(&dom, dom.document(), "span", &mut spans);
+        let v = find_laid_out(&laid, spans[1]).unwrap();
+        assert_eq!(
+            line_count(v),
+            1,
+            "行に余裕があるので折り返してはならない: {value:?} width={:?}",
+            v.layout.content
+        );
+    }
+}
+
+#[test]
+fn flex_item_widths_keep_their_fractional_part() {
+    // 上のテストの土台。アイテムの幅が整数へ丸められていないことを直接見る
+    // (丸めが復活すると、端数が消えることで先に気付ける)。
+    let (dom, laid) = layout(
+        r#"<div class="row"><span class="v">1 USD = 0.9143 EUR</span></div>"#,
+        "body { margin: 0; font-size: 14px; } \
+         .row { display: flex; }",
+    );
+    let mut spans = Vec::new();
+    find_all_tags(&dom, dom.document(), "span", &mut spans);
+    let v = find_laid_out(&laid, spans[0]).unwrap();
+    assert!(
+        v.layout.content.width.fract() != 0.0,
+        "自然幅の端数が失われている: {:?}",
+        v.layout.content
+    );
+}


### PR DESCRIPTION
Report by issue.
https://github.com/waka/sghtmltopdf/issues/15

## Cause:

It is not a text measurement problem at all. The intrinsic width is computed correctly, it is then rounded away.                                                                                                                                                                          
                                                                                                                                                                                              
Flex and grid layout are delegated to [taffy](https://github.com/DioxusLabs/taffy), which by default rounds its final layout to whole pixels.
What it does do is round the measured max-content width of a flex item, and it rounds to nearest, so roughly half the time the item ends up narrower than the content it was measured from.                                                                                                                            
                                                                                                                                                                                              
Measured with the bundled DejaVuSans at 14px:

| value | max-content width | after rounding | result |
|---|---|---|---|
| `1 USD = 0.9143 EUR` | 146.159px | 146.00 (down) | 0.16px short, `EUR` wraps |
| `1 USD 0.9143 EUR` | 129.978px | 130.00 (up) | fits |

## Fixed:

The rounding is disabled on the taffy tree, so item sizes keep the fractional part the measurement produced.