### PR TITLE
Make text-align move inline images and inline-block boxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- `text-align` now moves inline images and `inline-block` boxes along with the text (#19).
+  A line box keeps its text runs and its atomic inline boxes (`<img>`, `display: inline-block`,
+  form controls) in separate lists, and the alignment step only shifted the runs, so a
+  right-aligned header rendered its title on the right and its logo flush left. `justify`
+  counts the space before a box as a justification opportunity and shifts the box together
+  with the words around it, rather than pushing the words into it.
+- `text-align` is now read from the block container that establishes the inline formatting
+  context, rather than from the first text span in it. `text-align` applies to block
+  containers and is only inherited by inline boxes, so a value set on an inline one was
+  never meant to win: `<div style="text-align: right"><span style="text-align: left">WORD</span></div>`
+  left the word at x=0. A line holding nothing but boxes (`<div style="text-align: right"><img></div>`)
+  had no text span to read at all and was therefore always aligned left.
+
 ## 0.3.0 - 2026-08-30
 
 ### Added

--- a/core/src/layout/block.rs
+++ b/core/src/layout/block.rs
@@ -729,6 +729,8 @@ fn layout_box_impl(
                 content_x,
                 content_y,
                 Some(&*float_ctx),
+                // 無名ボックスには自身のスタイルが無い(`style`は初期値)。
+                b.node.map(|_| &style),
                 pos,
             );
             // 行内の`display: inline-block`ボックスは、行の位置が確定した

--- a/core/src/layout/block.rs
+++ b/core/src/layout/block.rs
@@ -730,7 +730,7 @@ fn layout_box_impl(
                 content_y,
                 Some(&*float_ctx),
                 // 無名ボックスには自身のスタイルが無い(`style`は初期値)。
-                b.node.map(|_| &style),
+                b.node.is_some().then_some(&style),
                 pos,
             );
             // 行内の`display: inline-block`ボックスは、行の位置が確定した

--- a/core/src/layout/inline.rs
+++ b/core/src/layout/inline.rs
@@ -191,6 +191,10 @@ enum InlineItem<'a> {
 /// 占有帯を問い合わせ、`available_width`/`origin_x`を動的に狭める(float周りの
 /// テキスト回り込み)。`None`(floatが無い、またはテーブル列幅の事前測定など
 /// 無関係な呼び出し)なら固定の`available_width`/`origin_x`のまま(既存動作)。
+///
+/// `container_style`はこのIFCを確立するブロックコンテナの計算スタイル
+/// (無名ボックスや採寸パスなら`None`)。テキストが1つも無く`<img>`や
+/// `display: inline-block`の箱だけの行で`text-align`を決めるために使う。
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn layout_inline_content(
     spans: &[InlineSpan],
@@ -200,6 +204,7 @@ pub(crate) fn layout_inline_content(
     origin_x: f32,
     origin_y: f32,
     float_ctx: Option<&FloatContext>,
+    container_style: Option<&ComputedStyle>,
     pos: &mut PosCtx,
 ) -> Vec<LineBox> {
     if fonts.is_empty() || spans.is_empty() {
@@ -214,13 +219,20 @@ pub(crate) fn layout_inline_content(
     // スタイルシートが`input`に付ける`white-space: pre`が段落全体をpre
     // 扱いにしてしまう)。箱しか無いIFC(`<p><input></p>`等)ではテキスト由来の
     // 代表値が存在しないため、初期値
-    // (`white-space: normal`/`text-align: left`/`text-indent: 0`)を使う
+    // (`white-space: normal`/`text-indent: 0`)を使う
     let representative = spans
         .iter()
         .position(|span| span.atomic.is_none())
         .and_then(|i| span_styles.get(i));
     let white_space = representative.map(|s| s.white_space).unwrap_or_default();
-    let text_align = representative.map(|s| s.text_align).unwrap_or_default();
+    // `text-align`だけは、箱しか無いIFCでもコンテナの値を使う。
+    // `<div style="text-align: right"><img></div>`のロゴを右に寄せるため
+    // (issue #19)。箱自身のスタイルは使えない: UAスタイルシートが
+    // `input`/`button`に`text-align`を直接指定しており、継承値と区別できない。
+    let text_align = representative
+        .map(|s| s.text_align)
+        .or_else(|| container_style.map(|s| s.text_align))
+        .unwrap_or_default();
     // `word-break`/`overflow-wrap`も`white-space`と同じくIFCの代表値で扱う。
     let word_break = representative.map(|s| s.word_break).unwrap_or_default();
     let overflow_wrap = representative.map(|s| s.overflow_wrap).unwrap_or_default();
@@ -261,10 +273,13 @@ pub(crate) fn layout_inline_content(
     let mut cursor_y = origin_y;
     let mut line_left = origin_x;
     let mut line_available_width = available_width;
-    // 現在組み立て中の行における、単語境界の位置(`current_runs`のインデックス)。
-    // `text-align: justify`がここに追加スペースを配分する(行頭に来た単語は
-    // 境界として記録しない、既存の行の左端そのものだから)。
-    let mut word_boundaries: Vec<usize> = Vec::new();
+    // 現在組み立て中の行における、単語境界の位置(行ボックス左端からのx、
+    // 単語間スペースを入れる前の`current_width`)。`text-align: justify`が
+    // ここに追加スペースを配分する(行頭に来た単語は境界として記録しない、
+    // 既存の行の左端そのものだから)。テキストランと`<img>`等の箱はそれぞれ
+    // `current_runs`/`current_atomics`に分かれて積まれるため、両方に同じ
+    // 規則で適用できるようインデックスではなくxで持つ。
+    let mut word_boundaries: Vec<f32> = Vec::new();
     // 直前のアイテムが強制改行だった場合の、その`<br>`が要求する行高さ。
     // 末尾の`<br>`に対して空行を1つ足すために使う。
     let mut trailing_break_height: Option<f32> = None;
@@ -348,6 +363,10 @@ pub(crate) fn layout_inline_content(
                         available_width,
                     );
                 } else if !line_is_empty {
+                    // 箱の前の空白も`justify`の伸縮対象(テキストランと同じ)。
+                    if space_before {
+                        word_boundaries.push(current_width);
+                    }
                     current_width += gap_width;
                 }
 
@@ -537,7 +556,7 @@ pub(crate) fn layout_inline_content(
                 continue;
             } else if !starting_new_line {
                 if is_first_chunk_of_word {
-                    word_boundaries.push(current_runs.len());
+                    word_boundaries.push(current_width);
                 }
                 current_width += gap_width;
             }
@@ -710,13 +729,17 @@ fn append_run(prev: &mut TextRun, next: TextRun, gap: f32, fonts: &FontCollectio
 
 /// 確定した行に`text-align`を適用する。`is_last_line`は`justify`が最後の行を
 /// 伸縮しない(CSS仕様)ための判定。`word_boundaries`は行内の単語境界の位置
-/// (`line.runs`のインデックス)で、`justify`がそこに追加スペースを配分する。
+/// (行ボックス左端からのx、単語間スペースの手前)で、`justify`がそこに追加
+/// スペースを配分する。
+///
+/// 行の中身はテキストラン(`line.runs`)と`<img>`/`display: inline-block`の箱
+/// (`line.atomics`)に分かれて持たれているので、どの分岐も両方をずらす。
 fn apply_text_align(
     line: &mut LineBox,
     text_align: TextAlign,
     is_last_line: bool,
     line_available_width: f32,
-    word_boundaries: &[usize],
+    word_boundaries: &[f32],
 ) {
     let leftover = line_available_width - line.rect.width;
     match text_align {
@@ -725,12 +748,16 @@ fn apply_text_align(
         TextAlign::Center => shift_all_runs(line, leftover / 2.0),
         TextAlign::Justify if !is_last_line && !word_boundaries.is_empty() && leftover > 0.0 => {
             let extra = leftover / word_boundaries.len() as f32;
-            let mut shift = 0.0;
-            for (i, run) in line.runs.iter_mut().enumerate() {
-                if word_boundaries.contains(&i) {
-                    shift += extra;
-                }
-                run.x_offset += shift;
+            // ランも箱も、自分より左にある境界の数ぶんだけ右へずれる
+            // (境界は各単語の直前の空白の手前にあるので、単語の先頭ランは
+            // 自分の境界を含めて数える)。
+            let shift_at =
+                |x: f32| extra * word_boundaries.iter().filter(|&&b| b <= x).count() as f32;
+            for run in &mut line.runs {
+                run.x_offset += shift_at(run.x_offset);
+            }
+            for atomic in &mut line.atomics {
+                atomic.x_offset += shift_at(atomic.x_offset);
             }
             line.rect.width = line_available_width;
         }
@@ -738,12 +765,19 @@ fn apply_text_align(
     }
 }
 
+/// 行の中身(テキストランとアトミックインラインボックス)をまとめて右へ`shift`px
+/// ずらす。`<img>`や`display: inline-block`の箱は`line.runs`ではなく
+/// `line.atomics`に載っているので、ランだけをずらすと箱が左端に取り残される
+/// (issue #19)。
 fn shift_all_runs(line: &mut LineBox, shift: f32) {
     if shift <= 0.0 {
         return;
     }
     for run in &mut line.runs {
         run.x_offset += shift;
+    }
+    for atomic in &mut line.atomics {
+        atomic.x_offset += shift;
     }
 }
 
@@ -1845,6 +1879,7 @@ mod tests {
             origin_x,
             origin_y,
             float_ctx,
+            None,
             &mut pos,
         )
     }
@@ -2460,6 +2495,60 @@ mod tests {
         assert!(
             last.rect.width < 150.0,
             "the last line should not be stretched by justify"
+        );
+    }
+
+    #[test]
+    fn text_align_justify_does_not_push_text_over_an_inline_block_on_the_same_line() {
+        // 「aa bb [箱] cc」の後に長い単語が来て折り返すと、最初の行は
+        // justifyで引き伸ばされる。単語境界(bb・cc)にだけ余りを配ると
+        // 箱が置き去りになり、右へずれたbbが箱に重なっていた。
+        let (_, spans, styles) = spans_for(
+            r#"aa bb <input style="width: 40px;"> cc dddddddddddddddddddddd"#,
+            "p { text-align: justify; }",
+        );
+        let fonts = dejavu_only();
+        let lines = layout_inline_content(&spans, &styles, &fonts, 180.0, 0.0, 0.0, None);
+        assert!(lines.len() >= 2, "expected the long word to wrap");
+        let line = &lines[0];
+        assert_eq!(line.atomics.len(), 1, "the box should be on the first line");
+        assert_eq!(line.rect.width, 180.0, "the first line should be justified");
+
+        let atomic = &line.atomics[0];
+        let box_left = atomic.x_offset;
+        let box_right = atomic.x_offset + atomic.margin_box_width;
+        for run in &line.runs {
+            let run_right = run.x_offset + run.width;
+            assert!(
+                run_right <= box_left + 0.01 || run.x_offset >= box_right - 0.01,
+                "run {:?} at [{}, {}] overlaps the box at [{}, {}]",
+                run.text,
+                run.x_offset,
+                run_right,
+                box_left,
+                box_right
+            );
+        }
+        // 箱の直前のラン("aa bb"、隣接ランは結合済み)と直後のラン("cc")の
+        // 隙間も、他の単語間と同じく広がっている(箱の前後で一方だけが
+        // 広がるのではない)。
+        let before = line
+            .runs
+            .iter()
+            .filter(|r| r.x_offset < box_left)
+            .max_by(|a, b| a.x_offset.total_cmp(&b.x_offset))
+            .expect("a run before the box");
+        let after = line
+            .runs
+            .iter()
+            .filter(|r| r.x_offset >= box_right - 0.01)
+            .min_by(|a, b| a.x_offset.total_cmp(&b.x_offset))
+            .expect("a run after the box");
+        let gap_before = box_left - (before.x_offset + before.width);
+        let gap_after = after.x_offset - box_right;
+        assert!(
+            (gap_before - gap_after).abs() < 0.01,
+            "expected equal gaps around the box, got before={gap_before} after={gap_after}"
         );
     }
 

--- a/core/src/layout/inline.rs
+++ b/core/src/layout/inline.rs
@@ -193,8 +193,9 @@ enum InlineItem<'a> {
 /// 無関係な呼び出し)なら固定の`available_width`/`origin_x`のまま(既存動作)。
 ///
 /// `container_style`はこのIFCを確立するブロックコンテナの計算スタイル
-/// (無名ボックスや採寸パスなら`None`)。テキストが1つも無く`<img>`や
-/// `display: inline-block`の箱だけの行で`text-align`を決めるために使う。
+/// (無名ボックスや採寸パスなら`None`)。`text-align`はブロックコンテナに
+/// 適用されるプロパティなので、行内のインラインボックスの値ではなく
+/// ここから読む。
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn layout_inline_content(
     spans: &[InlineSpan],
@@ -225,13 +226,15 @@ pub(crate) fn layout_inline_content(
         .position(|span| span.atomic.is_none())
         .and_then(|i| span_styles.get(i));
     let white_space = representative.map(|s| s.white_space).unwrap_or_default();
-    // `text-align`だけは、箱しか無いIFCでもコンテナの値を使う。
-    // `<div style="text-align: right"><img></div>`のロゴを右に寄せるため
-    // (issue #19)。箱自身のスタイルは使えない: UAスタイルシートが
-    // `input`/`button`に`text-align`を直接指定しており、継承値と区別できない。
-    let text_align = representative
+    // `text-align`はブロックコンテナに適用されるプロパティなので、
+    // インラインの代表値ではなくコンテナの計算値を優先する。
+    // `<div style="text-align: right"><img></div>`のロゴが右に寄り(issue #19)、
+    // `<div style="text-align: right"><span style="text-align: left">WORD</span></div>`
+    // で先頭spanの値が勝ってしまう既存の不具合も直る。コンテナが無い
+    // (無名ボックスや採寸パス)場合だけ代表値にフォールバックする。
+    let text_align = container_style
         .map(|s| s.text_align)
-        .or_else(|| container_style.map(|s| s.text_align))
+        .or_else(|| representative.map(|s| s.text_align))
         .unwrap_or_default();
     // `word-break`/`overflow-wrap`も`white-space`と同じくIFCの代表値で扱う。
     let word_break = representative.map(|s| s.word_break).unwrap_or_default();
@@ -555,7 +558,10 @@ pub(crate) fn layout_inline_content(
                 chunk_queue.push_front((chunk, is_first_chunk_of_word, allow_break_fallback));
                 continue;
             } else if !starting_new_line {
-                if is_first_chunk_of_word {
+                // 実際に空白がある位置だけが伸縮対象。`aaa<input>bbb`のように
+                // 空白が無い単語の切れ目(`gap_width == 0`)を境界に数えると、
+                // 箱と単語の間にだけ隙間が空いてしまう。
+                if is_first_chunk_of_word && word_space_before {
                     word_boundaries.push(current_width);
                 }
                 current_width += gap_width;
@@ -2549,6 +2555,47 @@ mod tests {
         assert!(
             (gap_before - gap_after).abs() < 0.01,
             "expected equal gaps around the box, got before={gap_before} after={gap_after}"
+        );
+    }
+
+    #[test]
+    fn text_align_justify_does_not_open_a_gap_around_a_box_written_without_spaces() {
+        // `aaa<input>bbb`には空白が無いので単語境界でもない。伸縮の対象に
+        // 数えてしまうと、箱とその両隣の文字の間だけが開いて見える。
+        let (_, spans, styles) = spans_for(
+            r#"aaa<input style="width: 40px;">bbb ccc dddddddddddddddddddddd"#,
+            "p { text-align: justify; }",
+        );
+        let fonts = dejavu_only();
+        let lines = layout_inline_content(&spans, &styles, &fonts, 180.0, 0.0, 0.0, None);
+        assert!(lines.len() >= 2, "expected the long word to wrap");
+        let line = &lines[0];
+        assert_eq!(line.rect.width, 180.0, "the first line should be justified");
+        let atomic = &line.atomics[0];
+        let box_left = atomic.x_offset;
+        let box_right = atomic.x_offset + atomic.margin_box_width;
+
+        let before = line
+            .runs
+            .iter()
+            .filter(|r| r.x_offset < box_left)
+            .max_by(|a, b| a.x_offset.total_cmp(&b.x_offset))
+            .expect("a run before the box");
+        let after = line
+            .runs
+            .iter()
+            .filter(|r| r.x_offset >= box_right - 0.01)
+            .min_by(|a, b| a.x_offset.total_cmp(&b.x_offset))
+            .expect("a run after the box");
+        assert!(
+            (box_left - (before.x_offset + before.width)).abs() < 0.01,
+            "expected `aaa` to touch the box, got a gap of {}",
+            box_left - (before.x_offset + before.width)
+        );
+        assert!(
+            (after.x_offset - box_right).abs() < 0.01,
+            "expected `bbb` to touch the box, got a gap of {}",
+            after.x_offset - box_right
         );
     }
 

--- a/core/src/layout/table.rs
+++ b/core/src/layout/table.rs
@@ -730,6 +730,8 @@ fn compute_natural_content_width(
                 0.0,
                 0.0,
                 None,
+                // 採寸パスでは幅が無制限で`text-align`の余りが出ないため不要。
+                None,
                 &mut pos,
             );
             lines.iter().map(|l| l.rect.width).fold(0.0f32, f32::max)

--- a/core/tests/inline_block_and_forms.rs
+++ b/core/tests/inline_block_and_forms.rs
@@ -492,3 +492,129 @@ fn an_inline_image_is_embedded_in_the_pdf() {
         "the inline JPEG must be embedded as an image XObject"
     );
 }
+
+// ===== `text-align`とインラインの`<img>` (issue #19) =====
+
+/// `text-align: right`は同じ行のテキストを右端に寄せるが、`<img>`は左端に
+/// 残っていた(issue #19)。置換要素もテキストと同じ行に載っている以上、
+/// 同じように寄せられなければならない。
+#[test]
+fn text_align_right_moves_an_inline_image_to_the_right_edge() {
+    let html_src = format!(r#"<div class="box"><img src="{}"></div>"#, jpeg_data_uri());
+    let css = "body { margin: 0; } \
+               .box { text-align: right; width: 400px; } \
+               img { width: 40px; height: 40px; }";
+    let (_, laid) = layout_with_images(&html_src, css);
+    let lines = all_lines(&laid);
+    assert_eq!(lines.len(), 1);
+    let img = &lines[0].atomics[0];
+    // コンテナ幅400px、画像幅40pxなので左端は360pxに来る(issue #19の期待値)。
+    assert!(
+        (img.content.layout.border_box().x - 360.0).abs() < 0.01,
+        "expected the image at x=360, got x={}",
+        img.content.layout.border_box().x
+    );
+}
+
+#[test]
+fn text_align_center_moves_an_inline_image_to_the_middle() {
+    let html_src = format!(r#"<div class="box"><img src="{}"></div>"#, jpeg_data_uri());
+    let css = "body { margin: 0; } \
+               .box { text-align: center; width: 400px; } \
+               img { width: 40px; height: 40px; }";
+    let (_, laid) = layout_with_images(&html_src, css);
+    let img = &all_lines(&laid)[0].atomics[0];
+    // (400 - 40) / 2 = 180
+    assert!(
+        (img.content.layout.border_box().x - 180.0).abs() < 0.01,
+        "expected the image at x=180, got x={}",
+        img.content.layout.border_box().x
+    );
+}
+
+/// issue #19の「もう1つの観察」: テキストと画像が同じ行にあると、テキストだけが
+/// 右に寄って画像が左に取り残され、両者が離れてしまっていた。
+#[test]
+fn text_align_right_keeps_text_and_an_inline_image_together_at_the_right_edge() {
+    let html_src = format!(
+        r#"<div class="box">WORD<img src="{}"></div>"#,
+        jpeg_data_uri()
+    );
+    let css = "body { margin: 0; } \
+               .box { text-align: right; width: 400px; } \
+               img { width: 40px; height: 40px; }";
+    let (_, laid) = layout_with_images(&html_src, css);
+    let lines = all_lines(&laid);
+    assert_eq!(lines.len(), 1);
+    let line = &lines[0];
+    let word = &line.runs[0];
+    let img = &line.atomics[0];
+    let img_box = img.content.layout.border_box();
+    // 画像の右端がコンテナの右端に接し、テキストはその直前に続く。
+    assert!(
+        (img_box.x + img_box.width - 400.0).abs() < 0.01,
+        "expected the image's right edge at 400, got {}",
+        img_box.x + img_box.width
+    );
+    assert!(
+        (line.rect.x + word.x_offset + word.width - img_box.x).abs() < 0.01,
+        "expected the text to end where the image starts (text end {}, image x {})",
+        line.rect.x + word.x_offset + word.width,
+        img_box.x
+    );
+}
+
+#[test]
+fn text_align_right_moves_an_inline_image_wrapped_in_a_span() {
+    let html_src = format!(
+        r#"<div class="box"><span><img src="{}"></span></div>"#,
+        jpeg_data_uri()
+    );
+    let css = "body { margin: 0; } \
+               .box { text-align: right; width: 400px; } \
+               img { width: 40px; height: 40px; }";
+    let (_, laid) = layout_with_images(&html_src, css);
+    let img = &all_lines(&laid)[0].atomics[0];
+    assert!(
+        (img.content.layout.border_box().x - 360.0).abs() < 0.01,
+        "expected the image at x=360, got x={}",
+        img.content.layout.border_box().x
+    );
+}
+
+/// UAスタイルシートは`input`自身に`text-align: left`を付けるが、それは箱の
+/// 中身の揃え方であって、箱をどこに置くかはコンテナの`text-align`が決める。
+#[test]
+fn text_align_right_moves_a_lone_input_despite_its_own_ua_text_align() {
+    let html_src = r#"<p class="box"><input></p>"#;
+    let css = "body { margin: 0; } .box { text-align: right; width: 400px; } \
+               input { width: 40px; }";
+    let (_, laid) = layout(html_src, css);
+    let input = &all_lines(&laid)[0].atomics[0];
+    let b = input.content.layout.border_box();
+    assert!(
+        (b.x + b.width - 400.0).abs() < 0.01,
+        "expected the input's right edge at 400, got {}",
+        b.x + b.width
+    );
+    assert!(
+        b.x > 300.0,
+        "the input must have moved right, got x={}",
+        b.x
+    );
+}
+
+/// 逆に、UAスタイルシートが`button`に付ける`text-align: center`が箱自身の
+/// 配置に漏れてはいけない(コンテナは`left`のまま)。
+#[test]
+fn a_lone_button_is_not_centered_by_its_own_ua_text_align() {
+    let html_src = r#"<p class="box"><button>ok</button></p>"#;
+    let css = "body { margin: 0; } .box { width: 400px; }";
+    let (_, laid) = layout(html_src, css);
+    let button = &all_lines(&laid)[0].atomics[0];
+    assert!(
+        button.content.layout.border_box().x.abs() < 0.01,
+        "expected the button at x=0, got x={}",
+        button.content.layout.border_box().x
+    );
+}

--- a/core/tests/inline_block_and_forms.rs
+++ b/core/tests/inline_block_and_forms.rs
@@ -618,3 +618,25 @@ fn a_lone_button_is_not_centered_by_its_own_ua_text_align() {
         button.content.layout.border_box().x
     );
 }
+
+/// `text-align`はブロックコンテナに適用されるプロパティで、インラインボックスは
+/// 継承するだけなので、行内の`<span>`に書かれた値がコンテナの値に勝ってはいけない。
+/// IFCの代表値を先頭のテキストspanから読んでいたため、先頭spanの`left`が勝って
+/// いた。
+#[test]
+fn the_containers_text_align_wins_over_a_text_align_on_an_inline_span() {
+    let html_src = r#"<div class="box"><span class="inner">WORD</span></div>"#;
+    let css = "body { margin: 0; } \
+               .box { text-align: right; width: 400px; } \
+               .inner { text-align: left; }";
+    let (_, laid) = layout(html_src, css);
+    let lines = all_lines(&laid);
+    assert_eq!(lines.len(), 1);
+    let line = &lines[0];
+    let word = &line.runs[0];
+    assert!(
+        (line.rect.x + word.x_offset + word.width - 400.0).abs() < 0.01,
+        "expected the word's right edge at 400, got {}",
+        line.rect.x + word.x_offset + word.width
+    );
+}


### PR DESCRIPTION
Fixes #19

## Summary

`text-align` moved the text on a line but left `<img>` (and any `display: inline-block` box or form control) flush against the left edge. A right-aligned invoice header rendered its title on the right and its logo on the left.

## Cause

Two things, both in `core/src/layout/inline.rs`:

1. A `LineBox` keeps text in `runs` and atomic inline boxes (`<img>`, `inline-block`, form controls) in `atomics`. `shift_all_runs` (for `right`/`center`) and the `justify` branch only ever moved `runs`.
2. `text-align` for an inline formatting context was read from the first *text* span. A line holding only boxes (`<div style="text-align: right"><img></div>`) has none, so it fell back to `left`.

`text-align` applies to block containers and is only inherited by inline boxes, so the container's computed value is the right source in every case, not just when the line has no text. `layout_inline_content` now takes the containing block's style (`container_style`, `None` for anonymous boxes and the table measuring pass) and reads `text-align` from it, falling back to the inline representative only when there is no container. That also fixes an existing bug the inline representative caused:

```html
<div style="text-align: right; width: 400px"><span style="text-align: left">WORD</span></div>
```

Before, the leading span's `left` won and the word stayed at x=0; now it is right-aligned.

`justify` records word boundaries as x positions rather than run indices, so runs and boxes shift by the same rule; the space before a box is a justification opportunity too, instead of the neighbouring words being pushed over the box. A boundary is only recorded where a space actually exists, so `aaa<input>bbb` — no spaces, so not a justification opportunity — keeps the box tight against the text on both sides.

## Tests

- `tests/inline_block_and_forms.rs`: right, center, `<img>` inside `<span>`, `WORD<img>` on one line (the "one more observation" in the issue), a lone `<input>` in a right-aligned block (its UA `text-align: left` must not win), a lone `<button>` in a left-aligned block (its UA `text-align: center` must not leak), and a container's `right` beating a `left` on an inline `<span>`.
- `src/layout/inline.rs`: `justify` with an inline box on a stretched line — no overlap, equal gaps on both sides of the box; and `justify` over `aaa<input>bbb`, where no gap may open around the box.

The first E2E test was written before the fix and failed with `expected the image at x=360, got x=0`.

## Verification with the issue's method

Release binaries built from unmodified `main` and from this branch, the issue's HTML rendered with each, rasterised at 96 dpi (`pdftoppm`) and measured with `magick -fuzz 5% -trim -format "%X %w" info:`:

| Case | Before (ink x) | After | Expected in #19 |
|---|---|---|---|
| `text-align: right`, `<img>` | 48 | **408** | 408 |
| `text-align: center`, `<img>` | 48 | **228** | 228 |
| `right`, `<img>` inside `<span>` | 48 | **408** | 408 |
| `right`, text `WORD` | 397 | 397 | 397 |
| `right`, `WORD<img>` | 98–407, split | **357–449**, together at the right edge | — |

`cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings` and `cargo test --workspace` pass (the one exception locally is `a_colour_emoji_font_is_refused_with_a_warning`, which fails the same way on unmodified `main` on my machine and is unrelated).

Rebased onto `main` at 0.3.0; the CHANGELOG entry is under a new Unreleased → Fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
