### PR TITLE
Map logical box properties to physical sides under horizontal-tb LTR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- Map the logical box properties to their physical sides (#21). `margin-inline-start`
+  becomes `margin-left`, `padding-block` becomes `padding-top` and `padding-bottom`, and so
+  on for `margin-*`, `padding-*`, `inset-*` and `border-*` (including the `-width`, `-style`
+  and `-color` longhands), plus the `inset` shorthand. The engine only supports
+  `horizontal-tb` LTR, so the mapping is fixed rather than driven by `writing-mode`.
+  Tailwind v4 emits these for `px-*`, `py-*`, `mx-auto` and `space-y-*`, and until now a
+  document built with it silently lost its horizontal padding and every centred block.
+
 ### Fixed
 
 - Stop rounding flex and grid item sizes to whole pixels (#15). taffy rounds its final

--- a/core/src/style/properties.rs
+++ b/core/src/style/properties.rs
@@ -379,6 +379,93 @@ pub fn parse_declaration<'i>(
         "grid-area" => parse_grid_area_shorthand(input),
         "justify-items" => Ok(vec![D::JustifyItems(parse_align_items(input)?)]),
         "justify-self" => Ok(vec![D::JustifySelf(parse_align_self(input)?)]),
+        // 論理プロパティ。対応する書字方向が`horizontal-tb`+LTRだけなので、
+        // 物理プロパティへの固定の写像として展開する(`inline-start`=左、
+        // `inline-end`=右、`block-start`=上、`block-end`=下)。`writing-mode`/
+        // `direction`は非対応のため、この写像が変わることはない。
+        "margin-inline-start" => Ok(vec![D::MarginLeft(parse_length_percentage_or_auto(input)?)]),
+        "margin-inline-end" => Ok(vec![D::MarginRight(parse_length_percentage_or_auto(input)?)]),
+        "margin-block-start" => Ok(vec![D::MarginTop(parse_length_percentage_or_auto(input)?)]),
+        "margin-block-end" => Ok(vec![D::MarginBottom(parse_length_percentage_or_auto(input)?)]),
+        "margin-inline" => {
+            parse_start_end(input, parse_length_percentage_or_auto, D::MarginLeft, D::MarginRight)
+        },
+        "margin-block" => {
+            parse_start_end(input, parse_length_percentage_or_auto, D::MarginTop, D::MarginBottom)
+        },
+        "padding-inline-start" => Ok(vec![D::PaddingLeft(parse_length_percentage(input)?)]),
+        "padding-inline-end" => Ok(vec![D::PaddingRight(parse_length_percentage(input)?)]),
+        "padding-block-start" => Ok(vec![D::PaddingTop(parse_length_percentage(input)?)]),
+        "padding-block-end" => Ok(vec![D::PaddingBottom(parse_length_percentage(input)?)]),
+        "padding-inline" => {
+            parse_start_end(input, parse_length_percentage, D::PaddingLeft, D::PaddingRight)
+        },
+        "padding-block" => {
+            parse_start_end(input, parse_length_percentage, D::PaddingTop, D::PaddingBottom)
+        },
+        "inset" => parse_inset_shorthand(input),
+        "inset-inline-start" => Ok(vec![D::Left(parse_length_percentage_or_auto(input)?)]),
+        "inset-inline-end" => Ok(vec![D::Right(parse_length_percentage_or_auto(input)?)]),
+        "inset-block-start" => Ok(vec![D::Top(parse_length_percentage_or_auto(input)?)]),
+        "inset-block-end" => Ok(vec![D::Bottom(parse_length_percentage_or_auto(input)?)]),
+        "inset-inline" => {
+            parse_start_end(input, parse_length_percentage_or_auto, D::Left, D::Right)
+        },
+        "inset-block" => {
+            parse_start_end(input, parse_length_percentage_or_auto, D::Top, D::Bottom)
+        },
+        "border-inline-start" => parse_border_left_shorthand(input),
+        "border-inline-end" => parse_border_right_shorthand(input),
+        "border-block-start" => parse_border_top_shorthand(input),
+        "border-block-end" => parse_border_bottom_shorthand(input),
+        "border-inline" => {
+            let mut decls = parse_border_left_shorthand(input)?;
+            decls.extend(mirror_border_side(&decls, Side::Right));
+            Ok(decls)
+        },
+        "border-block" => {
+            let mut decls = parse_border_top_shorthand(input)?;
+            decls.extend(mirror_border_side(&decls, Side::Bottom));
+            Ok(decls)
+        },
+        "border-inline-start-width" => Ok(vec![D::BorderLeftWidth(parse_length(input)?)]),
+        "border-inline-end-width" => Ok(vec![D::BorderRightWidth(parse_length(input)?)]),
+        "border-block-start-width" => Ok(vec![D::BorderTopWidth(parse_length(input)?)]),
+        "border-block-end-width" => Ok(vec![D::BorderBottomWidth(parse_length(input)?)]),
+        "border-inline-width" => {
+            parse_start_end(input, parse_length, D::BorderLeftWidth, D::BorderRightWidth)
+        },
+        "border-block-width" => {
+            parse_start_end(input, parse_length, D::BorderTopWidth, D::BorderBottomWidth)
+        },
+        "border-inline-start-style" => {
+            Ok(vec![D::BorderLeftStyle(parse_border_style_keyword(input)?)])
+        },
+        "border-inline-end-style" => {
+            Ok(vec![D::BorderRightStyle(parse_border_style_keyword(input)?)])
+        },
+        "border-block-start-style" => {
+            Ok(vec![D::BorderTopStyle(parse_border_style_keyword(input)?)])
+        },
+        "border-block-end-style" => {
+            Ok(vec![D::BorderBottomStyle(parse_border_style_keyword(input)?)])
+        },
+        "border-inline-style" => {
+            parse_start_end(input, parse_border_style_keyword, D::BorderLeftStyle, D::BorderRightStyle)
+        },
+        "border-block-style" => {
+            parse_start_end(input, parse_border_style_keyword, D::BorderTopStyle, D::BorderBottomStyle)
+        },
+        "border-inline-start-color" => Ok(vec![D::BorderLeftColor(parse_color(input)?)]),
+        "border-inline-end-color" => Ok(vec![D::BorderRightColor(parse_color(input)?)]),
+        "border-block-start-color" => Ok(vec![D::BorderTopColor(parse_color(input)?)]),
+        "border-block-end-color" => Ok(vec![D::BorderBottomColor(parse_color(input)?)]),
+        "border-inline-color" => {
+            parse_start_end(input, parse_color, D::BorderLeftColor, D::BorderRightColor)
+        },
+        "border-block-color" => {
+            parse_start_end(input, parse_color, D::BorderTopColor, D::BorderBottomColor)
+        },
         _ => Err(input.new_custom_error(())),
     }
 }
@@ -407,6 +494,59 @@ fn parse_padding_shorthand<'i>(
         D::PaddingBottom(bottom),
         D::PaddingLeft(left),
     ])
+}
+
+/// `inset`ショートハンド。`margin`と同じ1〜4値(上/右/下/左)の展開規則。
+fn parse_inset_shorthand<'i>(
+    input: &mut Parser<'i, '_>,
+) -> Result<Vec<PropertyDeclaration>, ParseError<'i, ()>> {
+    use PropertyDeclaration as D;
+    let (top, right, bottom, left) = parse_four_sides(input, parse_length_percentage_or_auto)?;
+    Ok(vec![
+        D::Top(top),
+        D::Right(right),
+        D::Bottom(bottom),
+        D::Left(left),
+    ])
+}
+
+/// `margin-inline`/`padding-block`/`inset-inline`/`border-block-width`等の
+/// 2辺ショートハンド。1値なら両辺、2値なら`start end`の順(CSS Logical
+/// Properties仕様通り)。`start`/`end`に対応する物理ロングハンドの
+/// コンストラクタを受け取って展開する。
+fn parse_start_end<'i, T: Copy>(
+    input: &mut Parser<'i, '_>,
+    mut parse_one: impl FnMut(&mut Parser<'i, '_>) -> Result<T, ParseError<'i, ()>>,
+    start: fn(T) -> PropertyDeclaration,
+    end: fn(T) -> PropertyDeclaration,
+) -> Result<Vec<PropertyDeclaration>, ParseError<'i, ()>> {
+    let first = parse_one(input)?;
+    let second = input.try_parse(&mut parse_one).unwrap_or(first);
+    Ok(vec![start(first), end(second)])
+}
+
+/// `border-inline`/`border-block`用。片側(左/上)の辺別ショートハンド展開を
+/// もう片側(右/下)へ写す。
+#[derive(Clone, Copy)]
+enum Side {
+    Right,
+    Bottom,
+}
+
+fn mirror_border_side(decls: &[PropertyDeclaration], to: Side) -> Vec<PropertyDeclaration> {
+    use PropertyDeclaration as D;
+    decls
+        .iter()
+        .map(|d| match (d, to) {
+            (D::BorderLeftWidth(w), Side::Right) => D::BorderRightWidth(*w),
+            (D::BorderLeftStyle(s), Side::Right) => D::BorderRightStyle(*s),
+            (D::BorderLeftColor(c), Side::Right) => D::BorderRightColor(*c),
+            (D::BorderTopWidth(w), Side::Bottom) => D::BorderBottomWidth(*w),
+            (D::BorderTopStyle(s), Side::Bottom) => D::BorderBottomStyle(*s),
+            (D::BorderTopColor(c), Side::Bottom) => D::BorderBottomColor(*c),
+            (other, _) => other.clone(),
+        })
+        .collect()
 }
 
 /// CSSの1〜4値ショートハンド展開規則(上/右/下/左)。

--- a/core/tests/logical_properties.rs
+++ b/core/tests/logical_properties.rs
@@ -1,0 +1,156 @@
+//! 論理プロパティ(`margin-inline`/`padding-block`/`inset-inline-start`等)の
+//! E2Eテスト。
+//!
+//! 対応する書字方向が`horizontal-tb`+LTRのみなので、論理プロパティは物理
+//! プロパティへの固定の写像として扱う(`inline-start`=左、`inline-end`=右、
+//! `block-start`=上、`block-end`=下)。Tailwind v4は`px-*`/`py-*`/`mx-auto`/
+//! `space-y-*`等をこの形で出力するため、無視されると横パディングと中央寄せが
+//! 丸ごと消える(#21)。
+
+use sghtmltopdf_core::fonts::{Font, FontCollection};
+use sghtmltopdf_core::html::{self, Dom, NodeData, NodeId};
+use sghtmltopdf_core::layout::{
+    build_box_tree, layout_document, LaidOutBox, LaidOutContent, Layout, PageSettings,
+};
+use sghtmltopdf_core::style::{compute_styles, parse_stylesheet, user_agent_stylesheet};
+
+const FONT_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fonts/DejaVuSans.ttf");
+
+fn test_fonts() -> FontCollection {
+    FontCollection::new(vec![
+        Font::load(FONT_PATH).expect("should load bundled test font")
+    ])
+}
+
+fn find_all_tags(dom: &Dom, id: NodeId, tag: &str, out: &mut Vec<NodeId>) {
+    if let NodeData::Element { name, .. } = &dom.node(id).data {
+        if &*name.local == tag {
+            out.push(id);
+        }
+    }
+    for child in dom.children(id) {
+        find_all_tags(dom, child, tag, out);
+    }
+}
+
+fn find_laid_out(b: &LaidOutBox, target: NodeId) -> Option<&LaidOutBox> {
+    if b.node == Some(target) {
+        return Some(b);
+    }
+    if let LaidOutContent::Blocks(children) = &b.content {
+        for child in children {
+            if let Some(found) = find_laid_out(child, target) {
+                return Some(found);
+            }
+        }
+    }
+    None
+}
+
+/// `body { margin: 0 }`の下で`<div class="c">x</div>`をレイアウトし、
+/// そのdivの`Layout`を返す。
+fn layout_div(css: &str) -> Layout {
+    let dom = html::parse(br#"<div class="c">x</div>"#);
+    let ua = user_agent_stylesheet();
+    let author = parse_stylesheet(&format!("body {{ margin: 0; }} {css}"));
+    let styles = compute_styles(&dom, &ua, &author);
+    let fonts = test_fonts();
+    let tree = build_box_tree(&dom, &styles);
+    let laid = layout_document(
+        &tree,
+        &styles,
+        &fonts,
+        PageSettings::default().content_width(),
+    );
+    let mut divs = Vec::new();
+    find_all_tags(&dom, dom.document(), "div", &mut divs);
+    find_laid_out(&laid, divs[0]).unwrap().layout
+}
+
+fn assert_near(actual: f32, expected: f32, what: &str) {
+    assert!(
+        (actual - expected).abs() < 0.5,
+        "{what} should be {expected} but was {actual}"
+    );
+}
+
+#[test]
+fn padding_inline_start_maps_to_padding_left() {
+    let l = layout_div(".c { padding-inline-start: 90px; }");
+    assert_near(l.padding.left, 90.0, "padding-left");
+    assert_near(l.padding.right, 0.0, "padding-right");
+}
+
+#[test]
+fn padding_inline_and_block_shorthands_take_one_or_two_values() {
+    let l = layout_div(".c { padding-inline: 10px 20px; padding-block: 5px; }");
+    assert_near(l.padding.left, 10.0, "padding-left");
+    assert_near(l.padding.right, 20.0, "padding-right");
+    assert_near(l.padding.top, 5.0, "padding-top");
+    assert_near(l.padding.bottom, 5.0, "padding-bottom");
+}
+
+#[test]
+fn margin_inline_start_maps_to_margin_left() {
+    let l = layout_div(".c { margin-inline-start: 90px; }");
+    assert_near(l.margin.left, 90.0, "margin-left");
+    assert_near(l.content.x, 90.0, "content x");
+}
+
+#[test]
+fn margin_block_end_maps_to_margin_bottom() {
+    let l = layout_div(".c { margin-block: 12px 30px; }");
+    assert_near(l.margin.top, 12.0, "margin-top");
+    assert_near(l.margin.bottom, 30.0, "margin-bottom");
+}
+
+#[test]
+fn margin_inline_auto_centres_a_fixed_width_block() {
+    let content_width = PageSettings::default().content_width();
+    let l = layout_div(".c { width: 100px; margin-inline: auto; }");
+    assert_near(l.content.x, (content_width - 100.0) / 2.0, "content x");
+}
+
+#[test]
+fn a_later_physical_declaration_overrides_an_earlier_logical_one() {
+    let l = layout_div(".c { padding-inline-start: 90px; padding-left: 10px; }");
+    assert_near(l.padding.left, 10.0, "padding-left");
+    let l = layout_div(".c { padding-left: 10px; padding-inline-start: 90px; }");
+    assert_near(l.padding.left, 90.0, "padding-left");
+}
+
+#[test]
+fn inset_inline_start_offsets_a_relative_box() {
+    let l =
+        layout_div(".c { position: relative; inset-inline-start: 120px; inset-block-start: 6px; }");
+    assert_near(l.content.x, 120.0, "content x");
+    assert_near(l.content.y, 6.0, "content y");
+}
+
+#[test]
+fn inset_shorthand_expands_like_margin() {
+    let l = layout_div(".c { position: relative; inset: 6px 0 0 120px; }");
+    assert_near(l.content.x, 120.0, "content x");
+    assert_near(l.content.y, 6.0, "content y");
+}
+
+#[test]
+fn border_inline_start_maps_to_border_left() {
+    let l =
+        layout_div(".c { border-inline-start: 4px solid black; border-block: 2px solid black; }");
+    assert_near(l.border.left, 4.0, "border-left");
+    assert_near(l.border.right, 0.0, "border-right");
+    assert_near(l.border.top, 2.0, "border-top");
+    assert_near(l.border.bottom, 2.0, "border-bottom");
+}
+
+#[test]
+fn border_inline_width_shorthand_takes_two_values() {
+    let l = layout_div(
+        ".c { border-style: solid; border-inline-width: 1px 3px; border-block-width: 5px; }",
+    );
+    assert_near(l.border.left, 1.0, "border-left");
+    assert_near(l.border.right, 3.0, "border-right");
+    assert_near(l.border.top, 5.0, "border-top");
+    assert_near(l.border.bottom, 5.0, "border-bottom");
+}

--- a/docs/po/en.po
+++ b/docs/po/en.po
@@ -4180,6 +4180,31 @@ msgstr "The one to four value shorthand"
 msgid "`padding-top` / `-right` / `-bottom` / `-left`"
 msgstr "`padding-top`, `-right`, `-bottom`, `-left`"
 
+#: src/supports/properties.md:41
+msgid "`margin-inline` / `margin-block` / `margin-inline-start`等"
+msgstr "`margin-inline`, `margin-block`, `margin-inline-start` and so on"
+
+#: src/supports/properties.md:41
+msgid ""
+"論理プロパティ。対応する書字方向が`horizontal-tb`+LTRのみなので、`inline-start`=左、"
+"`inline-end`=右、`block-start`=上、`block-end`=下へ固定で写像する(`writing-mode`/"
+"`direction`は非対応)。2辺ショートハンドは1〜2値(`start end`の順)。`auto`も通るので"
+"`margin-inline: auto`で中央寄せできる"
+msgstr ""
+"Logical properties. The only writing mode supported is `horizontal-tb` LTR, so "
+"they map to fixed physical sides: `inline-start` is left, `inline-end` is right, "
+"`block-start` is top and `block-end` is bottom (`writing-mode` and `direction` "
+"are not supported). The two-side shorthands take one or two values, start then "
+"end. `auto` passes through, so `margin-inline: auto` centres a block"
+
+#: src/supports/properties.md:42
+msgid "`padding-inline` / `padding-block` / `padding-inline-start`等"
+msgstr "`padding-inline`, `padding-block`, `padding-inline-start` and so on"
+
+#: src/supports/properties.md:42
+msgid "論理プロパティ。写像規則は`margin-inline`と同じ"
+msgstr "Logical properties, mapped the same way as `margin-inline`"
+
 #: src/supports/properties.md:40
 msgid "パーセンテージはcontaining block幅基準(仕様通り)"
 msgstr ""
@@ -4205,6 +4230,14 @@ msgstr ""
 #: src/supports/properties.md:47
 msgid "`border-top` / `-right` / `-bottom` / `-left`"
 msgstr "`border-top`, `-right`, `-bottom`, `-left`"
+
+#: src/supports/properties.md:50
+msgid ""
+"`border-inline` / `border-block` / `border-inline-start`等(`-width`/`-style`/"
+"`-color`のロングハンドを含む)"
+msgstr ""
+"`border-inline`, `border-block`, `border-inline-start` and so on, including the "
+"`-width`, `-style` and `-color` longhands"
 
 #: src/supports/properties.md:47
 msgid "辺別ショートハンド(値文法は`border`と同じ)"
@@ -4379,6 +4412,18 @@ msgstr ""
 #: src/supports/properties.md:67
 msgid "`inset`(ショートハンド)"
 msgstr "`inset`, the shorthand"
+
+#: src/supports/properties.md:67
+msgid "1〜4値ショートハンド(展開規則は`margin`と同じ)"
+msgstr "The one to four value shorthand, expanded the same way as `margin`"
+
+#: src/supports/properties.md:68
+msgid "`inset-inline` / `inset-block` / `inset-inline-start`等"
+msgstr "`inset-inline`, `inset-block`, `inset-inline-start` and so on"
+
+#: src/supports/properties.md:68
+msgid "論理プロパティ。写像規則は[`margin-inline`](#ボックスモデル)と同じ"
+msgstr "Logical properties, mapped the same way as [`margin-inline`](#box-model)"
 
 #: src/supports/properties.md:67
 msgid "個別の`top`/`right`/`bottom`/`left`を使う"
@@ -5453,19 +5498,20 @@ msgstr ""
 
 #: src/supports/properties.md:245
 msgid ""
-"ショートハンド: `font`/`inset`/`place-content`/`place-items`/`place-self`/"
+"ショートハンド: `font`/`place-content`/`place-items`/`place-self`/"
 "`text-decoration`の色・線種部分"
 msgstr ""
-"Shorthands: `font`, `inset`, `place-content`, `place-items`, `place-self`, "
+"Shorthands: `font`, `place-content`, `place-items`, `place-self`, "
 "and the colour and line-style parts of `text-decoration`"
 
 #: src/supports/properties.md:246
 msgid ""
-"論理プロパティ: `inline-size`/`block-size`/`margin-inline`/`padding-block`/"
-"`border-inline`等すべて"
+"論理プロパティのうち寸法系: `inline-size`/`block-size`/`min-inline-size`/"
+"`max-block-size`等(`margin`/`padding`/`inset`/`border`の論理プロパティは対応済み)"
 msgstr ""
-"Logical properties: `inline-size`, `block-size`, `margin-inline`, `padding-"
-"block`, `border-inline`, and all the rest"
+"The sizing logical properties: `inline-size`, `block-size`, `min-inline-size`, "
+"`max-block-size` and so on (the `margin`, `padding`, `inset` and `border` "
+"logical properties are supported)"
 
 #: src/supports/properties.md:247
 msgid ""
@@ -8999,12 +9045,12 @@ msgstr "Taken feature by feature, the following are not supported."
 
 #: src/appendix/limitations.md:48
 msgid ""
-"縦書き(`writing-mode`/`text-orientation`)と論理プロパティ(`margin-inline`"
-"等)、`direction`による右横書き"
+"縦書き(`writing-mode`/`text-orientation`)と`direction`による右横書き"
+"(`margin-inline`等の論理プロパティは`horizontal-tb`+LTRの固定写像としてのみ対応)"
 msgstr ""
-"Vertical writing with `writing-mode` and `text-orientation`, the logical "
-"properties such as `margin-inline`, and right-to-left text through "
-"`direction`"
+"Vertical writing with `writing-mode` and `text-orientation`, and right-to-left "
+"text through `direction` (logical properties such as `margin-inline` are "
+"supported only as a fixed mapping for `horizontal-tb` and LTR)"
 
 #: src/appendix/limitations.md:49
 msgid "多段組み(`columns`/`column-count`)"

--- a/docs/src/appendix/limitations.md
+++ b/docs/src/appendix/limitations.md
@@ -45,7 +45,7 @@
 
 機能単位では以下が非対応です。
 
-* 縦書き(`writing-mode`/`text-orientation`)と論理プロパティ(`margin-inline`等)、`direction`による右横書き
+* 縦書き(`writing-mode`/`text-orientation`)と`direction`による右横書き(`margin-inline`等の論理プロパティは`horizontal-tb`+LTRの固定写像としてのみ対応)
 * 多段組み(`columns`/`column-count`)
 * グラデーション(`linear-gradient()`等)と複数背景
 * 相対色構文(`rgb(from ...)`)と`color()`(`color-mix()`は対応済み)

--- a/docs/src/supports/properties.md
+++ b/docs/src/supports/properties.md
@@ -38,6 +38,8 @@
 | `margin-top` / `-right` / `-bottom` / `-left` | ✅ | 隣接兄弟間・親子間のマージン相殺に対応 |
 | `padding` | ✅ | 1〜4値ショートハンド |
 | `padding-top` / `-right` / `-bottom` / `-left` | ✅ | パーセンテージはcontaining block幅基準(仕様通り) |
+| `margin-inline` / `margin-block` / `margin-inline-start`等 | ⚠️ | 論理プロパティ。対応する書字方向が`horizontal-tb`+LTRのみなので、`inline-start`=左、`inline-end`=右、`block-start`=上、`block-end`=下へ固定で写像する(`writing-mode`/`direction`は非対応)。2辺ショートハンドは1〜2値(`start end`の順)。`auto`も通るので`margin-inline: auto`で中央寄せできる |
+| `padding-inline` / `padding-block` / `padding-inline-start`等 | ⚠️ | 論理プロパティ。写像規則は`margin-inline`と同じ |
 
 ## 枠線・角丸・アウトライン・影
 
@@ -45,6 +47,7 @@
 | - | - | - |
 | `border` | ✅ | `<width> \|\| <style> \|\| <color>`を任意順・任意省略で受け付け、4辺へ適用 |
 | `border-top` / `-right` / `-bottom` / `-left` | ✅ | 辺別ショートハンド(値文法は`border`と同じ) |
+| `border-inline` / `border-block` / `border-inline-start`等(`-width`/`-style`/`-color`のロングハンドを含む) | ⚠️ | 論理プロパティ。写像規則は[`margin-inline`](#ボックスモデル)と同じ |
 | `border-width` / `border-style` / `border-color` | ✅ | 1〜4値ショートハンド |
 | `border-*-width` | ⚠️ | `<length>`のみ。`thin`/`medium`/`thick`キーワードは非対応 |
 | `border-*-style` | ⚠️ | `none`/`hidden`/`solid`/`dashed`/`dotted`/`double`/`groove`/`ridge`/`inset`/`outset`。`hidden`は`none`と同一視(テーブルの枠線競合解決でも区別しない)。`groove`/`ridge`/`inset`/`outset`は`border-color`から2階調の陰影を算出して描画 |
@@ -64,7 +67,8 @@
 | `clear` | ✅ | `none`/`left`/`right`/`both` |
 | `position` | ⚠️ | `static`/`relative`/`absolute`/`fixed`。`sticky`は非対応。`absolute`/`fixed`には後述の制約あり |
 | `top` / `right` / `bottom` / `left` | ⚠️ | `absolute`/`fixed`では`bottom`単独指定による下端揃えが非対応(高さの循環参照を避けるため`top`基準に解決する)。`relative`ではオフセットとして機能する |
-| `inset`(ショートハンド) | ❌ | 個別の`top`/`right`/`bottom`/`left`を使う |
+| `inset`(ショートハンド) | ✅ | 1〜4値ショートハンド(展開規則は`margin`と同じ) |
+| `inset-inline` / `inset-block` / `inset-inline-start`等 | ⚠️ | 論理プロパティ。写像規則は[`margin-inline`](#ボックスモデル)と同じ |
 | `transform` | ⚠️ | `translate`/`translateX`/`translateY`/`scale`/`scaleX`/`scaleY`/`rotate`/`skew`/`skewX`/`skewY`/`matrix`。3D系(`translate3d`/`rotate3d`/`perspective()`等)は非対応。PDFのCTM変換で実装するため、変換後の内容はページ分割の判定に影響しない |
 | `transform-origin` | ⚠️ | `background-position`と同じ値文法(キーワード/長さ/パーセンテージの1〜2値)。初期値`50% 50%`。3値目(Z軸)は非対応 |
 
@@ -242,8 +246,8 @@ CSSで`width`/`height`の片方だけを指定した場合は内在アスペク�
 実装が無いだけで、意図的に永久除外と決めたものだけではない。
 カテゴリ表の`❌`行も参照。
 
-* ショートハンド: `font`/`inset`/`place-content`/`place-items`/`place-self`/`text-decoration`の色・線種部分
-* 論理プロパティ: `inline-size`/`block-size`/`margin-inline`/`padding-block`/`border-inline`等すべて
+* ショートハンド: `font`/`place-content`/`place-items`/`place-self`/`text-decoration`の色・線種部分
+* 論理プロパティのうち寸法系: `inline-size`/`block-size`/`min-inline-size`/`max-block-size`等(`margin`/`padding`/`inset`/`border`の論理プロパティは対応済み)
 * 書字方向: `direction`/`unicode-bidi`/`writing-mode`/`text-orientation`/`text-combine-upright`
 * テキスト詳細: `text-decoration-color`/`-style`/`-thickness`/`text-underline-offset`/`text-emphasis-skip`/`tab-size`/`ruby-*`/`text-justify`/`line-break`
 * フォント詳細: `font-variant`/`font-stretch`/`font-feature-settings`/`font-variation-settings`/`font-kerning`/`font-display`


### PR DESCRIPTION
Fixes #21

## What

Map the logical box properties to their physical sides. The engine only supports `horizontal-tb` LTR, so the mapping is fixed: `inline-start` → left, `inline-end` → right, `block-start` → top, `block-end` → bottom.

Covered:

- `margin-inline` / `margin-block` and the four `-start`/`-end` longhands
- `padding-inline` / `padding-block` and the four longhands
- `inset-inline` / `inset-block`, the four longhands, and the `inset` shorthand (previously listed as unsupported)
- `border-inline` / `border-block`, the four per-side shorthands, and the `-width` / `-style` / `-color` longhands

Two-side shorthands take one or two values, start then end, per CSS Logical Properties. `auto` passes through, so `margin-inline: auto` centres a block (`mx-auto` in Tailwind v4).

Not covered, deliberately: the sizing logical properties (`inline-size`, `block-size`, `min-inline-size`, …). The docs' unsupported list has been narrowed to say that.

## How

Each logical name is expanded in `parse_declaration` into the physical longhand declarations that the cascade and layout already handle (`core/src/style/properties.rs`). Because the expansion produces ordinary longhands in source order, cascade order between logical and physical declarations works without touching the cascade or layout code. Two small helpers were added: `parse_start_end` for the two-side shorthands and `mirror_border_side` so `border-inline`/`border-block` reuse the existing per-side border parsers.

## Tests

`core/tests/logical_properties.rs` (10 E2E tests through the real parse → cascade → layout pipeline) covering the cases in the issue plus cascade order and the border family. All 10 failed before the change and pass after. `cargo fmt`, `cargo clippy --all-targets -D warnings` and the full suite pass.

The issue's own probes, before → after (`xMin` of `X`, 36.0 = ignored):

| Case | Before | After |
|---|---|---|
| `padding-left: 90px` (control) | 103.5 | 103.5 |
| `padding-inline-start: 90px` | 36.0 | 103.5 |
| `margin-inline-start: 90px` | 36.0 | 103.5 |
| `width: 100px; margin-inline: auto` | 36.0 | 268.5 (centred) |

## Before / after

Same demo page ([demo.html](https://github.com/cmer/sghtmltopdf/blob/666d9a8a4c8c7b1aab54a078a7f9f7a9baba98d2/demo.html)): a physical-property control card on top, then the logical-property cases.

**Before**

![before](https://raw.githubusercontent.com/cmer/sghtmltopdf/666d9a8a4c8c7b1aab54a078a7f9f7a9baba98d2/before.png)

**After**

![after](https://raw.githubusercontent.com/cmer/sghtmltopdf/666d9a8a4c8c7b1aab54a078a7f9f7a9baba98d2/after.png)

The last row (`position: relative; inset-inline-start`) shows the background moving but not the text in the *after* image. That is a pre-existing painter issue that happens with physical `left` too, filed separately as #29; it is not caused by this change.

## Docs

`docs/src/supports/properties.md` (new rows, `inset` ✅, unsupported list narrowed), `docs/src/appendix/limitations.md`, the English `docs/po/en.po` entries and `CHANGELOG.md` under Unreleased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
