### PR TITLE
Emit /CMapName and /CIDSystemInfo in ToUnicode CMap stream dictionary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   measured max-content width so that text which fit was wrapped onto a second line. Which
   way the fraction rounded depended on the exact string, so the same row wrapped for one
   value and not for another (`1 USD = 0.9143 EUR` wrapped, `1 USD 0.9143 EUR` did not).
+- Write the required `/CMapName` and `/CIDSystemInfo` entries into the `/ToUnicode`
+  CMap stream dictionary. ISO 32000-1 table 120 lists both as required for a CMap
+  stream dictionary; the values were already declared inside the embedded CMap
+  program but not lifted into the dictionary. Strict PDF tooling (e.g. HexaPDF,
+  veraPDF) rejects the file without them, which blocks PDF/A-3 validation and
+  therefore Factur-X / ZUGFeRD hybrid e-invoice embedding.
 
 ## 0.2.0 - 2026-08-16
 

--- a/core/src/pdf/document.rs
+++ b/core/src/pdf/document.rs
@@ -4427,6 +4427,18 @@ mod tests {
             "ToUnicode CMap should be embedded"
         );
         assert!(
+            count_occurrences(&bytes, b"/CMapName /Custom") > 0,
+            "CMap stream dictionary must carry /CMapName (ISO 32000-1 table 120)"
+        );
+        assert!(
+            count_occurrences(&bytes, b"/CIDSystemInfo") >= 2,
+            "CMap stream dictionary must carry /CIDSystemInfo (ISO 32000-1 table 120)"
+        );
+        assert!(
+            count_occurrences(&bytes, b"/Ordering (UCS)") > 0,
+            "ToUnicode CMap /CIDSystemInfo should be Adobe-UCS-0"
+        );
+        assert!(
             count_occurrences(&bytes, b"/FlateDecode") > 0,
             "font stream should be compressed"
         );

--- a/core/src/pdf/font.rs
+++ b/core/src/pdf/font.rs
@@ -181,6 +181,12 @@ pub fn embed_font(
     }
     let cmap_bytes = maybe_deflate(&cmap.finish(), compress);
     let mut to_unicode = pdf.cmap(ids.to_unicode, &cmap_bytes);
+    to_unicode.name(Name(b"Custom"));
+    to_unicode.system_info(SystemInfo {
+        registry: Str(b"Adobe"),
+        ordering: Str(b"UCS"),
+        supplement: 0,
+    });
     if compress {
         to_unicode.filter(Filter::FlateDecode);
     }
@@ -313,6 +319,12 @@ pub fn embed_font_streaming_chunks(
     let cmap_bytes = maybe_deflate(&cmap.finish(), compress);
     let mut chunk = Chunk::new();
     let mut to_unicode = chunk.cmap(ids.to_unicode, &cmap_bytes);
+    to_unicode.name(Name(b"Custom"));
+    to_unicode.system_info(SystemInfo {
+        registry: Str(b"Adobe"),
+        ordering: Str(b"UCS"),
+        supplement: 0,
+    });
     if compress {
         to_unicode.filter(Filter::FlateDecode);
     }

--- a/core/src/pdf/font.rs
+++ b/core/src/pdf/font.rs
@@ -36,6 +36,19 @@ use subsetter::GlyphRemapper;
 
 use crate::fonts::Font;
 
+/// `/ToUnicode` CMapの`/CMapName`と埋め込みプログラム側の`CMapName`双方に
+/// 使用する名前。両者が一致しないとPDF仕様上ill-formedになるので、
+/// 単一の定数からすべての利用箇所に配る。
+const TO_UNICODE_CMAP_NAME: Name<'static> = Name(b"Custom");
+
+/// `/ToUnicode` CMapの`/CIDSystemInfo`と埋め込みプログラム側の`CIDSystemInfo`
+/// 双方に使用する値(Adobe-UCS-0固定)。同上の理由で単一の定数から配る。
+const TO_UNICODE_SYSTEM_INFO: SystemInfo<'static> = SystemInfo {
+    registry: Str(b"Adobe"),
+    ordering: Str(b"UCS"),
+    supplement: 0,
+};
+
 /// 埋め込むフォント一式のオブジェクトID。
 ///
 /// `cid_to_gid_map`は[`embed_font_streaming_chunks`]専用(`embed_font`は
@@ -168,25 +181,14 @@ pub fn embed_font(
     cid_font.cid_to_gid_map_predefined(Name(b"Identity"));
     cid_font.finish();
 
-    let mut cmap = UnicodeCmap::<u16>::new(
-        Name(b"Custom"),
-        SystemInfo {
-            registry: Str(b"Adobe"),
-            ordering: Str(b"UCS"),
-            supplement: 0,
-        },
-    );
+    let mut cmap = UnicodeCmap::<u16>::new(TO_UNICODE_CMAP_NAME, TO_UNICODE_SYSTEM_INFO);
     for (&old_gid, (_, text)) in &usage.glyphs {
         cmap.pair_with_multiple(old_to_new[&old_gid], text.chars());
     }
     let cmap_bytes = maybe_deflate(&cmap.finish(), compress);
     let mut to_unicode = pdf.cmap(ids.to_unicode, &cmap_bytes);
-    to_unicode.name(Name(b"Custom"));
-    to_unicode.system_info(SystemInfo {
-        registry: Str(b"Adobe"),
-        ordering: Str(b"UCS"),
-        supplement: 0,
-    });
+    to_unicode.name(TO_UNICODE_CMAP_NAME);
+    to_unicode.system_info(TO_UNICODE_SYSTEM_INFO);
     if compress {
         to_unicode.filter(Filter::FlateDecode);
     }
@@ -305,26 +307,15 @@ pub fn embed_font_streaming_chunks(
     cid_font.finish();
     chunks.push((ids.cid_font, chunk));
 
-    let mut cmap = UnicodeCmap::<u16>::new(
-        Name(b"Custom"),
-        SystemInfo {
-            registry: Str(b"Adobe"),
-            ordering: Str(b"UCS"),
-            supplement: 0,
-        },
-    );
+    let mut cmap = UnicodeCmap::<u16>::new(TO_UNICODE_CMAP_NAME, TO_UNICODE_SYSTEM_INFO);
     for (&old_gid, (_, text)) in &usage.glyphs {
         cmap.pair_with_multiple(old_gid, text.chars());
     }
     let cmap_bytes = maybe_deflate(&cmap.finish(), compress);
     let mut chunk = Chunk::new();
     let mut to_unicode = chunk.cmap(ids.to_unicode, &cmap_bytes);
-    to_unicode.name(Name(b"Custom"));
-    to_unicode.system_info(SystemInfo {
-        registry: Str(b"Adobe"),
-        ordering: Str(b"UCS"),
-        supplement: 0,
-    });
+    to_unicode.name(TO_UNICODE_CMAP_NAME);
+    to_unicode.system_info(TO_UNICODE_SYSTEM_INFO);
     if compress {
         to_unicode.filter(Filter::FlateDecode);
     }

--- a/core/src/pdf/streaming.rs
+++ b/core/src/pdf/streaming.rs
@@ -611,6 +611,18 @@ mod tests {
             count_occurrences(&bytes, b"/Type /CMap") > 0,
             "ToUnicode CMap should be embedded"
         );
+        assert!(
+            count_occurrences(&bytes, b"/CMapName /Custom") > 0,
+            "CMap stream dictionary must carry /CMapName (ISO 32000-1 table 120)"
+        );
+        assert!(
+            count_occurrences(&bytes, b"/CIDSystemInfo") >= 2,
+            "CMap stream dictionary must carry /CIDSystemInfo (ISO 32000-1 table 120)"
+        );
+        assert!(
+            count_occurrences(&bytes, b"/Ordering (UCS)") > 0,
+            "ToUnicode CMap /CIDSystemInfo should be Adobe-UCS-0"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

The `/ToUnicode` CMap stream dictionaries that sghtmltopdf writes carry only `/Type`, `/Filter` and `/Length`. ISO 32000-1:2008 **table 120** (*Additional entries in a CMap stream dictionary*) lists `/CMapName` and `/CIDSystemInfo` as **required**. Both values are already declared inside the embedded CMap PostScript program (`/CMapName /Custom`, `Adobe-UCS-0`), so no new information is being invented — they are just being lifted into the stream dictionary where the spec asks for them.

The fix is two lines at each of the two call sites in `core/src/pdf/font.rs` (`embed_font` and `embed_font_streaming_chunks`), using the `.name()` / `.system_info()` methods that `pdf-writer`'s `Cmap` writer already exposes.

## Why this matters — PDF validation & Factur-X / ZUGFeRD

Ordinary viewers (Preview, Acrobat, browser viewers) display these files fine and extract text correctly, which is why the defect is easy to miss. It surfaces the moment anything **validates** or **rewrites** the file:

- **HexaPDF refuses to write it back out.** `HexaPDF::Document.open(pdf).write(io)` fails with `Required field CMapName is not set`. That blocks *any* PDF post-processing that goes through HexaPDF: adding an attachment, editing metadata, splitting/merging pages, signing, etc.
- **PDF/A-3 (ISO 19005-3) validation fails.** PDF/A inherits ISO 32000-1's structural requirements. A veraPDF run will flag the missing entries.
- **Factur-X and ZUGFeRD are gated on PDF/A-3.** These European hybrid e-invoice formats *require* the invoice to be a valid PDF/A-3 with the CII XML attached. Without valid CMap dictionaries, sghtmltopdf-produced invoices cannot be turned into compliant e-invoices, even though the visible output is perfect. That closes off the whole European e-invoicing use case for this engine.
- **Portability against headless Chrome.** The same invoice rendered through `Page.printToPDF` (Skia/PDF) produces CMap dictionaries HexaPDF accepts. Since sghtmltopdf is most likely to be swapped in for headless Chrome, this is a portability gap.

Full write-up with reproduction + decompressed CMap program: [sghtmltopdf-cmap-dictionary-defect.md](https://github.com/waka/sghtmltopdf/blob/main/CHANGELOG.md) *(analysis lives in the downstream project that first hit this — happy to inline it here if useful).*

## Repro (before this PR)

```ruby
require "sghtmltopdf"
require "hexapdf"
html = %(<html><body style="font-family: sans-serif"><h1>CMap repro</h1><p>Hello 123</p></body></html>)
File.binwrite("repro.pdf", Sghtmltopdf.render(html, page_size: "A4"))
d = HexaPDF::Document.open("repro.pdf")
d.write(StringIO.new(+"".b))
# => HexaPDF::Error: Validation error for (7,0): Required field CMapName is not set
```

## Changes

- `core/src/pdf/font.rs` — write `/CMapName /Custom` and `/CIDSystemInfo << /Registry (Adobe) /Ordering (UCS) /Supplement 0 >>` into the ToUnicode CMap stream dictionary at both call sites.
- `core/src/pdf/document.rs`, `core/src/pdf/streaming.rs` — add assertions on the emitted bytes to guard against regression.
- `CHANGELOG.md` — Unreleased entry.

`/WMode` is left out; it is optional and defaults to horizontal, which matches what the embedded CMap program declares.

## Test plan

- [x] `cargo test --lib` (859 passed)
- [x] New assertions verify `/CMapName /Custom`, `/CIDSystemInfo`, and `/Ordering (UCS)` appear in the generated bytes for both the batch and streaming writers.
- [ ] Confirm downstream: HexaPDF `.write` on an sghtmltopdf-produced PDF now round-trips without the workaround.
- [ ] (nice-to-have) veraPDF PDF/A-3 conformance run.

Marking as **draft** for maintainer review — happy to adjust naming (e.g. `/CMapName` value) or split the test additions if preferred.