### PR TITLE
&:hoverを索引から引けるように・SVGのメモリ改善・trailerに/ID書き出し

### DIFF
--- a/bindings/ruby/ext/sghtmltopdf/src/callback_sink.rs
+++ b/bindings/ruby/ext/sghtmltopdf/src/callback_sink.rs
@@ -8,7 +8,7 @@
 //! 走らせると深さ200弱でスタックを溢れさせる。しかもGVLを解放した状態で
 //! ガードページに触れるため、プロセスが落ちるのではなくスレッドが固まる。
 //!
-//! そこでレンダリングは[`sghtmltopdf_core::cli::STACK_SIZE`]のスタックを
+//! そこでレンダリングは[`sghtmltopdf_core::render_stack::STACK_SIZE`]のスタックを
 //! 明示的に確保した専用スレッドで走らせ、確定したチャンクはチャネル越しに
 //! 元のスレッドへ渡す。Rubyへ触れるのは元のスレッドだけに限る。
 //!
@@ -292,7 +292,8 @@ pub fn pump_to_block<F>(
 where
     F: FnOnce(ChannelSink) -> Result<(), sghtmltopdf_core::cli::CliError> + Send + 'static,
 {
-    use sghtmltopdf_core::cli::{CliError, STACK_SIZE};
+    use sghtmltopdf_core::cli::CliError;
+    use sghtmltopdf_core::render_stack::STACK_SIZE;
 
     // どちらも容量0のrendezvous。レンダリング側は1チャンクごとに
     // ブロックの完了を待つ。

--- a/bindings/ruby/ext/sghtmltopdf/src/lib.rs
+++ b/bindings/ruby/ext/sghtmltopdf/src/lib.rs
@@ -13,7 +13,8 @@ use std::path::PathBuf;
 
 use magnus::rb_sys::AsRawValue;
 use magnus::{block::Proc, function, prelude::*, Error, RString, Ruby};
-use sghtmltopdf_core::cli::{self, convert};
+use sghtmltopdf_core::cli::convert;
+use sghtmltopdf_core::render_stack;
 use sghtmltopdf_core::sink::{FileSink, MemorySink};
 
 use callback_sink::{pump_to_block, BlockSlot, PendingUnwind, ValueSlot};
@@ -36,7 +37,7 @@ fn render_inner(html: Vec<u8>, argv: Vec<String>) -> Result<RString, Error> {
     // レイアウト・描画の再帰に耐えられないため(`callback_sink`のモジュール
     // doc参照)。この経路はRubyへコールバックしないので、そのまま移せる。
     let pdf = gvl::without_gvl(move || {
-        cli::with_render_stack(move || {
+        render_stack::with_render_stack(move || {
             convert::render_to_memory(&args, &fonts, Cursor::new(html), MemorySink::new())
         })
     })
@@ -69,7 +70,7 @@ fn render_to_file_inner(html: Vec<u8>, argv: Vec<String>, path: String) -> Resul
     })?;
 
     gvl::without_gvl(move || {
-        cli::with_render_stack(move || convert::render(&args, &fonts, Cursor::new(html), sink))
+        render_stack::with_render_stack(move || convert::render(&args, &fonts, Cursor::new(html), sink))
     })
     .map_err(|e| errors::to_ruby(&ruby, e))?;
     Ok(())

--- a/bindings/ruby/ext/sghtmltopdf/src/lib.rs
+++ b/bindings/ruby/ext/sghtmltopdf/src/lib.rs
@@ -13,7 +13,7 @@ use std::path::PathBuf;
 
 use magnus::rb_sys::AsRawValue;
 use magnus::{block::Proc, function, prelude::*, Error, RString, Ruby};
-use sghtmltopdf_core::cli::convert;
+use sghtmltopdf_core::cli::{self, convert};
 use sghtmltopdf_core::render_stack;
 use sghtmltopdf_core::sink::{FileSink, MemorySink};
 

--- a/bindings/ruby/spec/spec_helper.rb
+++ b/bindings/ruby/spec/spec_helper.rb
@@ -11,10 +11,12 @@ def elapsed_seconds
   Process.clock_gettime(Process::CLOCK_MONOTONIC) - started
 end
 
-# PDFの`/CreationDate`だけは実行時刻が入る(固定長なので他のオフセットには
-# 影響しない)。バイト列を比べるときはここを固定してから比較する。
+# PDFの`/CreationDate`とtrailerの`/ID`には実行時刻が入る(どちらも固定長
+# なので他のオフセットには影響しない)。バイト列を比べるときはここを固定して
+# から比較する。
 def normalize(pdf)
   pdf.gsub(/D:\d{14}Z/, "D:19700101000000Z")
+     .gsub(/\/ID \[<\h{32}> <\h{32}>\]/, "/ID [<#{'0' * 32}> <#{'0' * 32}>]")
 end
 
 RSpec.configure do |config|

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -45,7 +45,9 @@ cli = ["dep:clap"]
 server = ["cli", "dep:tiny_http"]
 # `<img src="*.svg">`と`background-image: url(*.svg)`をベクタのまま
 # (ラスタライズせずに)PDFへ埋め込む。svg2pdf経由でusvgを引き込むため、
-# 要らない場合は`--no-default-features`で切れるようfeatureにしている。
+# 要らない場合に切れるようfeatureにしている(ライブラリとして使うなら
+# `--no-default-features`、CLIやHTTPサーバは残してSVGだけ外すなら
+# `--no-default-features --features cli,server`)。
 svg = ["dep:svg2pdf"]
 # SVG内の`<text>`をグリフのまま埋め込む。使うフォントは文書と同じもの
 # (`pdf::svg::SvgFontDb`が`FontCollection`から組む)で、SVGのためにシステム
@@ -53,7 +55,7 @@ svg = ["dep:svg2pdf"]
 #
 # 既定で切っているのは依存が重いため。svg2pdfの`text`は`usvg/text`(シェイパの
 # rustybuzz、unicode系テーブル)と`resvg/text`を要求し、後者は`?`が付いていない
-# ので**optionalなresvg本体ごと**有効化してtiny-skiaまで引き込む。合わせて25
+# ので、optionalなresvg本体ごと有効化してtiny-skiaまで引き込む。合わせて25
 # クレート増える。fontdb 0.23(本体が使う0.24とは別インスタンス)も入る。
 # 切っている間、SVG内のテキストは描画されない(パス化もされない)。
 svg-text = ["svg", "svg2pdf?/text"]

--- a/core/src/cli/mod.rs
+++ b/core/src/cli/mod.rs
@@ -17,40 +17,10 @@ use std::process::ExitCode;
 
 use clap::{CommandFactory, FromArgMatches};
 
+use crate::render_stack::with_render_stack;
 use options::Cli;
 #[cfg(feature = "server")]
 use options::Command;
-
-/// レンダリングを走らせるスレッドに確保するスタックサイズ。
-///
-/// スタイル計算・ボックスツリー構築・レイアウト・PDF描画はDOMの深さぶん再帰
-/// するため、必要量は[`crate::html::MAX_ELEMENT_DEPTH`]で決まる。上限256段は
-/// デバッグビルド換算で約2.8MiBなので、5倍以上の余裕を取ってこの値にしている。
-///
-/// 既定任せにしないのは、スレッドの既定スタックが実行環境で大きく変わるため
-/// (Rustの生成スレッドは2MiB、`ulimit -s`次第でmainはもっと小さくなりうる、
-/// Rubyのスレッドは1MiB程度)。ここで固定しておけば、上限の判定が
-/// 「実際に耐えられる深さ」と食い違わない。
-pub const STACK_SIZE: usize = 16 * 1024 * 1024;
-
-/// `f`を[`STACK_SIZE`]のスタックを持つスレッド上で実行し、結果を返す。
-///
-/// `f`がパニックした場合は、そのパニックを呼び出し元スレッドへ伝播させる
-/// (スレッドを挟んだことで挙動が変わらないようにする)。
-pub fn with_render_stack<F, R>(f: F) -> R
-where
-    F: FnOnce() -> R + Send,
-    R: Send,
-{
-    std::thread::scope(|scope| {
-        std::thread::Builder::new()
-            .stack_size(STACK_SIZE)
-            .spawn_scoped(scope, f)
-            .expect("レンダリング用スレッドを作れませんでした")
-            .join()
-            .unwrap_or_else(|panic| std::panic::resume_unwind(panic))
-    })
-}
 
 /// CLIのエラー。バリアントがそのままexit codeに対応する。
 #[derive(Debug)]

--- a/core/src/cli/server.rs
+++ b/core/src/cli/server.rs
@@ -133,10 +133,10 @@ pub fn run(args: &ServerArgs) -> Result<(), CliError> {
         let shared = Arc::clone(&shared);
         let timeout = Duration::from_secs(args.timeout);
         // 既定の2MiBではレイアウト・描画の再帰に足りないため明示的に確保する
-        // (`super::STACK_SIZE`のdoc参照)。
+        // (`crate::render_stack::STACK_SIZE`のdoc参照)。
         let worker = std::thread::Builder::new()
             .name(format!("render-{index}"))
-            .stack_size(super::STACK_SIZE);
+            .stack_size(crate::render_stack::STACK_SIZE);
         let handle = worker.spawn(move || loop {
             let next = {
                 let guard = rx.lock().expect("受信キューのロックに失敗しました");
@@ -321,7 +321,7 @@ fn respond_chunked(
     // ワーカーと同様、再帰に耐えるスタックを明示的に確保する。
     let spawned = std::thread::Builder::new()
         .name("render-stream".to_string())
-        .stack_size(super::STACK_SIZE)
+        .stack_size(crate::render_stack::STACK_SIZE)
         .spawn(move || {
             if let Err(e) = super::convert::render(
                 &args,

--- a/core/src/engine.rs
+++ b/core/src/engine.rs
@@ -2462,11 +2462,11 @@ mod tests {
     ///
     /// テストスレッドの既定スタックは2MiBで、デバッグビルドの1段あたり約11KiB
     /// では上限ぶんの再帰に足りない。CLI・サーバと同じく
-    /// [`crate::cli::with_render_stack`]で確保してから走らせる
+    /// [`crate::render_stack::with_render_stack`]で確保してから走らせる
     /// (上限とスタックが対で意味を持つことの確認でもある)。
     #[test]
     fn html_just_within_the_depth_limit_still_renders() {
-        let pdf = crate::cli::with_render_stack(|| {
+        let pdf = crate::render_stack::with_render_stack(|| {
             let options = EngineOptions {
                 fonts: vec![font_spec()],
                 ..EngineOptions::default()

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -8,5 +8,6 @@ pub mod img;
 pub mod layout;
 mod numbering;
 pub mod pdf;
+pub mod render_stack;
 pub mod sink;
 pub mod style;

--- a/core/src/pdf/document.rs
+++ b/core/src/pdf/document.rs
@@ -412,6 +412,9 @@ pub fn encode_pdf_with_options(
     let info_id = alloc.next();
     write_document_info(pdf.document_info(info_id), &output.metadata);
 
+    let id = file_identifier(&output.metadata, pages.len());
+    pdf.set_file_id((id.clone(), id));
+
     pdf.finish()
 }
 
@@ -518,6 +521,38 @@ pub fn write_document_with_options<S: Sink>(
     );
     sink.write(&bytes)?;
     sink.finish()
+}
+
+/// trailerに書く`/ID`(ファイル識別子)。
+///
+/// PDFの規定では2つの文字列の配列で、1つ目は文書の作成時に決まる恒久的な
+/// 識別子、2つ目は更新のたびに変わる識別子。このクレートは追記更新
+/// (incremental update)を行わないので、両方に同じ値を書く。
+///
+/// 値の中身に規定は無く、文書ごとに一意であればよい。Info辞書に書くのと
+/// 同じメタデータ・作成日時・ページ数を混ぜたハッシュから16バイトを作る。
+/// PDF/Aはファイル識別子を要求するため、無いと適合しない。
+pub(super) fn file_identifier(metadata: &DocumentMetadata, page_count: usize) -> Vec<u8> {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+
+    let datetime = current_datetime();
+    let mut id = Vec::with_capacity(16);
+    // 64bitのハッシュを2本つないで16バイトにする(saltを変えて別の値にする)。
+    for salt in [0u64, 0x9e37_79b9_7f4a_7c15] {
+        let mut hasher = DefaultHasher::new();
+        salt.hash(&mut hasher);
+        producer_string().hash(&mut hasher);
+        metadata.title.hash(&mut hasher);
+        metadata.author.hash(&mut hasher);
+        metadata.subject.hash(&mut hasher);
+        metadata.keywords.hash(&mut hasher);
+        datetime.hash(&mut hasher);
+        page_count.hash(&mut hasher);
+        // `pdf_writer::Finish`もスコープにあるので、どちらの`finish`かを明示する。
+        id.extend_from_slice(&Hasher::finish(&hasher).to_be_bytes());
+    }
+    id
 }
 
 /// PDF Info辞書を書く。`/Producer`と`/CreationDate`は常時、残りは

--- a/core/src/pdf/img.rs
+++ b/core/src/pdf/img.rs
@@ -519,26 +519,15 @@ enum ImageIdsKind {
     /// 文書の`Ref`空間へ振り直し済みのsvg2pdfのチャンク。書き出す内容が
     /// 既に確定しているのでここに持たせている。
     ///
-    /// ストリーミング書き出しでは1度書き終えれば以降は`root`(=`ImageIds::root`)
-    /// しか要らないので、`graphic`を`None`にして`Chunk`を早く解放する
-    /// ([`ImageIds::forget_written_chunk`])。ラスタ画像がデコード結果とは別に
+    /// 書き出しは`src`ごとに1回だけなので、[`embed_image`]/
+    /// [`embed_image_streaming_chunks`]が複製ではなく`take`で取り出し、
+    /// 書き終えた時点で`None`になる。以降は`root`(=[`ImageIds::root`])だけが
+    /// 後続ページの`Do`参照のために残る。ラスタ画像がデコード結果とは別に
     /// XObjectのバイト列を残さないのと揃える意図。
     #[cfg(feature = "svg")]
     Vector {
         graphic: Option<Box<super::svg::RenumberedVectorGraphic>>,
     },
-}
-
-impl ImageIds {
-    /// 書き出し済みのSVGチャンクを解放する(ストリーミング書き出しで、
-    /// 1度`Sink`へ流し終えた後に呼ぶ)。`root`は後続ページの`Do`参照のために
-    /// 残す。ラスタ画像・未書き出しのSVG・SVG feature無効時では何もしない。
-    pub fn forget_written_chunk(&mut self) {
-        #[cfg(feature = "svg")]
-        if let ImageIdsKind::Vector { graphic } = &mut self.kind {
-            *graphic = None;
-        }
-    }
 }
 
 /// `image`に対応する`Ref`を、`image_ids`に無ければ新規に払い出す
@@ -559,7 +548,7 @@ pub fn ids_for_image<'a>(
     image_ids: &'a mut HashMap<usize, ImageIds>,
     failed: &mut HashSet<usize>,
     image: &Rc<PreparedImage>,
-) -> Option<(&'a ImageIds, bool)> {
+) -> Option<(&'a mut ImageIds, bool)> {
     let key = Rc::as_ptr(image) as usize;
     if failed.contains(&key) {
         return None;
@@ -597,7 +586,7 @@ pub fn ids_for_image<'a>(
         };
         image_ids.insert(key, ids);
     }
-    Some((&image_ids[&key], is_new))
+    Some((image_ids.get_mut(&key)?, is_new))
 }
 
 /// バッチモード向け: `image`のXObjectを`pdf`(`DerefMut<Target = Chunk>`)へ
@@ -605,16 +594,17 @@ pub fn ids_for_image<'a>(
 pub fn embed_image(
     pdf: &mut impl std::ops::DerefMut<Target = Chunk>,
     image: &PreparedImage,
-    ids: &ImageIds,
+    ids: &mut ImageIds,
     grayscale: bool,
 ) {
-    match &ids.kind {
-        ImageIdsKind::Raster { alpha: alpha_id } => {
+    match &mut ids.kind {
+        ImageIdsKind::Raster { alpha } => {
+            let alpha_id = *alpha;
             let (color, alpha) = raster_planes(image, grayscale);
             if let (Some(alpha), Some(alpha_id)) = (&alpha, alpha_id) {
                 write_plane(
                     pdf,
-                    *alpha_id,
+                    alpha_id,
                     pixels(image.width),
                     pixels(image.height),
                     alpha,
@@ -627,17 +617,18 @@ pub fn embed_image(
                 pixels(image.width),
                 pixels(image.height),
                 &color,
-                *alpha_id,
+                alpha_id,
             );
         }
         #[cfg(feature = "svg")]
         ImageIdsKind::Vector { graphic } => {
-            let graphic = graphic
-                .as_ref()
-                .expect("SVGチャンクはバッチモードでは書き出す直前に1度だけ参照される");
-            warn_if_grayscale_svg(grayscale);
-            // `Chunk::extend`がオフセットの付け替えまでやってくれる。
-            pdf.extend(&graphic.chunk);
+            // 書き出しは`src`ごとに1回だけなので、取り出して手放す
+            // (ここで`Chunk`を解放できる)。
+            if let Some(graphic) = graphic.take() {
+                warn_if_grayscale_svg(grayscale);
+                // `Chunk::extend`がオフセットの付け替えまでやってくれる。
+                pdf.extend(&graphic.chunk);
+            }
         }
     }
 }
@@ -646,11 +637,12 @@ pub fn embed_image(
 /// (フォントの`embed_font_streaming_chunks`と同じ形)。
 pub fn embed_image_streaming_chunks(
     image: &PreparedImage,
-    ids: &ImageIds,
+    ids: &mut ImageIds,
     grayscale: bool,
 ) -> Vec<EmbedChunk> {
-    match &ids.kind {
-        ImageIdsKind::Raster { alpha: alpha_id } => {
+    match &mut ids.kind {
+        ImageIdsKind::Raster { alpha } => {
+            let alpha_id = *alpha;
             let (color, alpha) = raster_planes(image, grayscale);
             // アルファと本体は別チャンクにして1枚ずつ書き出す
             // (両方を同時にメモリへ載せないため)。
@@ -659,13 +651,13 @@ pub fn embed_image_streaming_chunks(
                 let mut chunk = Chunk::new();
                 write_plane(
                     &mut chunk,
-                    *alpha_id,
+                    alpha_id,
                     pixels(image.width),
                     pixels(image.height),
                     alpha,
                     None,
                 );
-                chunks.push(EmbedChunk::single(*alpha_id, chunk));
+                chunks.push(EmbedChunk::single(alpha_id, chunk));
             }
             let mut chunk = Chunk::new();
             write_plane(
@@ -674,26 +666,24 @@ pub fn embed_image_streaming_chunks(
                 pixels(image.width),
                 pixels(image.height),
                 &color,
-                *alpha_id,
+                alpha_id,
             );
             chunks.push(EmbedChunk::single(ids.root, chunk));
             chunks
         }
         #[cfg(feature = "svg")]
-        ImageIdsKind::Vector { graphic } => {
-            let graphic = graphic
-                .as_ref()
-                .expect("SVGチャンクはストリーミング書き出しでも1度だけ参照される");
-            warn_if_grayscale_svg(grayscale);
-            // チャンクを複製するが、ここへ来るのは`src`ごとに1回だけで、
-            // 中身はベクタの描画命令(数KB程度)なので借用にして
-            // ライフタイムを持ち回るほどの量ではない。書き出し後に
-            // 呼び出し側が[`ImageIds::forget_written_chunk`]で元を解放する。
-            vec![EmbedChunk {
-                chunk: graphic.chunk.clone(),
-                offsets: graphic.offsets.clone(),
-            }]
-        }
+        ImageIdsKind::Vector { graphic } => match graphic.take() {
+            // 書き出しは`src`ごとに1回だけなので、複製せず取り出して渡す
+            // (`Sink`へ流し終えた時点で`Chunk`が解放される)。
+            Some(graphic) => {
+                warn_if_grayscale_svg(grayscale);
+                vec![EmbedChunk {
+                    chunk: graphic.chunk,
+                    offsets: graphic.offsets,
+                }]
+            }
+            None => Vec::new(),
+        },
     }
 }
 

--- a/core/src/pdf/streaming.rs
+++ b/core/src/pdf/streaming.rs
@@ -275,14 +275,6 @@ impl<S: Sink> StreamingPdfWriter<S> {
             for embed in &embedded {
                 self.write_objects(&embed.chunk, &embed.offsets)?;
             }
-            // 書き出し済みのSVGチャンクは以降不要なので解放する。`root`は
-            // `ImageIds`側に残るので、後続ページの`Do`参照は引き続き引ける。
-            // ラスタ画像・未書き出しのSVGはこの呼び出しで何も起きない。
-            if is_new {
-                if let Some(entry) = self.image_ids.get_mut(&(Rc::as_ptr(image) as usize)) {
-                    entry.forget_written_chunk();
-                }
-            }
             page_image_refs.push(root);
         }
 

--- a/core/src/pdf/streaming.rs
+++ b/core/src/pdf/streaming.rs
@@ -27,7 +27,7 @@ use crate::style::{ComputedStyle, PageRule};
 
 use super::document::{
     alpha_gs_resource_name, collect_anchor_positions, collect_image_uses, collect_link_areas,
-    collect_margin_box_usage, collect_opacity_uses, collect_usage, render_box,
+    collect_margin_box_usage, collect_opacity_uses, collect_usage, file_identifier, render_box,
     render_header_footer_rules, render_margin_boxes, render_page_overlay, write_document_info,
     write_link_annotation, write_resources, LinkSettings, PageOverlay, RefAllocator, RenderTarget,
     ALPHA_STEPS,
@@ -552,9 +552,16 @@ impl<S: Sink> StreamingPdfWriter<S> {
         for (_, offset) in &self.offsets {
             buf.extend_from_slice(format!("{offset:010} 00000 n \n").as_bytes());
         }
+        // `/ID`(ファイル識別子)はバッチ書き出しと同じ作り方をする。
+        // ここは`pdf_writer::Pdf`を通さず自前でtrailerを書くので、
+        // 16進文字列として直接書く(バイト列としては同じ値)。
+        let id: String = file_identifier(&self.output.metadata, self.page_ids.len())
+            .iter()
+            .map(|b| format!("{b:02x}"))
+            .collect();
         buf.extend_from_slice(
             format!(
-                "trailer\n<< /Size {size} /Root {} 0 R /Info {} 0 R >>\n",
+                "trailer\n<< /Size {size} /Root {} 0 R /Info {} 0 R /ID [<{id}> <{id}>] >>\n",
                 self.catalog_id.get(),
                 info_id.get()
             )

--- a/core/src/pdf/svg.rs
+++ b/core/src/pdf/svg.rs
@@ -270,6 +270,7 @@ pub fn warn_about_inline_svg(dom: &crate::html::Dom, root: crate::html::NodeId, 
 
 #[cfg(feature = "svg")]
 mod convert {
+    use std::cell::RefCell;
     use std::collections::HashMap;
 
     use pdf_writer::{Chunk, Ref};
@@ -285,7 +286,11 @@ mod convert {
     /// [`renumber_into_document`]で振り直す。
     #[derive(Debug, Clone)]
     pub struct VectorGraphic {
-        chunk: Chunk,
+        /// 振り直しは画像1枚につき1度だけなので、[`renumber_into_document`]が
+        /// ここから取り出して手放す。デコード結果は`src`をキーにした
+        /// キャッシュが文書の最後まで持つため、振り直し前のチャンクを
+        /// 残しておくと同じ内容を二重に抱えることになる。
+        chunk: RefCell<Option<Chunk>>,
         /// `chunk`内のForm XObjectのRef(コンテンツストリームから`Do`する対象)。
         root: Ref,
     }
@@ -350,7 +355,14 @@ mod convert {
         // 丸めるとアスペクト比が変わり、`object-fit: contain`/`cover`や
         // `width`だけ指定したときの高さの導出が目に見えてずれる
         // (40.6x10.4 → 41x10で比が5%変わる)。
-        Ok((size.width(), size.height(), VectorGraphic { chunk, root }))
+        Ok((
+            size.width(),
+            size.height(),
+            VectorGraphic {
+                chunk: RefCell::new(Some(chunk)),
+                root,
+            },
+        ))
     }
 
     /// usvgのパースオプション。
@@ -430,9 +442,17 @@ mod convert {
         graphic: &VectorGraphic,
         alloc: &mut RefAllocator,
     ) -> Result<RenumberedVectorGraphic, SvgError> {
+        // 振り直した時点で元のチャンクは要らないので、取り出して手放す。
+        // 2度目はここで止まる(`ids_for_image`が画像1枚につき1度しか
+        // 呼ばないため、実際には起きない)。
+        let Some(source) = graphic.chunk.borrow_mut().take() else {
+            return Err(SvgError(
+                "振り直し済みのSVGをもう一度埋め込もうとしました".to_string(),
+            ));
+        };
         let mut next = alloc.peek().get();
         let mut mapping: HashMap<Ref, Ref> = HashMap::new();
-        let chunk = graphic.chunk.renumber(|old| {
+        let chunk = source.renumber(|old| {
             *mapping.entry(old).or_insert_with(|| {
                 let assigned = Ref::new(next);
                 next += 1;
@@ -440,6 +460,7 @@ mod convert {
             })
         });
 
+        drop(source);
         let root = *mapping
             .get(&graphic.root)
             .ok_or_else(|| SvgError("Form XObjectのRefが振り直されませんでした".to_string()))?;
@@ -527,9 +548,23 @@ mod convert {
                 convert_svg(CIRCLE.as_bytes(), &SvgFontDb::empty()).expect("should convert");
             assert_eq!((width, height), (20.0, 10.0));
             assert!(
-                graphic.chunk.refs().len() >= 1,
+                graphic.chunk.borrow().as_ref().unwrap().refs().len() >= 1,
                 "the chunk should hold at least the form XObject"
             );
+        }
+
+        #[test]
+        fn renumbering_hands_off_the_original_chunk() {
+            // 振り直し前のチャンクはキャッシュが文書の最後まで持つため、
+            // 振り直した時点で手放す(二重に抱えない)。
+            let (.., graphic) = convert_svg(CIRCLE.as_bytes(), &SvgFontDb::empty()).unwrap();
+            let mut alloc = RefAllocator::default();
+            renumber_into_document(&graphic, &mut alloc).expect("should renumber");
+            assert!(graphic.chunk.borrow().is_none());
+            // 2度目は番号を消費せずエラーになる。
+            let before = alloc.peek();
+            assert!(renumber_into_document(&graphic, &mut alloc).is_err());
+            assert_eq!(alloc.peek(), before);
         }
 
         #[test]

--- a/core/src/render_stack.rs
+++ b/core/src/render_stack.rs
@@ -1,0 +1,35 @@
+//! レンダリング用スタックの確保。
+//!
+//! スタイル計算・ボックスツリー構築・レイアウト・PDF描画はDOMの深さぶん
+//! 再帰するため、呼び出し元のスレッドのスタックが小さいと深い文書で落ちる。
+//! CLI・HTTPサーバ・Rubyバインディング・エンジンのテストが共通で使う。
+
+/// レンダリングを走らせるスレッドに確保するスタックサイズ。
+///
+/// 必要量は[`crate::html::MAX_ELEMENT_DEPTH`]で決まる。上限256段は
+/// デバッグビルド換算で約2.8MiBなので、5倍以上の余裕を取ってこの値にしている。
+///
+/// 既定任せにしないのは、スレッドの既定スタックが実行環境で大きく変わるため
+/// (Rustの生成スレッドは2MiB、`ulimit -s`次第でmainはもっと小さくなりうる、
+/// Rubyのスレッドは1MiB程度)。ここで固定しておけば、上限の判定が
+/// 「実際に耐えられる深さ」と食い違わない。
+pub const STACK_SIZE: usize = 16 * 1024 * 1024;
+
+/// `f`を[`STACK_SIZE`]のスタックを持つスレッド上で実行し、結果を返す。
+///
+/// `f`がパニックした場合は、そのパニックを呼び出し元スレッドへ伝播させる
+/// (スレッドを挟んだことで挙動が変わらないようにする)。
+pub fn with_render_stack<F, R>(f: F) -> R
+where
+    F: FnOnce() -> R + Send,
+    R: Send,
+{
+    std::thread::scope(|scope| {
+        std::thread::Builder::new()
+            .stack_size(STACK_SIZE)
+            .spawn_scoped(scope, f)
+            .expect("レンダリング用スレッドを作れませんでした")
+            .join()
+            .unwrap_or_else(|panic| std::panic::resume_unwind(panic))
+    })
+}

--- a/core/src/style/properties.rs
+++ b/core/src/style/properties.rs
@@ -1356,9 +1356,18 @@ impl CalcValue {
 
 /// `calc(...)`を[`SpecifiedCalc`]へパースする。裸の数値が残る式(長さとして
 /// 無効)はエラーにする。`min`/`max`/`clamp`は非対応。
+/// `calc()`と括弧のネストを受け付ける深さの上限。
+///
+/// このパーサは再帰下降なので、深さがそのままスタックの消費になる
+/// (信頼できないCSSを食わせるとスタックオーバーフローで落とせる)。
+/// `calc(calc(...) * calc(...))`のような実際のCSSは数段で収まるので、
+/// 大きく余裕を取ったこの値を超えたら無効値として宣言ごと捨てる。
+/// DOMの深さに対する[`crate::html::MAX_ELEMENT_DEPTH`]と同じ考え方。
+const MAX_CALC_DEPTH: u32 = 32;
+
 fn parse_calc<'i>(input: &mut Parser<'i, '_>) -> Result<SpecifiedCalc, ParseError<'i, ()>> {
     input.expect_function_matching("calc")?;
-    let value = input.parse_nested_block(parse_calc_sum)?;
+    let value = input.parse_nested_block(|input| parse_calc_sum(input, 1))?;
     if value.number != 0.0 {
         // `calc(2)`のように裸の数値が残る = 長さ文脈では無効。
         return Err(input.new_custom_error(()));
@@ -1371,8 +1380,11 @@ fn parse_calc<'i>(input: &mut Parser<'i, '_>) -> Result<SpecifiedCalc, ParseErro
     })
 }
 
-fn parse_calc_sum<'i>(input: &mut Parser<'i, '_>) -> Result<CalcValue, ParseError<'i, ()>> {
-    let mut acc = parse_calc_product(input)?;
+fn parse_calc_sum<'i>(
+    input: &mut Parser<'i, '_>,
+    depth: u32,
+) -> Result<CalcValue, ParseError<'i, ()>> {
+    let mut acc = parse_calc_product(input, depth)?;
     loop {
         // `+`/`-`の前後には空白が必須(CSS仕様)。cssparserは`+5`のような
         // 符号付き数値を1トークンにするため、Delimでない場合はループを抜ける。
@@ -1386,7 +1398,7 @@ fn parse_calc_sum<'i>(input: &mut Parser<'i, '_>) -> Result<CalcValue, ParseErro
         });
         match sign {
             Ok(sign) => {
-                let rhs = parse_calc_product(input)?;
+                let rhs = parse_calc_product(input, depth)?;
                 acc = acc.add(rhs.scale(sign));
             }
             Err(_) => return Ok(acc),
@@ -1394,8 +1406,11 @@ fn parse_calc_sum<'i>(input: &mut Parser<'i, '_>) -> Result<CalcValue, ParseErro
     }
 }
 
-fn parse_calc_product<'i>(input: &mut Parser<'i, '_>) -> Result<CalcValue, ParseError<'i, ()>> {
-    let mut acc = parse_calc_value(input)?;
+fn parse_calc_product<'i>(
+    input: &mut Parser<'i, '_>,
+    depth: u32,
+) -> Result<CalcValue, ParseError<'i, ()>> {
+    let mut acc = parse_calc_value(input, depth)?;
     loop {
         enum Op {
             Mul,
@@ -1411,7 +1426,7 @@ fn parse_calc_product<'i>(input: &mut Parser<'i, '_>) -> Result<CalcValue, Parse
         });
         match op {
             Ok(Op::Mul) => {
-                let rhs = parse_calc_value(input)?;
+                let rhs = parse_calc_value(input, depth)?;
                 // 次元×次元は不可(少なくとも一方が純粋な数値、CSS仕様)。
                 if acc.is_pure_number() {
                     acc = rhs.scale(acc.number);
@@ -1422,7 +1437,7 @@ fn parse_calc_product<'i>(input: &mut Parser<'i, '_>) -> Result<CalcValue, Parse
                 }
             }
             Ok(Op::Div) => {
-                let rhs = parse_calc_value(input)?;
+                let rhs = parse_calc_value(input, depth)?;
                 if !rhs.is_pure_number() || rhs.number == 0.0 {
                     return Err(input.new_custom_error(()));
                 }
@@ -1433,7 +1448,10 @@ fn parse_calc_product<'i>(input: &mut Parser<'i, '_>) -> Result<CalcValue, Parse
     }
 }
 
-fn parse_calc_value<'i>(input: &mut Parser<'i, '_>) -> Result<CalcValue, ParseError<'i, ()>> {
+fn parse_calc_value<'i>(
+    input: &mut Parser<'i, '_>,
+    depth: u32,
+) -> Result<CalcValue, ParseError<'i, ()>> {
     // 括弧、またはネストした`calc()`(CSS Values 4ではどちらも同じ扱い)。
     // Tailwind v4の`space-y-*`/`divide-*`は
     // `calc(calc(var(--spacing) * N) * calc(1 - var(--tw-space-y-reverse)))`
@@ -1445,7 +1463,10 @@ fn parse_calc_value<'i>(input: &mut Parser<'i, '_>) -> Result<CalcValue, ParseEr
             .try_parse(|input| input.expect_function_matching("calc"))
             .is_ok()
     {
-        return input.parse_nested_block(parse_calc_sum);
+        if depth >= MAX_CALC_DEPTH {
+            return Err(input.new_custom_error(()));
+        }
+        return input.parse_nested_block(|input| parse_calc_sum(input, depth + 1));
     }
     let token = input.next()?.clone();
     match token {

--- a/core/src/style/properties.rs
+++ b/core/src/style/properties.rs
@@ -217,10 +217,10 @@ pub fn parse_declaration<'i>(
         "margin-bottom" => Ok(vec![D::MarginBottom(parse_length_percentage_or_auto(input)?)]),
         "margin-left" => Ok(vec![D::MarginLeft(parse_length_percentage_or_auto(input)?)]),
         "padding" => parse_padding_shorthand(input),
-        "padding-top" => Ok(vec![D::PaddingTop(parse_length_percentage(input)?)]),
-        "padding-right" => Ok(vec![D::PaddingRight(parse_length_percentage(input)?)]),
-        "padding-bottom" => Ok(vec![D::PaddingBottom(parse_length_percentage(input)?)]),
-        "padding-left" => Ok(vec![D::PaddingLeft(parse_length_percentage(input)?)]),
+        "padding-top" => Ok(vec![D::PaddingTop(parse_non_negative_length_percentage(input)?)]),
+        "padding-right" => Ok(vec![D::PaddingRight(parse_non_negative_length_percentage(input)?)]),
+        "padding-bottom" => Ok(vec![D::PaddingBottom(parse_non_negative_length_percentage(input)?)]),
+        "padding-left" => Ok(vec![D::PaddingLeft(parse_non_negative_length_percentage(input)?)]),
         "border" => parse_border_shorthand(input),
         "border-width" => parse_border_width_shorthand(input),
         "border-color" => parse_border_color_shorthand(input),
@@ -393,15 +393,25 @@ pub fn parse_declaration<'i>(
         "margin-block" => {
             parse_start_end(input, parse_length_percentage_or_auto, D::MarginTop, D::MarginBottom)
         },
-        "padding-inline-start" => Ok(vec![D::PaddingLeft(parse_length_percentage(input)?)]),
-        "padding-inline-end" => Ok(vec![D::PaddingRight(parse_length_percentage(input)?)]),
-        "padding-block-start" => Ok(vec![D::PaddingTop(parse_length_percentage(input)?)]),
-        "padding-block-end" => Ok(vec![D::PaddingBottom(parse_length_percentage(input)?)]),
+        "padding-inline-start" => Ok(vec![D::PaddingLeft(parse_non_negative_length_percentage(input)?)]),
+        "padding-inline-end" => Ok(vec![D::PaddingRight(parse_non_negative_length_percentage(input)?)]),
+        "padding-block-start" => Ok(vec![D::PaddingTop(parse_non_negative_length_percentage(input)?)]),
+        "padding-block-end" => Ok(vec![D::PaddingBottom(parse_non_negative_length_percentage(input)?)]),
         "padding-inline" => {
-            parse_start_end(input, parse_length_percentage, D::PaddingLeft, D::PaddingRight)
+            parse_start_end(
+                input,
+                parse_non_negative_length_percentage,
+                D::PaddingLeft,
+                D::PaddingRight,
+            )
         },
         "padding-block" => {
-            parse_start_end(input, parse_length_percentage, D::PaddingTop, D::PaddingBottom)
+            parse_start_end(
+                input,
+                parse_non_negative_length_percentage,
+                D::PaddingTop,
+                D::PaddingBottom,
+            )
         },
         "inset" => parse_inset_shorthand(input),
         "inset-inline-start" => Ok(vec![D::Left(parse_length_percentage_or_auto(input)?)]),
@@ -466,6 +476,20 @@ pub fn parse_declaration<'i>(
         "border-block-color" => {
             parse_start_end(input, parse_color, D::BorderTopColor, D::BorderBottomColor)
         },
+        // 論理版の角丸。1つ目が block 方向、2つ目が inline 方向を指す
+        // (`border-start-end-radius`は上端の行方向終端=右上)。
+        "border-start-start-radius" => {
+            Ok(vec![D::BorderTopLeftRadius(parse_corner_radius(input)?)])
+        },
+        "border-start-end-radius" => {
+            Ok(vec![D::BorderTopRightRadius(parse_corner_radius(input)?)])
+        },
+        "border-end-start-radius" => {
+            Ok(vec![D::BorderBottomLeftRadius(parse_corner_radius(input)?)])
+        },
+        "border-end-end-radius" => {
+            Ok(vec![D::BorderBottomRightRadius(parse_corner_radius(input)?)])
+        },
         _ => Err(input.new_custom_error(())),
     }
 }
@@ -487,7 +511,7 @@ fn parse_padding_shorthand<'i>(
     input: &mut Parser<'i, '_>,
 ) -> Result<Vec<PropertyDeclaration>, ParseError<'i, ()>> {
     use PropertyDeclaration as D;
-    let (top, right, bottom, left) = parse_four_sides(input, parse_length_percentage)?;
+    let (top, right, bottom, left) = parse_four_sides(input, parse_non_negative_length_percentage)?;
     Ok(vec![
         D::PaddingTop(top),
         D::PaddingRight(right),
@@ -525,26 +549,33 @@ fn parse_start_end<'i, T: Copy>(
     Ok(vec![start(first), end(second)])
 }
 
-/// `border-inline`/`border-block`用。片側(左/上)の辺別ショートハンド展開を
-/// もう片側(右/下)へ写す。
+/// [`mirror_border_side`]が写す先の辺。
 #[derive(Clone, Copy)]
 enum Side {
     Right,
     Bottom,
 }
 
+/// `border-inline`/`border-block`用。片側(左/上)の辺別ショートハンド展開を
+/// もう片側(右/下)へ写す。
+///
+/// 写せない宣言は捨てる。辺別ショートハンドが返すのは幅/スタイル/色だけ
+/// なので現状は起きないが、そのまま複製すると左(上)の宣言が2回出て
+/// しまうため、素通しはしない。
 fn mirror_border_side(decls: &[PropertyDeclaration], to: Side) -> Vec<PropertyDeclaration> {
     use PropertyDeclaration as D;
     decls
         .iter()
-        .map(|d| match (d, to) {
-            (D::BorderLeftWidth(w), Side::Right) => D::BorderRightWidth(*w),
-            (D::BorderLeftStyle(s), Side::Right) => D::BorderRightStyle(*s),
-            (D::BorderLeftColor(c), Side::Right) => D::BorderRightColor(*c),
-            (D::BorderTopWidth(w), Side::Bottom) => D::BorderBottomWidth(*w),
-            (D::BorderTopStyle(s), Side::Bottom) => D::BorderBottomStyle(*s),
-            (D::BorderTopColor(c), Side::Bottom) => D::BorderBottomColor(*c),
-            (other, _) => other.clone(),
+        .filter_map(|d| {
+            Some(match (d, to) {
+                (D::BorderLeftWidth(w), Side::Right) => D::BorderRightWidth(*w),
+                (D::BorderLeftStyle(s), Side::Right) => D::BorderRightStyle(*s),
+                (D::BorderLeftColor(c), Side::Right) => D::BorderRightColor(*c),
+                (D::BorderTopWidth(w), Side::Bottom) => D::BorderBottomWidth(*w),
+                (D::BorderTopStyle(s), Side::Bottom) => D::BorderBottomStyle(*s),
+                (D::BorderTopColor(c), Side::Bottom) => D::BorderBottomColor(*c),
+                _ => return None,
+            })
         })
         .collect()
 }
@@ -1239,6 +1270,20 @@ fn parse_text_decoration_line<'i>(
         }
     }
     Ok(line)
+}
+
+/// `padding`のように負の値を受け付けないプロパティ用。負の値はCSSでは
+/// 無効なので、宣言ごと捨てられるようパースエラーにする。
+/// `calc()`は解決するまで符号が決まらないため、ここでは通す
+/// (CSSの規定でも計算結果が負なら0へクランプする扱い)。
+fn parse_non_negative_length_percentage<'i>(
+    input: &mut Parser<'i, '_>,
+) -> Result<SpecifiedLengthPercentage, ParseError<'i, ()>> {
+    let value = parse_length_percentage(input)?;
+    if value.is_negative() {
+        return Err(input.new_custom_error(()));
+    }
+    Ok(value)
 }
 
 fn parse_length_percentage<'i>(

--- a/core/src/style/rule_index.rs
+++ b/core/src/style/rule_index.rs
@@ -26,7 +26,7 @@ enum Bucket {
     Class(String),
     LocalName(String),
     /// タグ名・クラス・idのいずれも要求しない(`*`、属性セレクタ、
-    /// `:is()`など)。どの要素に対しても候補になる。
+    /// 複数セレクタの`:is()`など)。どの要素に対しても候補になる。
     Any,
 }
 
@@ -144,6 +144,20 @@ fn bucket_of(selector: &selectors::parser::Selector<SgSelectorImpl>) -> Bucket {
             {
                 bucket = Bucket::LocalName(name.lower_name.0.to_string());
             }
+            // CSS Nestingの`&`は`:is(親セレクタ)`へ展開されるため、
+            // `&:hover`のように`&`が絞り込みキーを担う形は、中を見ないと
+            // 全て`Bucket::Any`に落ちて全要素と照合される。
+            // 中が単一セレクタのときは、その絞り込みキーをそのまま引き継ぐ。
+            // (`:is(.a, .b)`のような複数セレクタは、どれか1つを選ぶと
+            // 取りこぼすため`Bucket::Any`のままにする。)
+            Component::Is(list) if list.slice().len() == 1 => match bucket_of(&list.slice()[0]) {
+                Bucket::Id(name) => return Bucket::Id(name),
+                Bucket::Class(name) => bucket = Bucket::Class(name),
+                Bucket::LocalName(name) if matches!(bucket, Bucket::Any) => {
+                    bucket = Bucket::LocalName(name)
+                }
+                _ => {}
+            },
             _ => {}
         }
     }
@@ -229,6 +243,27 @@ mod tests {
             candidates_for(css, r#"<p class="lead">t</p>"#, "p"),
             vec![0]
         );
+    }
+
+    #[test]
+    fn a_nested_rule_is_narrowed_by_the_parent_inside_is() {
+        // `&:hover`は`:is(.lead):hover`へ展開される。`:is()`の中を見ないと
+        // 絞り込みキーが取れず、全要素の候補になってしまう。
+        let css = ".lead { &:hover { color: red; } } .other { &:hover { color: blue; } }";
+        assert_eq!(
+            candidates_for(css, r#"<p class="lead">t</p>"#, "p"),
+            vec![0]
+        );
+        // クラスの違う要素の候補には入らない。
+        assert!(candidates_for(css, "<p>t</p>", "p").is_empty());
+    }
+
+    #[test]
+    fn a_multi_selector_is_stays_a_candidate_for_every_element() {
+        // `:is(.a, .b)`はどれか1つのバケットを選ぶと取りこぼすため、
+        // 絞り込まずに常に候補へ入れる。
+        let out = candidates_for(":is(.a, .b):hover { color: red; }", "<p>t</p>", "p");
+        assert_eq!(out, vec![0]);
     }
 
     #[test]

--- a/core/src/style/stylesheet.rs
+++ b/core/src/style/stylesheet.rs
@@ -91,7 +91,13 @@ fn flatten_top_level_rule(
     page_rules: &mut Vec<PageRule>,
 ) {
     match rule {
-        TopLevelRule::Style(r) => rules.extend(r),
+        // 宣言が空のルールはカスケードにも擬似要素の解決にも寄与しないので、
+        // 索引と照合のコストだけが残る。ここで捨てる。
+        // ネストしたルールの親(`.a { &:hover { } }`の`.a`)は宣言を持たない
+        // ことが多く、残すとネスト1つにつきルールが2つに増える。
+        TopLevelRule::Style(r) => {
+            rules.extend(r.into_iter().filter(|rule| !rule.declarations.is_empty()))
+        }
         TopLevelRule::FontFace(r) => font_faces.push(r),
         TopLevelRule::Page(r) => page_rules.push(r),
         TopLevelRule::Media(inner) => {
@@ -149,8 +155,8 @@ impl<'i> QualifiedRuleParser<'i> for TopLevelRuleParser {
 /// ネストしたルールの後ろに並ぶ。先頭へ巻き上げると、`&`で親自身を上書き
 /// するルールとの勝敗がソース順と食い違うため、書かれた順を保つ。
 ///
-/// 先頭のルール(親そのもの)は宣言が空でも残す(従来どおり)。末尾の
-/// 宣言ルールは、対応する宣言があるときだけ作る。
+/// 先頭のルール(親そのもの)と末尾の宣言ルールは、宣言が無ければ空のまま
+/// 返る。宣言が空のルールは[`flatten_top_level_rule`]が捨てる。
 fn parse_style_rule_body(
     selectors: SelectorList<SgSelectorImpl>,
     input: &mut Parser<'_, '_>,
@@ -160,16 +166,23 @@ fn parse_style_rule_body(
         declarations: Vec::new(),
     }];
     // 宣言を受け入れる先。ネストしたルールを挟むたびに`None`へ戻し、
-    // 次の宣言が来た時点で親と同じセレクタのルールを新しく作る。
+    // 次の宣言が来た時点で`&`と同じセレクタのルールを新しく作る。
     let mut open: Option<usize> = Some(0);
+    // ネストしたルールより後ろに書いた宣言(仕様のCSSNestedDeclarations)は
+    // `&`と同じセレクタを持つ。親がセレクタリストのときは`:is(親)`へ
+    // まとまって詳細度が親そのものとは変わるので、解決結果を別に用意する。
+    let mut nested_selectors: Option<SelectorList<SgSelectorImpl>> = None;
 
     let mut body_parser = StyleRuleBodyParser { parent: &selectors };
     for item in RuleBodyParser::new(input, &mut body_parser).filter_map(Result::ok) {
         match item {
             StyleRuleBodyItem::Declarations(declarations) => {
                 let index = *open.get_or_insert_with(|| {
+                    let selectors = nested_selectors
+                        .get_or_insert_with(|| parent_selector_reference(&selectors))
+                        .clone();
                     rules.push(StyleRule {
-                        selectors: selectors.clone(),
+                        selectors,
                         declarations: Vec::new(),
                     });
                     rules.len() - 1
@@ -183,6 +196,24 @@ fn parse_style_rule_body(
         }
     }
     rules
+}
+
+/// `&`(親セレクタ)を`parent`で解決したセレクタリスト。
+///
+/// 親が1つだけなら`:is()`で包んでも詳細度は変わらないため、そのまま返す
+/// (出力されるセレクタを不必要に変えない)。
+fn parent_selector_reference(
+    parent: &SelectorList<SgSelectorImpl>,
+) -> SelectorList<SgSelectorImpl> {
+    if parent.slice().len() == 1 {
+        return parent.clone();
+    }
+    let mut input = ParserInput::new("&");
+    let mut parser = Parser::new(&mut input);
+    match SelectorList::parse(&SelectorParser, &mut parser, ParseRelative::ForNesting) {
+        Ok(list) => list.replace_parent_selector(parent),
+        Err(_) => parent.clone(),
+    }
 }
 
 /// [`StyleRuleBodyParser`]が返す、ルール本体の1項目。
@@ -767,48 +798,45 @@ mod tests {
     #[test]
     fn nested_rule_with_explicit_parent_selector_is_flattened() {
         let sheet = parse_stylesheet(".wrap { & .probe { color: rgb(1, 2, 3) } }");
-        assert_eq!(selector_texts(&sheet), [".wrap", ":is(.wrap) .probe"]);
-        assert!(sheet.rules[0].declarations.is_empty());
-        assert_eq!(sheet.rules[1].declarations.len(), 1);
+        // 宣言を持たない親(`.wrap`)はルールとして残らない。
+        assert_eq!(selector_texts(&sheet), [":is(.wrap) .probe"]);
+        assert_eq!(sheet.rules[0].declarations.len(), 1);
     }
 
     #[test]
     fn nested_rule_without_parent_selector_is_a_descendant_of_the_parent() {
         let sheet = parse_stylesheet(".wrap { .probe { color: rgb(1, 2, 3) } }");
-        assert_eq!(selector_texts(&sheet), [".wrap", ":is(.wrap) .probe"]);
+        assert_eq!(selector_texts(&sheet), [":is(.wrap) .probe"]);
     }
 
     #[test]
     fn nested_compound_parent_selector_is_flattened() {
         let sheet = parse_stylesheet(".wrap { &.probe { color: rgb(1, 2, 3) } }");
-        assert_eq!(selector_texts(&sheet), [".wrap", ":is(.wrap).probe"]);
+        assert_eq!(selector_texts(&sheet), [":is(.wrap).probe"]);
     }
 
     #[test]
     fn nested_rule_with_leading_combinator_is_flattened() {
         let sheet = parse_stylesheet(".list { > li { color: rgb(1, 2, 3) } }");
-        assert_eq!(selector_texts(&sheet), [".list", ":is(.list) > li"]);
+        assert_eq!(selector_texts(&sheet), [":is(.list) > li"]);
     }
 
     #[test]
     fn nested_type_selector_is_parsed_as_a_rule() {
         let sheet = parse_stylesheet(".wrap { p { color: rgb(1, 2, 3) } }");
-        assert_eq!(selector_texts(&sheet), [".wrap", ":is(.wrap) p"]);
+        assert_eq!(selector_texts(&sheet), [":is(.wrap) p"]);
     }
 
     #[test]
     fn nested_selector_list_parent_is_kept_as_a_list() {
         let sheet = parse_stylesheet(".a, .b { .c { color: rgb(1, 2, 3) } }");
-        assert_eq!(selector_texts(&sheet), [".a, .b", ":is(.a, .b) .c"]);
+        assert_eq!(selector_texts(&sheet), [":is(.a, .b) .c"]);
     }
 
     #[test]
     fn deeper_nesting_is_flattened_in_source_order() {
         let sheet = parse_stylesheet(".a { .b { .c { color: rgb(1, 2, 3) } } }");
-        assert_eq!(
-            selector_texts(&sheet),
-            [".a", ":is(.a) .b", ":is(:is(.a) .b) .c"]
-        );
+        assert_eq!(selector_texts(&sheet), [":is(:is(.a) .b) .c"]);
     }
 
     #[test]
@@ -835,13 +863,38 @@ mod tests {
     #[test]
     fn a_parent_with_only_nested_rules_has_no_trailing_rule() {
         let sheet = parse_stylesheet(".wrap { .probe { color: rgb(1, 2, 3) } }");
-        assert_eq!(sheet.rules.len(), 2, "空の末尾ルールを作らない");
+        assert_eq!(sheet.rules.len(), 1, "空の末尾ルールを作らない");
+    }
+
+    #[test]
+    fn declarations_after_a_nested_rule_use_the_resolved_parent_selector() {
+        // ネストしたルールより後ろの宣言は`&`と同じセレクタを持つ。
+        // 親がセレクタリストなら`:is(.p, #q)`にまとまり、詳細度は
+        // 最も強いセレクタ(ここでは`#q`の(1,0,0))で揃う。
+        let sheet = parse_stylesheet(".p, #q { .c { color: rgb(1, 2, 3) } margin-left: 5px }");
+        assert_eq!(selector_texts(&sheet), [":is(.p, #q) .c", ":is(.p, #q)"]);
+        let trailing = &sheet.rules[1].selectors;
+        assert_eq!(trailing.slice().len(), 1);
+        assert_eq!(
+            trailing.slice()[0].specificity(),
+            parse_stylesheet("#q { color: rgb(1, 2, 3) }").rules[0]
+                .selectors
+                .slice()[0]
+                .specificity()
+        );
+    }
+
+    #[test]
+    fn rules_without_declarations_are_dropped() {
+        // 宣言の無いルールはカスケードに寄与しないので索引にも入れない。
+        let sheet = parse_stylesheet(".a { } .b { color: rgb(1, 2, 3) } .c { }");
+        assert_eq!(selector_texts(&sheet), [".b"]);
     }
 
     #[test]
     fn nested_rules_inside_media_are_flattened() {
         let sheet = parse_stylesheet("@media print { .wrap { .probe { color: rgb(1, 2, 3) } } }");
-        assert_eq!(selector_texts(&sheet), [".wrap", ":is(.wrap) .probe"]);
+        assert_eq!(selector_texts(&sheet), [":is(.wrap) .probe"]);
     }
 
     #[test]

--- a/core/src/style/stylesheet.rs
+++ b/core/src/style/stylesheet.rs
@@ -785,6 +785,36 @@ mod tests {
         assert!(parse_inline_style("").is_empty());
     }
 
+    #[test]
+    fn negative_padding_is_rejected() {
+        // CSSでは`padding`に負の値を書けない。宣言ごと捨てる。
+        for css in [
+            "p { padding-left: -5px }",
+            "p { padding: -5px }",
+            "p { padding: 5px -5px }",
+            "p { padding-inline-start: -5px }",
+            "p { padding-block: -1em }",
+            "p { padding-top: -10% }",
+        ] {
+            assert!(
+                parse_stylesheet(css).rules.is_empty(),
+                "negative padding should be dropped: {css}"
+            );
+        }
+        // 0と正の値、`calc()`(符号は解決するまで決まらない)は通す。
+        for css in [
+            "p { padding-left: 0 }",
+            "p { padding: 5px }",
+            "p { padding-left: calc(10px - 20px) }",
+        ] {
+            assert_eq!(
+                parse_stylesheet(css).rules.len(),
+                1,
+                "should be accepted: {css}"
+            );
+        }
+    }
+
     // ===== CSS Nesting (#25) =====
 
     fn selector_texts(sheet: &Stylesheet) -> Vec<String> {

--- a/core/src/style/stylesheet.rs
+++ b/core/src/style/stylesheet.rs
@@ -797,7 +797,10 @@ mod tests {
             )
         };
         assert_eq!(parse_stylesheet(&nested(32)).rules.len(), 1, "32段は通す");
-        assert!(parse_stylesheet(&nested(33)).rules.is_empty(), "33段は捨てる");
+        assert!(
+            parse_stylesheet(&nested(33)).rules.is_empty(),
+            "33段は捨てる"
+        );
 
         // 括弧も`calc()`と同じ深さに数える。
         let parens = format!(

--- a/core/src/style/stylesheet.rs
+++ b/core/src/style/stylesheet.rs
@@ -786,6 +786,29 @@ mod tests {
     }
 
     #[test]
+    fn deeply_nested_calc_is_rejected_instead_of_overflowing_the_stack() {
+        // 再帰下降パーサなので、深さがそのままスタックの消費になる。
+        // 上限(32段)までは通し、それより深い値は宣言ごと捨てる。
+        let nested = |n: usize| {
+            format!(
+                "p {{ padding-left: {}1px{} }}",
+                "calc(".repeat(n),
+                ")".repeat(n)
+            )
+        };
+        assert_eq!(parse_stylesheet(&nested(32)).rules.len(), 1, "32段は通す");
+        assert!(parse_stylesheet(&nested(33)).rules.is_empty(), "33段は捨てる");
+
+        // 括弧も`calc()`と同じ深さに数える。
+        let parens = format!(
+            "p {{ padding-left: calc({}1px{}) }}",
+            "(".repeat(40),
+            ")".repeat(40)
+        );
+        assert!(parse_stylesheet(&parens).rules.is_empty());
+    }
+
+    #[test]
     fn negative_padding_is_rejected() {
         // CSSでは`padding`に負の値を書けない。宣言ごと捨てる。
         for css in [

--- a/core/src/style/values.rs
+++ b/core/src/style/values.rs
@@ -625,6 +625,13 @@ pub enum SpecifiedLength {
 }
 
 impl SpecifiedLength {
+    /// 負の長さか。
+    pub fn is_negative(self) -> bool {
+        match self {
+            Self::Px(v) | Self::Em(v) | Self::Rem(v) => v < 0.0,
+        }
+    }
+
     /// `font_size`(em基準、px)と`root_font_size`(rem基準、px)を使って
     /// 計算値の[`Length`]へ解決する。
     pub fn resolve(self, font_size: f32, root_font_size: f32) -> Length {
@@ -690,6 +697,15 @@ pub enum SpecifiedLengthPercentage {
 }
 
 impl SpecifiedLengthPercentage {
+    /// 書かれた値が負か。`calc()`は解決するまで符号が決まらないので`false`。
+    pub fn is_negative(self) -> bool {
+        match self {
+            Self::Length(length) => length.is_negative(),
+            Self::Percentage(p) => p < 0.0,
+            Self::Calc(_) => false,
+        }
+    }
+
     pub fn resolve(self, font_size: f32, root_font_size: f32) -> LengthPercentage {
         match self {
             Self::Length(length) => {

--- a/core/tests/cli.rs
+++ b/core/tests/cli.rs
@@ -612,6 +612,30 @@ fn the_info_dictionary_always_carries_a_producer() {
 }
 
 #[test]
+fn the_trailer_carries_a_file_identifier() {
+    // PDF/Aはファイル識別子(`/ID`)を要求する。バッチ・ストリーミングの
+    // どちらの書き出しでも、同じ作り方で16バイトを2つ書く。
+    for (args, name) in [
+        (&[][..], "file-id-batch"),
+        (&["--streaming"][..], "file-id-streaming"),
+    ] {
+        let bytes = run_cli_with(PLAIN_HTML, args, name);
+        let text = String::from_utf8_lossy(&bytes);
+        let trailer = text
+            .rfind("trailer")
+            .map(|i| &text[i..])
+            .expect("the PDF should have a trailer");
+        let id = trailer
+            .split_once("/ID [<")
+            .and_then(|(_, rest)| rest.split_once('>'))
+            .map(|(id, _)| id)
+            .unwrap_or_else(|| panic!("{name}: the trailer should carry /ID: {trailer}"));
+        assert_eq!(id.len(), 32, "{name}: /ID should be 16 bytes in hex");
+        assert!(id.chars().all(|c| c.is_ascii_hexdigit()), "{name}: {id}");
+    }
+}
+
+#[test]
 fn the_title_option_wins_over_the_html_title() {
     let html = "<html><head><title>from html</title></head><body><p>x</p></body></html>";
 

--- a/core/tests/custom_properties.rs
+++ b/core/tests/custom_properties.rs
@@ -223,7 +223,9 @@ fn extract_author_stylesheet_resolves_var_via_the_style_tag_helper() {
         ":root { --w: 33px; } .box { width: var(--w); }",
     );
     let sheet = extract_stylesheet(&dom);
-    assert_eq!(sheet.rules.len(), 2);
+    // カスタムプロパティの宣言はテキスト置換で解決済みなので、`:root`側は
+    // 宣言の無いルールとして捨てられ、`.box`の1つだけが残る。
+    assert_eq!(sheet.rules.len(), 1);
 }
 
 #[test]

--- a/core/tests/logical_properties.rs
+++ b/core/tests/logical_properties.rs
@@ -67,6 +67,24 @@ fn layout_div(css: &str) -> Layout {
     find_laid_out(&laid, divs[0]).unwrap().layout
 }
 
+/// `body { margin: 0 }`の下で`<div class="c">x</div>`の計算済みスタイルから
+/// 4隅の角丸半径(水平方向)を左上/右上/左下/右下の順で返す。
+fn corner_radii(css: &str) -> [f32; 4] {
+    let dom = html::parse(br#"<div class="c">x</div>"#);
+    let ua = user_agent_stylesheet();
+    let author = parse_stylesheet(&format!("body {{ margin: 0; }} {css}"));
+    let styles = compute_styles(&dom, &ua, &author);
+    let mut divs = Vec::new();
+    find_all_tags(&dom, dom.document(), "div", &mut divs);
+    let style = &styles[&divs[0]];
+    [
+        style.border_top_left_radius.horizontal.0,
+        style.border_top_right_radius.horizontal.0,
+        style.border_bottom_left_radius.horizontal.0,
+        style.border_bottom_right_radius.horizontal.0,
+    ]
+}
+
 fn assert_near(actual: f32, expected: f32, what: &str) {
     assert!(
         (actual - expected).abs() < 0.5,
@@ -153,4 +171,25 @@ fn border_inline_width_shorthand_takes_two_values() {
     assert_near(l.border.right, 3.0, "border-right");
     assert_near(l.border.top, 5.0, "border-top");
     assert_near(l.border.bottom, 5.0, "border-bottom");
+}
+
+#[test]
+fn logical_corner_radii_map_to_the_physical_corners() {
+    // 1つ目がblock方向、2つ目がinline方向。
+    assert_eq!(
+        corner_radii(".c { border-start-start-radius: 1px }"),
+        [1.0, 0.0, 0.0, 0.0]
+    );
+    assert_eq!(
+        corner_radii(".c { border-start-end-radius: 2px }"),
+        [0.0, 2.0, 0.0, 0.0]
+    );
+    assert_eq!(
+        corner_radii(".c { border-end-start-radius: 3px }"),
+        [0.0, 0.0, 3.0, 0.0]
+    );
+    assert_eq!(
+        corner_radii(".c { border-end-end-radius: 4px }"),
+        [0.0, 0.0, 0.0, 4.0]
+    );
 }

--- a/docs/po/en.po
+++ b/docs/po/en.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: sghtmltopdf\n"
-"POT-Creation-Date: 2026-08-16T19:53:45+09:00\n"
+"POT-Creation-Date: 2026-08-30T16:06:58+09:00\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -901,7 +901,7 @@ msgstr ""
 msgid "CSSの指定"
 msgstr "What the CSS says"
 
-#: src/getting-started/docker.md:71
+#: src/getting-started/docker.md:71 src/supports/images.md:75
 msgid "使われるフォント"
 msgstr "Font that is used"
 
@@ -3061,16 +3061,16 @@ msgid ""
 msgstr "Precompiled gems are distributed, so no Rust toolchain is needed."
 
 #: src/usage/ruby_rails.md:21 src/supports/properties.md:20
-#: src/supports/properties.md:31 src/supports/properties.md:44
-#: src/supports/properties.md:61 src/supports/properties.md:81
-#: src/supports/properties.md:108 src/supports/properties.md:123
-#: src/supports/properties.md:141 src/supports/properties.md:150
-#: src/supports/properties.md:161 src/supports/properties.md:176
-#: src/supports/properties.md:211 src/supports/properties.md:230
-#: src/supports/selectors.md:15 src/supports/selectors.md:27
-#: src/supports/selectors.md:46 src/supports/selectors.md:57
-#: src/supports/selectors.md:76 src/supports/selectors.md:89
-#: src/supports/selectors.md:120
+#: src/supports/properties.md:31 src/supports/properties.md:46
+#: src/supports/properties.md:65 src/supports/properties.md:86
+#: src/supports/properties.md:113 src/supports/properties.md:128
+#: src/supports/properties.md:146 src/supports/properties.md:155
+#: src/supports/properties.md:166 src/supports/properties.md:181
+#: src/supports/properties.md:216 src/supports/properties.md:235
+#: src/supports/selectors.md:15 src/supports/selectors.md:28
+#: src/supports/selectors.md:47 src/supports/selectors.md:58
+#: src/supports/selectors.md:77 src/supports/selectors.md:90
+#: src/supports/selectors.md:121
 msgid "対応"
 msgstr "Supported"
 
@@ -3600,7 +3600,7 @@ msgstr ""
 "` yet, there are helpers that inline the CSS into a `<style>` element."
 
 #: src/usage/ruby_rails.md:177 src/usage/ruby_rails.md:178
-#: src/supports/images.md:14
+#: src/supports/images.md:148
 msgid "\"logo.png\""
 msgstr "\"logo.png\""
 
@@ -3904,24 +3904,24 @@ msgid "表示・可視性"
 msgstr "Display and visibility"
 
 #: src/supports/properties.md:20 src/supports/properties.md:31
-#: src/supports/properties.md:44 src/supports/properties.md:61
-#: src/supports/properties.md:81 src/supports/properties.md:108
-#: src/supports/properties.md:123 src/supports/properties.md:141
-#: src/supports/properties.md:150 src/supports/properties.md:161
-#: src/supports/properties.md:176 src/supports/properties.md:211
-#: src/supports/properties.md:230 src/supports/pagination.md:13
+#: src/supports/properties.md:46 src/supports/properties.md:65
+#: src/supports/properties.md:86 src/supports/properties.md:113
+#: src/supports/properties.md:128 src/supports/properties.md:146
+#: src/supports/properties.md:155 src/supports/properties.md:166
+#: src/supports/properties.md:181 src/supports/properties.md:216
+#: src/supports/properties.md:235 src/supports/pagination.md:13
 msgid "プロパティ"
 msgstr "Property"
 
 #: src/supports/properties.md:20 src/supports/properties.md:31
-#: src/supports/properties.md:44 src/supports/properties.md:61
-#: src/supports/properties.md:81 src/supports/properties.md:108
-#: src/supports/properties.md:123 src/supports/properties.md:141
-#: src/supports/properties.md:150 src/supports/properties.md:161
-#: src/supports/properties.md:176 src/supports/properties.md:211
-#: src/supports/properties.md:230 src/supports/selectors.md:15
-#: src/supports/selectors.md:27 src/supports/selectors.md:46
-#: src/supports/selectors.md:76 src/supports/selectors.md:120
+#: src/supports/properties.md:46 src/supports/properties.md:65
+#: src/supports/properties.md:86 src/supports/properties.md:113
+#: src/supports/properties.md:128 src/supports/properties.md:146
+#: src/supports/properties.md:155 src/supports/properties.md:166
+#: src/supports/properties.md:181 src/supports/properties.md:216
+#: src/supports/properties.md:235 src/supports/selectors.md:15
+#: src/supports/selectors.md:28 src/supports/selectors.md:47
+#: src/supports/selectors.md:77 src/supports/selectors.md:121
 #: src/migration/wkhtmltopdf-options.md:29
 #: src/migration/wkhtmltopdf-options.md:67
 #: src/migration/wkhtmltopdf-options.md:76
@@ -3939,32 +3939,34 @@ msgstr "`display`"
 #: src/supports/properties.md:26 src/supports/properties.md:27
 #: src/supports/properties.md:33 src/supports/properties.md:34
 #: src/supports/properties.md:35 src/supports/properties.md:36
-#: src/supports/properties.md:49 src/supports/properties.md:50
-#: src/supports/properties.md:52 src/supports/properties.md:53
-#: src/supports/properties.md:55 src/supports/properties.md:57
-#: src/supports/properties.md:65 src/supports/properties.md:66
-#: src/supports/properties.md:68 src/supports/properties.md:69
-#: src/supports/properties.md:83 src/supports/properties.md:84
-#: src/supports/properties.md:85 src/supports/properties.md:86
-#: src/supports/properties.md:90 src/supports/properties.md:91
-#: src/supports/properties.md:92 src/supports/properties.md:93
-#: src/supports/properties.md:94 src/supports/properties.md:95
-#: src/supports/properties.md:97 src/supports/properties.md:98
-#: src/supports/properties.md:99 src/supports/properties.md:100
-#: src/supports/properties.md:101 src/supports/properties.md:102
-#: src/supports/properties.md:104 src/supports/properties.md:110
-#: src/supports/properties.md:112 src/supports/properties.md:115
-#: src/supports/properties.md:116 src/supports/properties.md:126
-#: src/supports/properties.md:128 src/supports/properties.md:144
-#: src/supports/properties.md:146 src/supports/properties.md:152
-#: src/supports/properties.md:163 src/supports/properties.md:164
-#: src/supports/properties.md:180 src/supports/properties.md:185
-#: src/supports/properties.md:187 src/supports/selectors.md:37
-#: src/supports/selectors.md:48 src/supports/selectors.md:49
-#: src/supports/selectors.md:78 src/supports/selectors.md:80
-#: src/supports/selectors.md:82 src/supports/selectors.md:122
+#: src/supports/properties.md:41 src/supports/properties.md:42
+#: src/supports/properties.md:50 src/supports/properties.md:52
+#: src/supports/properties.md:53 src/supports/properties.md:55
+#: src/supports/properties.md:56 src/supports/properties.md:57
+#: src/supports/properties.md:59 src/supports/properties.md:61
+#: src/supports/properties.md:69 src/supports/properties.md:70
+#: src/supports/properties.md:72 src/supports/properties.md:73
+#: src/supports/properties.md:74 src/supports/properties.md:88
+#: src/supports/properties.md:89 src/supports/properties.md:90
+#: src/supports/properties.md:91 src/supports/properties.md:95
+#: src/supports/properties.md:96 src/supports/properties.md:97
+#: src/supports/properties.md:98 src/supports/properties.md:99
+#: src/supports/properties.md:100 src/supports/properties.md:102
+#: src/supports/properties.md:103 src/supports/properties.md:104
+#: src/supports/properties.md:105 src/supports/properties.md:106
+#: src/supports/properties.md:107 src/supports/properties.md:109
+#: src/supports/properties.md:115 src/supports/properties.md:117
+#: src/supports/properties.md:120 src/supports/properties.md:121
+#: src/supports/properties.md:131 src/supports/properties.md:133
+#: src/supports/properties.md:149 src/supports/properties.md:151
+#: src/supports/properties.md:157 src/supports/properties.md:168
+#: src/supports/properties.md:169 src/supports/properties.md:185
+#: src/supports/properties.md:190 src/supports/properties.md:192
+#: src/supports/selectors.md:38 src/supports/selectors.md:49
+#: src/supports/selectors.md:50 src/supports/selectors.md:79
+#: src/supports/selectors.md:81 src/supports/selectors.md:83
 #: src/supports/selectors.md:123 src/supports/selectors.md:124
-#: src/supports/selectors.md:125
+#: src/supports/selectors.md:125 src/supports/selectors.md:126
 msgid "⚠️"
 msgstr "⚠️"
 
@@ -4115,40 +4117,41 @@ msgstr "`margin`"
 
 #: src/supports/properties.md:37 src/supports/properties.md:38
 #: src/supports/properties.md:39 src/supports/properties.md:40
-#: src/supports/properties.md:46 src/supports/properties.md:47
-#: src/supports/properties.md:48 src/supports/properties.md:51
-#: src/supports/properties.md:54 src/supports/properties.md:63
-#: src/supports/properties.md:64 src/supports/properties.md:88
-#: src/supports/properties.md:89 src/supports/properties.md:96
-#: src/supports/properties.md:103 src/supports/properties.md:111
-#: src/supports/properties.md:113 src/supports/properties.md:114
-#: src/supports/properties.md:125 src/supports/properties.md:127
-#: src/supports/properties.md:129 src/supports/properties.md:130
-#: src/supports/properties.md:143 src/supports/properties.md:145
-#: src/supports/properties.md:153 src/supports/properties.md:154
-#: src/supports/properties.md:165 src/supports/properties.md:166
-#: src/supports/properties.md:178 src/supports/properties.md:179
-#: src/supports/properties.md:181 src/supports/properties.md:182
-#: src/supports/properties.md:183 src/supports/properties.md:184
-#: src/supports/properties.md:186 src/supports/properties.md:213
-#: src/supports/properties.md:214 src/supports/properties.md:215
-#: src/supports/properties.md:216 src/supports/properties.md:217
+#: src/supports/properties.md:48 src/supports/properties.md:49
+#: src/supports/properties.md:51 src/supports/properties.md:54
+#: src/supports/properties.md:58 src/supports/properties.md:67
+#: src/supports/properties.md:68 src/supports/properties.md:71
+#: src/supports/properties.md:93 src/supports/properties.md:94
+#: src/supports/properties.md:101 src/supports/properties.md:108
+#: src/supports/properties.md:116 src/supports/properties.md:118
+#: src/supports/properties.md:119 src/supports/properties.md:130
+#: src/supports/properties.md:132 src/supports/properties.md:134
+#: src/supports/properties.md:135 src/supports/properties.md:148
+#: src/supports/properties.md:150 src/supports/properties.md:158
+#: src/supports/properties.md:159 src/supports/properties.md:170
+#: src/supports/properties.md:171 src/supports/properties.md:183
+#: src/supports/properties.md:184 src/supports/properties.md:186
+#: src/supports/properties.md:187 src/supports/properties.md:188
+#: src/supports/properties.md:189 src/supports/properties.md:191
 #: src/supports/properties.md:218 src/supports/properties.md:219
-#: src/supports/properties.md:220 src/supports/properties.md:232
-#: src/supports/properties.md:233 src/supports/selectors.md:17
-#: src/supports/selectors.md:18 src/supports/selectors.md:19
-#: src/supports/selectors.md:20 src/supports/selectors.md:21
-#: src/supports/selectors.md:22 src/supports/selectors.md:29
-#: src/supports/selectors.md:30 src/supports/selectors.md:31
-#: src/supports/selectors.md:32 src/supports/selectors.md:33
-#: src/supports/selectors.md:34 src/supports/selectors.md:35
-#: src/supports/selectors.md:36 src/supports/selectors.md:38
-#: src/supports/selectors.md:59 src/supports/selectors.md:60
-#: src/supports/selectors.md:61 src/supports/selectors.md:62
-#: src/supports/selectors.md:81 src/supports/selectors.md:83
-#: src/supports/selectors.md:91 src/supports/selectors.md:92
-#: src/supports/selectors.md:93 src/supports/selectors.md:94
-#: src/supports/selectors.md:96 src/supports/selectors.md:126
+#: src/supports/properties.md:220 src/supports/properties.md:221
+#: src/supports/properties.md:222 src/supports/properties.md:223
+#: src/supports/properties.md:224 src/supports/properties.md:225
+#: src/supports/properties.md:237 src/supports/properties.md:238
+#: src/supports/selectors.md:17 src/supports/selectors.md:18
+#: src/supports/selectors.md:19 src/supports/selectors.md:20
+#: src/supports/selectors.md:21 src/supports/selectors.md:22
+#: src/supports/selectors.md:23 src/supports/selectors.md:30
+#: src/supports/selectors.md:31 src/supports/selectors.md:32
+#: src/supports/selectors.md:33 src/supports/selectors.md:34
+#: src/supports/selectors.md:35 src/supports/selectors.md:36
+#: src/supports/selectors.md:37 src/supports/selectors.md:39
+#: src/supports/selectors.md:60 src/supports/selectors.md:61
+#: src/supports/selectors.md:62 src/supports/selectors.md:63
+#: src/supports/selectors.md:82 src/supports/selectors.md:84
+#: src/supports/selectors.md:92 src/supports/selectors.md:93
+#: src/supports/selectors.md:94 src/supports/selectors.md:95
+#: src/supports/selectors.md:97 src/supports/selectors.md:127
 msgid "✅"
 msgstr "✅"
 
@@ -4172,7 +4175,7 @@ msgstr ""
 msgid "`padding`"
 msgstr "`padding`"
 
-#: src/supports/properties.md:39 src/supports/properties.md:48
+#: src/supports/properties.md:39 src/supports/properties.md:51
 msgid "1〜4値ショートハンド"
 msgstr "The one to four value shorthand"
 
@@ -4180,22 +4183,29 @@ msgstr "The one to four value shorthand"
 msgid "`padding-top` / `-right` / `-bottom` / `-left`"
 msgstr "`padding-top`, `-right`, `-bottom`, `-left`"
 
+#: src/supports/properties.md:40
+msgid "パーセンテージはcontaining block幅基準(仕様通り)"
+msgstr ""
+"Percentages resolve against the containing block's width, as the "
+"specification says"
+
 #: src/supports/properties.md:41
 msgid "`margin-inline` / `margin-block` / `margin-inline-start`等"
 msgstr "`margin-inline`, `margin-block`, `margin-inline-start` and so on"
 
 #: src/supports/properties.md:41
 msgid ""
-"論理プロパティ。対応する書字方向が`horizontal-tb`+LTRのみなので、`inline-start`=左、"
-"`inline-end`=右、`block-start`=上、`block-end`=下へ固定で写像する(`writing-mode`/"
-"`direction`は非対応)。2辺ショートハンドは1〜2値(`start end`の順)。`auto`も通るので"
-"`margin-inline: auto`で中央寄せできる"
+"論理プロパティ。対応する書字方向が`horizontal-tb`+LTRのみなので、`inline-"
+"start`=左、`inline-end`=右、`block-start`=上、`block-end`=下へ固定で写像する"
+"(`writing-mode`/`direction`は非対応)。2辺ショートハンドは1〜2値(`start end`の"
+"順)。`auto`も通るので`margin-inline: auto`で中央寄せできる"
 msgstr ""
-"Logical properties. The only writing mode supported is `horizontal-tb` LTR, so "
-"they map to fixed physical sides: `inline-start` is left, `inline-end` is right, "
-"`block-start` is top and `block-end` is bottom (`writing-mode` and `direction` "
-"are not supported). The two-side shorthands take one or two values, start then "
-"end. `auto` passes through, so `margin-inline: auto` centres a block"
+"Logical properties. The only writing mode supported is `horizontal-tb` LTR, "
+"so they map to fixed physical sides: `inline-start` is left, `inline-end` is "
+"right, `block-start` is top and `block-end` is bottom (`writing-mode` and "
+"`direction` are not supported). The two-side shorthands take one or two "
+"values, start then end. `auto` passes through, so `margin-inline: auto` "
+"centres a block"
 
 #: src/supports/properties.md:42
 msgid "`padding-inline` / `padding-block` / `padding-inline-start`等"
@@ -4205,21 +4215,15 @@ msgstr "`padding-inline`, `padding-block`, `padding-inline-start` and so on"
 msgid "論理プロパティ。写像規則は`margin-inline`と同じ"
 msgstr "Logical properties, mapped the same way as `margin-inline`"
 
-#: src/supports/properties.md:40
-msgid "パーセンテージはcontaining block幅基準(仕様通り)"
-msgstr ""
-"Percentages resolve against the containing block's width, as the "
-"specification says"
-
-#: src/supports/properties.md:42
+#: src/supports/properties.md:44
 msgid "枠線・角丸・アウトライン・影"
 msgstr "Borders, rounded corners, outlines, and shadows"
 
-#: src/supports/properties.md:46
+#: src/supports/properties.md:48
 msgid "`border`"
 msgstr "`border`"
 
-#: src/supports/properties.md:46
+#: src/supports/properties.md:48
 msgid ""
 "`<width> \\|\\| <style> \\|\\| <color>`を任意順・任意省略で受け付け、4辺へ適"
 "用"
@@ -4227,40 +4231,45 @@ msgstr ""
 "Accepts `<width> \\|\\| <style> \\|\\| <color>` in any order with any part "
 "omitted, and applies it to all four sides"
 
-#: src/supports/properties.md:47
+#: src/supports/properties.md:49
 msgid "`border-top` / `-right` / `-bottom` / `-left`"
 msgstr "`border-top`, `-right`, `-bottom`, `-left`"
+
+#: src/supports/properties.md:49
+msgid "辺別ショートハンド(値文法は`border`と同じ)"
+msgstr "The per-side shorthands; the value syntax is the same as `border`"
 
 #: src/supports/properties.md:50
 msgid ""
 "`border-inline` / `border-block` / `border-inline-start`等(`-width`/`-style`/"
 "`-color`のロングハンドを含む)"
 msgstr ""
-"`border-inline`, `border-block`, `border-inline-start` and so on, including the "
-"`-width`, `-style` and `-color` longhands"
+"`border-inline`, `border-block`, `border-inline-start` and so on, including "
+"the `-width`, `-style` and `-color` longhands"
 
-#: src/supports/properties.md:47
-msgid "辺別ショートハンド(値文法は`border`と同じ)"
-msgstr "The per-side shorthands; the value syntax is the same as `border`"
+#: src/supports/properties.md:50 src/supports/properties.md:72
+msgid "論理プロパティ。写像規則は[`margin-inline`](#ボックスモデル)と同じ"
+msgstr ""
+"Logical properties, mapped the same way as [`margin-inline`](#box-model)"
 
-#: src/supports/properties.md:48
+#: src/supports/properties.md:51
 msgid "`border-width` / `border-style` / `border-color`"
 msgstr "`border-width`, `border-style`, `border-color`"
 
-#: src/supports/properties.md:49
+#: src/supports/properties.md:52
 msgid "`border-*-width`"
 msgstr "`border-*-width`"
 
-#: src/supports/properties.md:49
+#: src/supports/properties.md:52
 msgid "`<length>`のみ。`thin`/`medium`/`thick`キーワードは非対応"
 msgstr ""
 "`<length>` only. The `thin`, `medium`, and `thick` keywords are not supported"
 
-#: src/supports/properties.md:50
+#: src/supports/properties.md:53
 msgid "`border-*-style`"
 msgstr "`border-*-style`"
 
-#: src/supports/properties.md:50
+#: src/supports/properties.md:53
 msgid ""
 "`none`/`hidden`/`solid`/`dashed`/`dotted`/`double`/`groove`/`ridge`/`inset`/"
 "`outset`。`hidden`は`none`と同一視(テーブルの枠線競合解決でも区別しない)。"
@@ -4272,19 +4281,19 @@ msgstr ""
 "resolving table border conflicts. `groove`, `ridge`, `inset`, and `outset` "
 "are drawn with two shades derived from `border-color`"
 
-#: src/supports/properties.md:51
+#: src/supports/properties.md:54
 msgid "`border-*-color`"
 msgstr "`border-*-color`"
 
-#: src/supports/properties.md:51
+#: src/supports/properties.md:54
 msgid "初期値は`currentcolor`"
 msgstr "`currentcolor` by default"
 
-#: src/supports/properties.md:52
+#: src/supports/properties.md:55
 msgid "`border-radius`"
 msgstr "`border-radius`"
 
-#: src/supports/properties.md:52
+#: src/supports/properties.md:55
 msgid ""
 "1〜4値+`/`区切りの楕円構文に対応。パーセンテージ指定は非対応(`<length>`の"
 "み)。4辺の太さ・スタイル・色が揃っていない場合は角丸を諦めて直線4辺へフォール"
@@ -4296,21 +4305,34 @@ msgstr ""
 "drawn instead. Combining it with `groove`, `ridge`, `inset`, or `outset` "
 "falls back in the same way"
 
-#: src/supports/properties.md:53
+#: src/supports/properties.md:56
 msgid "`border-top-left-radius`ほか3隅"
 msgstr "`border-top-left-radius` and the other three corners"
 
-#: src/supports/properties.md:53
+#: src/supports/properties.md:56
 msgid "`<length>{1,2}`(水平/垂直半径)。制約は`border-radius`と同じ"
 msgstr ""
 "`<length>{1,2}`, the horizontal and vertical radii. The same restrictions as "
 "`border-radius`"
 
-#: src/supports/properties.md:54
+#: src/supports/properties.md:57
+msgid "`border-start-start-radius`ほか3隅"
+msgstr "`border-start-start-radius` and the other three corners"
+
+#: src/supports/properties.md:57
+msgid ""
+"論理プロパティ。1つ目がblock方向、2つ目がinline方向を指す(`border-start-end-"
+"radius`=右上)。写像規則は[`margin-inline`](#ボックスモデル)と同じ"
+msgstr ""
+"Logical property. The first keyword is the block axis and the second the "
+"inline axis (`border-start-end-radius` is the top-right corner). Mapped the "
+"same way as [`margin-inline`](#box-model)"
+
+#: src/supports/properties.md:58
 msgid "`outline`"
 msgstr "`outline`"
 
-#: src/supports/properties.md:54
+#: src/supports/properties.md:58
 msgid ""
 "`<width> \\|\\| <style> \\|\\| <color>`。border-boxの外側に描画し、レイアウト"
 "には影響しない"
@@ -4318,43 +4340,43 @@ msgstr ""
 "`<width> \\|\\| <style> \\|\\| <color>`. Drawn outside the border box, with "
 "no effect on layout"
 
-#: src/supports/properties.md:55
+#: src/supports/properties.md:59
 msgid "`outline-width` / `outline-style` / `outline-color`"
 msgstr "`outline-width`, `outline-style`, `outline-color`"
 
-#: src/supports/properties.md:55
+#: src/supports/properties.md:59
 msgid "`outline-style`は`border-style`と同じ値集合。UA依存の`auto`は非対応"
 msgstr ""
 "`outline-style` takes the same values as `border-style`. The UA-defined "
 "`auto` is not supported"
 
-#: src/supports/properties.md:56
+#: src/supports/properties.md:60
 msgid "`outline-offset`"
 msgstr "`outline-offset`"
 
-#: src/supports/properties.md:56 src/supports/properties.md:67
-#: src/supports/properties.md:87 src/supports/properties.md:117
-#: src/supports/properties.md:155 src/supports/properties.md:167
-#: src/supports/properties.md:188 src/supports/properties.md:189
-#: src/supports/properties.md:221 src/supports/properties.md:222
-#: src/supports/properties.md:223 src/supports/selectors.md:23
-#: src/supports/selectors.md:50 src/supports/selectors.md:51
-#: src/supports/selectors.md:63 src/supports/selectors.md:79
-#: src/supports/selectors.md:84 src/supports/selectors.md:85
-#: src/supports/selectors.md:97 src/supports/selectors.md:99
-#: src/supports/selectors.md:127 src/supports/selectors.md:128
+#: src/supports/properties.md:60 src/supports/properties.md:92
+#: src/supports/properties.md:122 src/supports/properties.md:160
+#: src/supports/properties.md:172 src/supports/properties.md:193
+#: src/supports/properties.md:194 src/supports/properties.md:226
+#: src/supports/properties.md:227 src/supports/properties.md:228
+#: src/supports/selectors.md:24 src/supports/selectors.md:51
+#: src/supports/selectors.md:52 src/supports/selectors.md:64
+#: src/supports/selectors.md:80 src/supports/selectors.md:85
+#: src/supports/selectors.md:86 src/supports/selectors.md:98
+#: src/supports/selectors.md:100 src/supports/selectors.md:128
+#: src/supports/selectors.md:129
 msgid "❌"
 msgstr "❌"
 
-#: src/supports/properties.md:56
+#: src/supports/properties.md:60
 msgid "常に0固定"
 msgstr "Always 0"
 
-#: src/supports/properties.md:57
+#: src/supports/properties.md:61
 msgid "`box-shadow`"
 msgstr "`box-shadow`"
 
-#: src/supports/properties.md:57
+#: src/supports/properties.md:61
 msgid ""
 "`none \\| <shadow>#`(カンマ区切りで複数指定可、先頭が最前面)。`inset`はパース"
 "するが描画は非対応。ぼかしは4段階の同心矩形による近似"
@@ -4363,32 +4385,32 @@ msgstr ""
 "being frontmost. `inset` parses but is not drawn. The blur is approximated "
 "with four concentric rectangles"
 
-#: src/supports/properties.md:59
+#: src/supports/properties.md:63
 msgid "配置(positioning / float / transform)"
 msgstr "Placement: positioning, float, and transform"
 
-#: src/supports/properties.md:63
+#: src/supports/properties.md:67
 msgid "`float`"
 msgstr "`float`"
 
-#: src/supports/properties.md:63
+#: src/supports/properties.md:67
 msgid "`none`/`left`/`right`。`width: auto`のshrink-to-fitに対応"
 msgstr ""
 "`none`, `left`, and `right`. Shrink-to-fit for `width: auto` is supported"
 
-#: src/supports/properties.md:64
+#: src/supports/properties.md:68
 msgid "`clear`"
 msgstr "`clear`"
 
-#: src/supports/properties.md:64
+#: src/supports/properties.md:68
 msgid "`none`/`left`/`right`/`both`"
 msgstr "`none`, `left`, `right`, and `both`"
 
-#: src/supports/properties.md:65
+#: src/supports/properties.md:69
 msgid "`position`"
 msgstr "`position`"
 
-#: src/supports/properties.md:65
+#: src/supports/properties.md:69
 msgid ""
 "`static`/`relative`/`absolute`/`fixed`。`sticky`は非対応。`absolute`/`fixed`"
 "には後述の制約あり"
@@ -4396,11 +4418,11 @@ msgstr ""
 "`static`, `relative`, `absolute`, and `fixed`. `sticky` is not supported, "
 "and `absolute` and `fixed` carry the restrictions listed below"
 
-#: src/supports/properties.md:66
+#: src/supports/properties.md:70
 msgid "`top` / `right` / `bottom` / `left`"
 msgstr "`top`, `right`, `bottom`, `left`"
 
-#: src/supports/properties.md:66
+#: src/supports/properties.md:70
 msgid ""
 "`absolute`/`fixed`では`bottom`単独指定による下端揃えが非対応(高さの循環参照を"
 "避けるため`top`基準に解決する)。`relative`ではオフセットとして機能する"
@@ -4409,31 +4431,23 @@ msgstr ""
 "is not supported; everything resolves from `top`, to avoid a circular "
 "dependency on the height. With `relative` they act as offsets"
 
-#: src/supports/properties.md:67
+#: src/supports/properties.md:71
 msgid "`inset`(ショートハンド)"
 msgstr "`inset`, the shorthand"
 
-#: src/supports/properties.md:67
+#: src/supports/properties.md:71
 msgid "1〜4値ショートハンド(展開規則は`margin`と同じ)"
 msgstr "The one to four value shorthand, expanded the same way as `margin`"
 
-#: src/supports/properties.md:68
+#: src/supports/properties.md:72
 msgid "`inset-inline` / `inset-block` / `inset-inline-start`等"
 msgstr "`inset-inline`, `inset-block`, `inset-inline-start` and so on"
 
-#: src/supports/properties.md:68
-msgid "論理プロパティ。写像規則は[`margin-inline`](#ボックスモデル)と同じ"
-msgstr "Logical properties, mapped the same way as [`margin-inline`](#box-model)"
-
-#: src/supports/properties.md:67
-msgid "個別の`top`/`right`/`bottom`/`left`を使う"
-msgstr "Use `top`, `right`, `bottom`, and `left` individually"
-
-#: src/supports/properties.md:68
+#: src/supports/properties.md:73
 msgid "`transform`"
 msgstr "`transform`"
 
-#: src/supports/properties.md:68
+#: src/supports/properties.md:73
 msgid ""
 "`translate`/`translateX`/`translateY`/`scale`/`scaleX`/`scaleY`/`rotate`/"
 "`skew`/`skewX`/`skewY`/`matrix`。3D系(`translate3d`/`rotate3d`/"
@@ -4446,11 +4460,11 @@ msgstr ""
 "implemented as a PDF CTM transform, so the transformed content has no "
 "bearing on where the pages break"
 
-#: src/supports/properties.md:69
+#: src/supports/properties.md:74
 msgid "`transform-origin`"
 msgstr "`transform-origin`"
 
-#: src/supports/properties.md:69
+#: src/supports/properties.md:74
 msgid ""
 "`background-position`と同じ値文法(キーワード/長さ/パーセンテージの1〜2値)。初"
 "期値`50% 50%`。3値目(Z軸)は非対応"
@@ -4459,11 +4473,11 @@ msgstr ""
 "lengths, and percentages. `50% 50%` by default. A third value for the Z axis "
 "is not supported"
 
-#: src/supports/properties.md:71
+#: src/supports/properties.md:76
 msgid "`position: absolute`/`fixed`の既知の制約:"
 msgstr "Known restrictions on `position: absolute` and `fixed`:"
 
-#: src/supports/properties.md:73
+#: src/supports/properties.md:78
 msgid ""
 "絶対配置要素は「通常フローから外し、確定したページへ後付けするオーバーレイ」"
 "として配置する"
@@ -4471,7 +4485,7 @@ msgstr ""
 "An absolutely positioned element is taken out of the normal flow and laid "
 "down afterwards as an overlay on a page that has already been settled"
 
-#: src/supports/properties.md:74
+#: src/supports/properties.md:79
 msgid ""
 "containing blockになれるのは、単一ページに収まっているpositioned祖先(または"
 "ページ領域)"
@@ -4479,7 +4493,7 @@ msgstr ""
 "Only a positioned ancestor that fits on a single page, or the page area "
 "itself, can act as the containing block"
 
-#: src/supports/properties.md:75
+#: src/supports/properties.md:80
 msgid ""
 "テキストの途中に置いた`absolute`は、その前後のテキストが別々の行に分かれる(ブ"
 "ラウザのように1行のまま残らない)"
@@ -4488,25 +4502,25 @@ msgstr ""
 "it onto separate lines, instead of keeping it on one line the way a browser "
 "does."
 
-#: src/supports/properties.md:76
+#: src/supports/properties.md:81
 msgid "絶対配置要素自身がページを跨ぐ分割は非対応(1ページにbest-effortで置く)"
 msgstr ""
 "Splitting an absolutely positioned element across pages is not supported; it "
 "is placed on one page as best it can be"
 
-#: src/supports/properties.md:77
+#: src/supports/properties.md:82
 msgid "ストリーミングモード(`Mode::Streaming`)では絶対配置を無視する"
 msgstr "In streaming mode, `Mode::Streaming`, absolute positioning is ignored"
 
-#: src/supports/properties.md:79
+#: src/supports/properties.md:84
 msgid "フォント・テキスト"
 msgstr "Fonts and text"
 
-#: src/supports/properties.md:83
+#: src/supports/properties.md:88
 msgid "`font-family`"
 msgstr "`font-family`"
 
-#: src/supports/properties.md:83
+#: src/supports/properties.md:88
 msgid ""
 "カンマ区切りリスト。汎用family名は`serif`/`sans-serif`/`monospace`をシステム"
 "フォントから解決する(`cursive`/`fantasy`は解決しない)。`sans-serif`の解決先は"
@@ -4517,11 +4531,11 @@ msgstr ""
 "are not. What `sans-serif` resolves to can be pinned with the CLI's `--"
 "gothic-font`"
 
-#: src/supports/properties.md:84
+#: src/supports/properties.md:89
 msgid "`font-size`"
 msgstr "`font-size`"
 
-#: src/supports/properties.md:84
+#: src/supports/properties.md:89
 msgid ""
 "`<length>`(`px`/`em`/`rem`)のみ。`smaller`/`larger`/`medium`等のキーワード、"
 "パーセンテージ指定は非対応"
@@ -4529,11 +4543,11 @@ msgstr ""
 "`<length>` only, in `px`, `em`, or `rem`. Keywords such as `smaller`, "
 "`larger`, and `medium`, and percentages, are not supported"
 
-#: src/supports/properties.md:85 src/supports/fonts.md:107
+#: src/supports/properties.md:90 src/supports/fonts.md:107
 msgid "`font-weight`"
 msgstr "`font-weight`"
 
-#: src/supports/properties.md:85
+#: src/supports/properties.md:90
 msgid ""
 "`normal`/`bold`/`100`〜`900`。数値は600以上を`bold`とみなす2値化。太字フォン"
 "トが無い場合は塗り+縁取りの疑似ボールドで描画"
@@ -4542,11 +4556,11 @@ msgstr ""
 "states, 600 and above counting as `bold`. Without a bold face, a synthetic "
 "bold is drawn by filling and stroking"
 
-#: src/supports/properties.md:86 src/supports/fonts.md:108
+#: src/supports/properties.md:91 src/supports/fonts.md:108
 msgid "`font-style`"
 msgstr "`font-style`"
 
-#: src/supports/properties.md:86
+#: src/supports/properties.md:91
 msgid ""
 "`normal`/`italic`/`oblique`(`oblique`は`italic`と同一視、傾斜角の指定は不"
 "可)。イタリック字形が無い場合はテキスト行列のせん断による疑似イタリック"
@@ -4555,19 +4569,19 @@ msgstr ""
 "angle may be given. Without italic glyphs, a synthetic italic is produced by "
 "shearing the text matrix"
 
-#: src/supports/properties.md:87
+#: src/supports/properties.md:92
 msgid "`font`(ショートハンド)"
 msgstr "`font`, the shorthand"
 
-#: src/supports/properties.md:87
+#: src/supports/properties.md:92
 msgid "個別のロングハンドを使う"
 msgstr "Use the individual longhands"
 
-#: src/supports/properties.md:88
+#: src/supports/properties.md:93
 msgid "`color`"
 msgstr "`color`"
 
-#: src/supports/properties.md:88
+#: src/supports/properties.md:93
 msgid ""
 "継承プロパティ。指定できる色の記法は[セレクタ・値・at-rule](selectors.md#色)"
 "を参照"
@@ -4575,19 +4589,19 @@ msgstr ""
 "Inherited. See [Selectors, values, and at-rules](selectors.md#colours) for "
 "the colour notations that may be used"
 
-#: src/supports/properties.md:89
+#: src/supports/properties.md:94
 msgid "`line-height`"
 msgstr "`line-height`"
 
-#: src/supports/properties.md:89
+#: src/supports/properties.md:94
 msgid "`normal`/`<number>`/`<length>`/`<percentage>`"
 msgstr "`normal`, `<number>`, `<length>`, and `<percentage>`"
 
-#: src/supports/properties.md:90
+#: src/supports/properties.md:95
 msgid "`text-align`"
 msgstr "`text-align`"
 
-#: src/supports/properties.md:90
+#: src/supports/properties.md:95
 msgid ""
 "`left`/`right`/`center`/`justify`。`justify`は最終行以外の単語間で余白を配分"
 "する。`start`/`end`は非対応(`direction`自体が非対応のため)"
@@ -4596,20 +4610,20 @@ msgstr ""
 "between words on every line but the last. `start` and `end` are not "
 "supported, since `direction` itself is not"
 
-#: src/supports/properties.md:91
+#: src/supports/properties.md:96
 msgid "`text-indent`"
 msgstr "`text-indent`"
 
-#: src/supports/properties.md:91
+#: src/supports/properties.md:96
 msgid "`<length>`/`<percentage>`。`hanging`/`each-line`は非対応"
 msgstr ""
 "`<length>` and `<percentage>`. `hanging` and `each-line` are not supported"
 
-#: src/supports/properties.md:92
+#: src/supports/properties.md:97
 msgid "`text-transform`"
 msgstr "`text-transform`"
 
-#: src/supports/properties.md:92
+#: src/supports/properties.md:97
 msgid ""
 "`none`/`uppercase`/`lowercase`/`capitalize`(語頭のみ変換)。`full-width`/"
 "`full-size-kana`は非対応"
@@ -4617,11 +4631,11 @@ msgstr ""
 "`none`, `uppercase`, `lowercase`, and `capitalize`, which changes the first "
 "letter of each word only. `full-width` and `full-size-kana` are not supported"
 
-#: src/supports/properties.md:93
+#: src/supports/properties.md:98
 msgid "`text-decoration` / `text-decoration-line`"
 msgstr "`text-decoration`, `text-decoration-line`"
 
-#: src/supports/properties.md:93
+#: src/supports/properties.md:98
 msgid ""
 "`none`/`underline`/`line-through`(併記可)。`overline`/`blink`は非対応。ショー"
 "トハンドの`text-decoration-color`/`-style`/`-thickness`部分も非対応。祖先から"
@@ -4632,11 +4646,11 @@ msgstr ""
 "style`, and `-thickness` parts of the shorthand. Propagation from ancestor "
 "to descendant is simplified by treating it as an inherited property"
 
-#: src/supports/properties.md:94
+#: src/supports/properties.md:99
 msgid "`text-shadow`"
 msgstr "`text-shadow`"
 
-#: src/supports/properties.md:94
+#: src/supports/properties.md:99
 msgid ""
 "`none \\| <shadow>#`(`<offset-x> <offset-y> <blur>? <color>?`)。PDFにぼかし"
 "フィルタが無いため、blurはアルファを下げた多重描画による近似。継承プロパティ"
@@ -4645,11 +4659,11 @@ msgstr ""
 "PDF has no blur filter, so the blur is approximated by drawing several times "
 "at reduced alpha. Inherited"
 
-#: src/supports/properties.md:95
+#: src/supports/properties.md:100
 msgid "`text-overflow`"
 msgstr "`text-overflow`"
 
-#: src/supports/properties.md:95
+#: src/supports/properties.md:100
 msgid ""
 "`clip`/`ellipsis`。`overflow`が`visible`以外のときのみ有効。幅方向にはみ出し"
 "た行のみが対象(ブロック全体のオーバーフローは扱わない)。`<string>`指定は非対"
@@ -4659,11 +4673,11 @@ msgstr ""
 "than `visible`. It applies to lines that overflow horizontally; overflow of "
 "the block as a whole is not handled. A `<string>` value is not supported"
 
-#: src/supports/properties.md:96
+#: src/supports/properties.md:101
 msgid "`word-break`"
 msgstr "`word-break`"
 
-#: src/supports/properties.md:96
+#: src/supports/properties.md:101
 msgid ""
 "`normal`(CJK文字が隣接する境界のみ改行可)/`break-all`/`keep-all`。非推奨値"
 "`break-word`は非対応"
@@ -4671,11 +4685,11 @@ msgstr ""
 "`normal`, which allows a break only where CJK characters meet, plus `break-"
 "all` and `keep-all`. The deprecated `break-word` is not supported"
 
-#: src/supports/properties.md:97
+#: src/supports/properties.md:102
 msgid "`overflow-wrap` / `word-wrap`"
 msgstr "`overflow-wrap`, `word-wrap`"
 
-#: src/supports/properties.md:97
+#: src/supports/properties.md:102
 msgid ""
 "`normal`/`break-word`/`anywhere`(`anywhere`は`break-word`と同一視)。改行機会"
 "は増やさず、行頭に置いても収まらない語だけを文字単位で割る"
@@ -4684,11 +4698,11 @@ msgstr ""
 "adds no break opportunities; it splits between characters only for a word "
 "that would not fit even at the start of a line"
 
-#: src/supports/properties.md:98
+#: src/supports/properties.md:103
 msgid "`hyphens`"
 msgstr "`hyphens`"
 
-#: src/supports/properties.md:98
+#: src/supports/properties.md:103
 msgid ""
 "`none`/`manual`/`auto`。soft hyphen(U+00AD)でのみ分割し、分割時に行末へハイフ"
 "ンを表示する。`auto`は辞書を持たないため`manual`と同じ挙動(自動ハイフネーショ"
@@ -4699,11 +4713,11 @@ msgstr ""
 "dictionary, so `auto` behaves like `manual` and never hyphenates "
 "automatically"
 
-#: src/supports/properties.md:99
+#: src/supports/properties.md:104
 msgid "`text-emphasis` / `-style` / `-color` / `-position`"
 msgstr "`text-emphasis`, `-style`, `-color`, `-position`"
 
-#: src/supports/properties.md:99
+#: src/supports/properties.md:104
 msgid ""
 "`dot`/`circle`/`double-circle`/`triangle`/`sesame`(`filled`/`open`)と"
 "`<string>`。キーワードのマークはPDFのパスで描くためフォントの字形に依存しない"
@@ -4719,37 +4733,37 @@ msgstr ""
 "room for the marks. `text-emphasis-skip`, which skips punctuation, is not "
 "supported"
 
-#: src/supports/properties.md:100
+#: src/supports/properties.md:105
 msgid "`letter-spacing`"
 msgstr "`letter-spacing`"
 
-#: src/supports/properties.md:100
+#: src/supports/properties.md:105
 msgid "`normal`/`<length>`。パーセンテージは非対応"
 msgstr "`normal` and `<length>`. Percentages are not supported"
 
-#: src/supports/properties.md:101
+#: src/supports/properties.md:106
 msgid "`word-spacing`"
 msgstr "`word-spacing`"
 
-#: src/supports/properties.md:101
+#: src/supports/properties.md:106
 msgid "`normal`/`<length>`"
 msgstr "`normal` and `<length>`"
 
-#: src/supports/properties.md:102
+#: src/supports/properties.md:107
 msgid "`white-space`"
 msgstr "`white-space`"
 
-#: src/supports/properties.md:102
+#: src/supports/properties.md:107
 msgid "`normal`/`nowrap`/`pre`。`pre-wrap`/`pre-line`/`break-spaces`は非対応"
 msgstr ""
 "`normal`, `nowrap`, and `pre`. `pre-wrap`, `pre-line`, and `break-spaces` "
 "are not supported"
 
-#: src/supports/properties.md:103
+#: src/supports/properties.md:108
 msgid "`vertical-align`"
 msgstr "`vertical-align`"
 
-#: src/supports/properties.md:103
+#: src/supports/properties.md:108
 msgid ""
 "`baseline`/`sub`/`super`/`text-top`/`text-bottom`/`top`/`middle`/`bottom`/"
 "`<length>`/`<percentage>`。テーブルセル文脈では`top`/`middle`/`bottom`(と"
@@ -4759,11 +4773,11 @@ msgstr ""
 "`bottom`, `<length>`, and `<percentage>`. In a table cell, `top`, `middle`, "
 "`bottom`, and `baseline` are the meaningful ones"
 
-#: src/supports/properties.md:104
+#: src/supports/properties.md:109
 msgid "`quotes`"
 msgstr "`quotes`"
 
-#: src/supports/properties.md:104
+#: src/supports/properties.md:109
 msgid ""
 "`none`または`\"開き\" \"閉じ\"`のペアの繰り返し。`content`の`open-quote`/"
 "`close-quote`と組で使う。継承プロパティ"
@@ -4771,15 +4785,15 @@ msgstr ""
 "`none`, or repeated `\"open\" \"close\"` pairs. Used together with `open-"
 "quote` and `close-quote` in `content`. Inherited"
 
-#: src/supports/properties.md:106
+#: src/supports/properties.md:111
 msgid "背景"
 msgstr "Backgrounds"
 
-#: src/supports/properties.md:110
+#: src/supports/properties.md:115
 msgid "`background`(ショートハンド)"
 msgstr "`background`, the shorthand"
 
-#: src/supports/properties.md:110
+#: src/supports/properties.md:115
 msgid ""
 "`<color>`/`<image>`/`<repeat>`/`<attachment>`/`<position>[ / <size>]`を任意順"
 "で受け付ける。指定しなかったロングハンドは仕様通り初期値へリセットされる。"
@@ -4792,20 +4806,20 @@ msgstr ""
 "origin`, that is a keyword such as `padding-box`, is a parse error and "
 "throws the whole declaration away"
 
-#: src/supports/properties.md:111
+#: src/supports/properties.md:116
 msgid "`background-color`"
 msgstr "`background-color`"
 
-#: src/supports/properties.md:111
+#: src/supports/properties.md:116
 msgid "アルファ付きの色はExtGStateで透過描画"
 msgstr ""
 "Colours with an alpha channel are drawn transparently through an ExtGState"
 
-#: src/supports/properties.md:112
+#: src/supports/properties.md:117
 msgid "`background-image`"
 msgstr "`background-image`"
 
-#: src/supports/properties.md:112
+#: src/supports/properties.md:117
 msgid ""
 "`none \\| url(...)`のみ。`linear-gradient()`等のグラデーション関数、カンマ区"
 "切りの複数背景は非対応。既定ではintrinsicサイズでタイル配置"
@@ -4814,11 +4828,11 @@ msgstr ""
 "and several comma separated backgrounds, are not supported. By default the "
 "image is tiled at its intrinsic size"
 
-#: src/supports/properties.md:113
+#: src/supports/properties.md:118
 msgid "`background-position`"
 msgstr "`background-position`"
 
-#: src/supports/properties.md:113
+#: src/supports/properties.md:118
 msgid ""
 "キーワード(`left`/`center`/`right`/`top`/`bottom`)と長さ/パーセンテージの1〜2"
 "値。3〜4値構文(`right 10px bottom 20px`)は非対応"
@@ -4827,20 +4841,20 @@ msgstr ""
 "`bottom`, plus lengths and percentages. The three and four value syntax, "
 "such as `right 10px bottom 20px`, is not supported"
 
-#: src/supports/properties.md:114
+#: src/supports/properties.md:119
 msgid "`background-size`"
 msgstr "`background-size`"
 
-#: src/supports/properties.md:114
+#: src/supports/properties.md:119
 msgid "`cover`/`contain`/`<length-percentage> \\| auto`の1〜2値"
 msgstr ""
 "`cover`, `contain`, or one or two values of `<length-percentage> \\| auto`"
 
-#: src/supports/properties.md:115
+#: src/supports/properties.md:120
 msgid "`background-repeat`"
 msgstr "`background-repeat`"
 
-#: src/supports/properties.md:115
+#: src/supports/properties.md:120
 msgid ""
 "`repeat`/`repeat-x`/`repeat-y`/`no-repeat`。CSS3の`round`/`space`、2値構文は"
 "非対応"
@@ -4848,25 +4862,25 @@ msgstr ""
 "`repeat`, `repeat-x`, `repeat-y`, and `no-repeat`. The CSS3 `round` and "
 "`space`, and the two value syntax, are not supported"
 
-#: src/supports/properties.md:116
+#: src/supports/properties.md:121
 msgid "`background-attachment`"
 msgstr "`background-attachment`"
 
-#: src/supports/properties.md:116
+#: src/supports/properties.md:121
 msgid "`scroll`/`fixed`(スクロールの概念が無いため`fixed`は`scroll`と同一視)"
 msgstr ""
 "`scroll` and `fixed`; since there is no scrolling, `fixed` is treated as "
 "`scroll`"
 
-#: src/supports/properties.md:117
+#: src/supports/properties.md:122
 msgid "`background-clip` / `background-origin` / `background-blend-mode`"
 msgstr "`background-clip`, `background-origin`, `background-blend-mode`"
 
-#: src/supports/properties.md:117
+#: src/supports/properties.md:122
 msgid "未実装。背景はborder-box基準で描画する"
 msgstr "Not implemented. Backgrounds are drawn against the border box"
 
-#: src/supports/properties.md:119
+#: src/supports/properties.md:124
 msgid ""
 "`border-radius`と`background-image`を併用した場合、角丸によるクリップは行わな"
 "い(角丸は背景色の塗りにのみ効く)。"
@@ -4875,15 +4889,15 @@ msgstr ""
 "not clipped to the rounded corners; the rounding applies to the background "
 "colour fill only."
 
-#: src/supports/properties.md:121
+#: src/supports/properties.md:126
 msgid "テーブル"
 msgstr "Tables"
 
-#: src/supports/properties.md:125
+#: src/supports/properties.md:130
 msgid "`table-layout`"
 msgstr "`table-layout`"
 
-#: src/supports/properties.md:125
+#: src/supports/properties.md:130
 msgid ""
 "`auto`/`fixed`。`auto`ではセル内容の自然幅を測って列幅を決める(ネストしたテー"
 "ブル・flexの自然幅測定のみ非対応で0扱い)"
@@ -4892,11 +4906,11 @@ msgstr ""
 "natural width of the cell contents; measuring the natural width of a nested "
 "table or a flex container is not supported and counts as 0"
 
-#: src/supports/properties.md:126
+#: src/supports/properties.md:131
 msgid "`border-collapse`"
 msgstr "`border-collapse`"
 
-#: src/supports/properties.md:126
+#: src/supports/properties.md:131
 msgid ""
 "`separate`/`collapse`。`collapse`は見た目の枠線統合のみを行う(CSS2.1 §17.6.2"
 "の競合解決を「太い方が勝ち、同幅ならスタイル優先順」で簡略化)。継承プロパティ"
@@ -4905,46 +4919,46 @@ msgstr ""
 "simplifying the conflict resolution of CSS 2.1 §17.6.2 to \"the thicker one "
 "wins, and at equal width the style order decides\". Inherited"
 
-#: src/supports/properties.md:127
+#: src/supports/properties.md:132
 msgid "`border-spacing`"
 msgstr "`border-spacing`"
 
-#: src/supports/properties.md:127
+#: src/supports/properties.md:132
 msgid ""
 "`<length>{1,2}`。`border-collapse: collapse`時は0として扱う。継承プロパティ"
 msgstr ""
 "`<length>{1,2}`. Treated as 0 under `border-collapse: collapse`. Inherited"
 
-#: src/supports/properties.md:128
+#: src/supports/properties.md:133
 msgid "`caption-side`"
 msgstr "`caption-side`"
 
-#: src/supports/properties.md:128
+#: src/supports/properties.md:133
 msgid "`top`/`bottom`。縦書き向けの`left`/`right`は非対応"
 msgstr ""
 "`top` and `bottom`. The `left` and `right` values, which are for vertical "
 "writing, are not supported"
 
-#: src/supports/properties.md:129
+#: src/supports/properties.md:134
 msgid "`empty-cells`"
 msgstr "`empty-cells`"
 
-#: src/supports/properties.md:129
+#: src/supports/properties.md:134
 msgid ""
 "`show`/`hide`。`border-collapse: separate`でのみ意味を持つ。継承プロパティ"
 msgstr ""
 "`show` and `hide`, meaningful only under `border-collapse: separate`. "
 "Inherited"
 
-#: src/supports/properties.md:130
+#: src/supports/properties.md:135
 msgid "`vertical-align`(セル)"
 msgstr "`vertical-align` on a cell"
 
-#: src/supports/properties.md:130
+#: src/supports/properties.md:135
 msgid "上記[フォント・テキスト](#フォントテキスト)を参照"
 msgstr "See [Fonts and text](#fonts-and-text) above"
 
-#: src/supports/properties.md:132
+#: src/supports/properties.md:137
 msgid ""
 "`<colgroup>`/`<col>`の`width`属性・CSS`width`による列幅指定、`rowspan`/"
 "`colspan`、`<thead>`のページまたぎ繰り返しに対応。 `rowspan=\"0\"`は1として扱"
@@ -4954,7 +4968,7 @@ msgstr ""
 "`<col>`, `rowspan` and `colspan`, and repeating `<thead>` across pages are "
 "all supported. `rowspan=\"0\"` counts as 1."
 
-#: src/supports/properties.md:135
+#: src/supports/properties.md:140
 msgid ""
 "セルの`min-width`/`max-width`は列幅アルゴリズムに反映される。 `table-layout: "
 "auto`では列の自然幅をクランプする形で効くため、表を紙幅に収める比例縮尺の後は"
@@ -4968,24 +4982,24 @@ msgstr ""
 "width stated on the first row's cells, and a cell with `width: auto` and "
 "only a `min-width` uses that value as the column width."
 
-#: src/supports/properties.md:139
+#: src/supports/properties.md:144
 msgid "リスト"
 msgstr "Lists"
 
-#: src/supports/properties.md:143
+#: src/supports/properties.md:148
 msgid "`list-style`(ショートハンド)"
 msgstr "`list-style`, the shorthand"
 
-#: src/supports/properties.md:143
+#: src/supports/properties.md:148
 msgid "`type`/`position`/`image`を任意順・任意省略で受け付ける"
 msgstr ""
 "Accepts `type`, `position`, and `image` in any order with any part omitted"
 
-#: src/supports/properties.md:144
+#: src/supports/properties.md:149
 msgid "`list-style-type`"
 msgstr "`list-style-type`"
 
-#: src/supports/properties.md:144
+#: src/supports/properties.md:149
 msgid ""
 "`disc`/`circle`/`square`/`decimal`/`decimal-leading-zero`/`lower-roman`/"
 "`upper-roman`/`lower-alpha`(`lower-latin`)/`upper-alpha`(`upper-latin`)/"
@@ -4996,19 +5010,19 @@ msgstr ""
 "latin`), and `none`. `cjk-*`, `hiragana`, `katakana`, and the like are not "
 "supported. Inherited"
 
-#: src/supports/properties.md:145
+#: src/supports/properties.md:150
 msgid "`list-style-position`"
 msgstr "`list-style-position`"
 
-#: src/supports/properties.md:145
+#: src/supports/properties.md:150
 msgid "`outside`/`inside`。継承プロパティ"
 msgstr "`outside` and `inside`. Inherited"
 
-#: src/supports/properties.md:146
+#: src/supports/properties.md:151
 msgid "`list-style-image`"
 msgstr "`list-style-image`"
 
-#: src/supports/properties.md:146
+#: src/supports/properties.md:151
 msgid ""
 "`none \\| url(...)`をパースするが描画には使わない(常に`list-style-type`のテキ"
 "ストマーカーへフォールバック)"
@@ -5016,15 +5030,15 @@ msgstr ""
 "`none \\| url(...)` parses but is never drawn; it always falls back to the "
 "text marker from `list-style-type`"
 
-#: src/supports/properties.md:148
+#: src/supports/properties.md:153
 msgid "生成コンテンツ・カウンタ"
 msgstr "Generated content and counters"
 
-#: src/supports/properties.md:152
+#: src/supports/properties.md:157
 msgid "`content`"
 msgstr "`content`"
 
-#: src/supports/properties.md:152
+#: src/supports/properties.md:157
 msgid ""
 "`::before`/`::after`/`::first-letter`および`@page`のmargin box用。文字列リテ"
 "ラル・`attr()`・`counter()`/`counters()`・`open-quote`/`close-quote`/`no-"
@@ -5037,31 +5051,31 @@ msgstr ""
 "Inserting an image with `url()` is not supported. As a simplification, `::"
 "before` and `::after` are not generated on an element that has block children"
 
-#: src/supports/properties.md:153
+#: src/supports/properties.md:158
 msgid "`counter-reset`"
 msgstr "`counter-reset`"
 
-#: src/supports/properties.md:153
+#: src/supports/properties.md:158
 msgid "`none`または`name [<integer>]`の繰り返し"
 msgstr "`none`, or repeated `name [<integer>]`"
 
-#: src/supports/properties.md:154
+#: src/supports/properties.md:159
 msgid "`counter-increment`"
 msgstr "`counter-increment`"
 
-#: src/supports/properties.md:154
+#: src/supports/properties.md:159
 msgid "`none`または`name [<integer>]`の繰り返し(値省略時は1)"
 msgstr "`none`, or repeated `name [<integer>]`, the value being 1 when omitted"
 
-#: src/supports/properties.md:155
+#: src/supports/properties.md:160
 msgid "`counter-set`"
 msgstr "`counter-set`"
 
-#: src/supports/properties.md:155 src/supports/properties.md:223
+#: src/supports/properties.md:160 src/supports/properties.md:228
 msgid "未実装"
 msgstr "Not implemented"
 
-#: src/supports/properties.md:157
+#: src/supports/properties.md:162
 msgid ""
 "`counter(page)`/`counter(pages)`によるページ番号は`@page`のmargin box内で使え"
 "る(`counter(pages)`はストリーミングモードでは総ページ数が確定しないためエラー"
@@ -5071,15 +5085,15 @@ msgstr ""
 "the `@page` margin boxes. `counter(pages)` is an error in streaming mode, "
 "where the total page count is never settled."
 
-#: src/supports/properties.md:159
+#: src/supports/properties.md:164
 msgid "ページ分割(CSS Fragmentation)"
 msgstr "Page breaking (CSS Fragmentation)"
 
-#: src/supports/properties.md:163 src/supports/pagination.md:15
+#: src/supports/properties.md:168 src/supports/pagination.md:15
 msgid "`break-before` / `break-after`"
 msgstr "`break-before`, `break-after`"
 
-#: src/supports/properties.md:163
+#: src/supports/properties.md:168
 msgid ""
 "`auto`/`avoid`(`avoid-page`/`avoid-column`も同義)/`always`(`page`も同義)。"
 "`left`/`right`/`recto`/`verso`(見開き制御)、多段組み関連の値は非対応"
@@ -5088,41 +5102,41 @@ msgstr ""
 "`always` (`page` means the same). `left`, `right`, `recto`, and `verso`, "
 "which control spreads, and the multi-column values are not supported"
 
-#: src/supports/properties.md:164 src/supports/pagination.md:16
+#: src/supports/properties.md:169 src/supports/pagination.md:16
 msgid "`break-inside`"
 msgstr "`break-inside`"
 
-#: src/supports/properties.md:164
+#: src/supports/properties.md:169
 msgid "`auto`/`avoid`(`avoid-page`/`avoid-column`も同義)"
 msgstr "`auto` and `avoid` (`avoid-page` and `avoid-column` mean the same)"
 
-#: src/supports/properties.md:165
+#: src/supports/properties.md:170
 msgid "`page-break-before` / `page-break-after` / `page-break-inside`"
 msgstr "`page-break-before`, `page-break-after`, `page-break-inside`"
 
-#: src/supports/properties.md:165
+#: src/supports/properties.md:170
 msgid "上記`break-*`のエイリアス(wkhtmltopdf/wicked_pdf資産からの移行用)"
 msgstr ""
 "Aliases for the `break-*` properties above, for moving existing wkhtmltopdf "
 "and wicked_pdf work across"
 
-#: src/supports/properties.md:166
+#: src/supports/properties.md:171
 msgid "`orphans` / `widows`"
 msgstr "`orphans`, `widows`"
 
-#: src/supports/properties.md:166
+#: src/supports/properties.md:171
 msgid "1以上の整数。初期値2"
 msgstr "An integer of 1 or more; 2 by default"
 
-#: src/supports/properties.md:167
+#: src/supports/properties.md:172
 msgid "`page`(名前付きページ)"
 msgstr "`page`, named pages"
 
-#: src/supports/properties.md:167
+#: src/supports/properties.md:172
 msgid "`@page intro`のような名前付きページ自体が非対応"
 msgstr "Named pages themselves, such as `@page intro`, are not supported"
 
-#: src/supports/properties.md:169
+#: src/supports/properties.md:174
 msgid ""
 "HTML属性`data-page-break=\"before|after|avoid\"`によるシンタックスシュガーも"
 "利用できる。"
@@ -5130,11 +5144,11 @@ msgstr ""
 "The HTML attribute `data-page-break=\"before|after|avoid\"` is available as "
 "syntactic sugar."
 
-#: src/supports/properties.md:171
+#: src/supports/properties.md:176
 msgid "Flexbox"
 msgstr "Flexbox"
 
-#: src/supports/properties.md:173
+#: src/supports/properties.md:178
 msgid ""
 "`display: flex`のレイアウトは[taffy](https://github.com/DioxusLabs/taffy)へ委"
 "譲する。 flexコンテナはページ分割上アトミック(`display: table`と同じく途中で"
@@ -5144,27 +5158,27 @@ msgstr ""
 "DioxusLabs/taffy). A flex container is atomic as far as page breaking goes: "
 "like `display: table`, it is never split part way through."
 
-#: src/supports/properties.md:178
+#: src/supports/properties.md:183
 msgid "`flex-direction`"
 msgstr "`flex-direction`"
 
-#: src/supports/properties.md:178
+#: src/supports/properties.md:183
 msgid "`row`/`row-reverse`/`column`/`column-reverse`"
 msgstr "`row`, `row-reverse`, `column`, and `column-reverse`"
 
-#: src/supports/properties.md:179
+#: src/supports/properties.md:184
 msgid "`flex-wrap`"
 msgstr "`flex-wrap`"
 
-#: src/supports/properties.md:179
+#: src/supports/properties.md:184
 msgid "`nowrap`/`wrap`/`wrap-reverse`"
 msgstr "`nowrap`, `wrap`, and `wrap-reverse`"
 
-#: src/supports/properties.md:180
+#: src/supports/properties.md:185
 msgid "`justify-content`"
 msgstr "`justify-content`"
 
-#: src/supports/properties.md:180
+#: src/supports/properties.md:185
 msgid ""
 "`normal`(初期値)/`flex-start`(`start`)/`flex-end`(`end`)/`center`/`space-"
 "between`/`space-around`/`space-evenly`。`safe`/`unsafe`オーバーフローキーワー"
@@ -5174,21 +5188,21 @@ msgstr ""
 "`center`, `space-between`, `space-around`, and `space-evenly`. The `safe` "
 "and `unsafe` overflow keywords are not supported"
 
-#: src/supports/properties.md:181
+#: src/supports/properties.md:186
 msgid "`align-items`"
 msgstr "`align-items`"
 
-#: src/supports/properties.md:181
+#: src/supports/properties.md:186
 msgid "`flex-start`(`start`)/`flex-end`(`end`)/`center`/`baseline`/`stretch`"
 msgstr ""
 "`flex-start` (`start`), `flex-end` (`end`), `center`, `baseline`, and "
 "`stretch`"
 
-#: src/supports/properties.md:182
+#: src/supports/properties.md:187
 msgid "`align-content`"
 msgstr "`align-content`"
 
-#: src/supports/properties.md:182
+#: src/supports/properties.md:187
 msgid ""
 "`flex-start`(`start`)/`flex-end`(`end`)/`center`/`stretch`/`space-between`/"
 "`space-around`/`space-evenly`"
@@ -5196,41 +5210,41 @@ msgstr ""
 "`flex-start` (`start`), `flex-end` (`end`), `center`, `stretch`, `space-"
 "between`, `space-around`, and `space-evenly`"
 
-#: src/supports/properties.md:183
+#: src/supports/properties.md:188
 msgid "`align-self`"
 msgstr "`align-self`"
 
-#: src/supports/properties.md:183
+#: src/supports/properties.md:188
 msgid ""
 "`auto`/`flex-start`(`start`)/`flex-end`(`end`)/`center`/`baseline`/`stretch`"
 msgstr ""
 "`auto`, `flex-start` (`start`), `flex-end` (`end`), `center`, `baseline`, "
 "and `stretch`"
 
-#: src/supports/properties.md:184
+#: src/supports/properties.md:189
 msgid "`flex-grow` / `flex-shrink`"
 msgstr "`flex-grow`, `flex-shrink`"
 
-#: src/supports/properties.md:184
+#: src/supports/properties.md:189
 msgid "非負の`<number>`(負値は無効な宣言として無視)"
 msgstr ""
 "A non-negative `<number>`; a negative value makes the declaration invalid "
 "and it is ignored"
 
-#: src/supports/properties.md:185
+#: src/supports/properties.md:190
 msgid "`flex-basis`"
 msgstr "`flex-basis`"
 
-#: src/supports/properties.md:185
+#: src/supports/properties.md:190
 msgid "`auto`/`content`/`<length-percentage>`。`content`は`auto`と同一視"
 msgstr ""
 "`auto`, `content`, and `<length-percentage>`. `content` is treated as `auto`"
 
-#: src/supports/properties.md:186
+#: src/supports/properties.md:191
 msgid "`flex`(ショートハンド)"
 msgstr "`flex`, the shorthand"
 
-#: src/supports/properties.md:186
+#: src/supports/properties.md:191
 msgid ""
 "`none`および`<grow> [<shrink>] [<basis>]`。CSS仕様の既定値規則(`flex: 1`の"
 "basisは`0%`、`flex: <width>`のgrow/shrinkは1)を再現"
@@ -5239,53 +5253,53 @@ msgstr ""
 "rules are reproduced: the basis of `flex: 1` is `0%`, and the grow and "
 "shrink of `flex: <width>` are 1"
 
-#: src/supports/properties.md:187
+#: src/supports/properties.md:192
 msgid "`gap` / `row-gap` / `column-gap`"
 msgstr "`gap`, `row-gap`, `column-gap`"
 
-#: src/supports/properties.md:187
+#: src/supports/properties.md:192
 msgid "flexコンテナでのみ有効(多段組みの`column-gap`としては機能しない)"
 msgstr ""
 "In effect on flex containers only; it does not act as the multi-column "
 "`column-gap`"
 
-#: src/supports/properties.md:188
+#: src/supports/properties.md:193
 msgid "`order`"
 msgstr "`order`"
 
-#: src/supports/properties.md:188
+#: src/supports/properties.md:193
 msgid "taffy 0.12系が未対応のため"
 msgstr "The taffy 0.12 series does not support it"
 
-#: src/supports/properties.md:189
+#: src/supports/properties.md:194
 msgid "`place-content` / `place-items` / `place-self`(ショートハンド)"
 msgstr "`place-content`, `place-items`, `place-self`, the shorthands"
 
-#: src/supports/properties.md:189
+#: src/supports/properties.md:194
 msgid "未実装。個別のロングハンドを使う"
 msgstr "Not implemented. Use the individual longhands"
 
-#: src/supports/properties.md:190 src/supports/properties.md:219
+#: src/supports/properties.md:195 src/supports/properties.md:224
 msgid "`justify-items` / `justify-self`"
 msgstr "`justify-items`, `justify-self`"
 
-#: src/supports/properties.md:190 src/migration/wicked-pdf.md:72
+#: src/supports/properties.md:195 src/migration/wicked-pdf.md:72
 #: src/migration/wicked-pdf.md:73 src/migration/wicked-pdf.md:74
 #: src/migration/wicked-pdf.md:75 src/migration/wicked-pdf.md:76
 #: src/migration/wicked-pdf.md:77
 msgid "—"
 msgstr "—"
 
-#: src/supports/properties.md:190
+#: src/supports/properties.md:195
 msgid "flexアイテムには適用されない(下記)"
 msgstr "They do not apply to flex items; see below"
 
-#: src/supports/properties.md:192
+#: src/supports/properties.md:197
 msgid "`justify-items`/`justify-self`がflexで効かないのは仕様"
 msgstr ""
 "`justify-items` and `justify-self` having no effect in flex is by design"
 
-#: src/supports/properties.md:194
+#: src/supports/properties.md:199
 msgid ""
 "CSS Box Alignmentでは`justify-items`/`justify-self`はGrid・ブロックレイアウト"
 "用のプロパティで、flexアイテムには適用されない(主軸方向のアイテム個別の配置は"
@@ -5300,7 +5314,7 @@ msgstr ""
 "which layout is delegated, only the Grid algorithm looks at them; the "
 "flexbox algorithm never does."
 
-#: src/supports/properties.md:198
+#: src/supports/properties.md:203
 msgid ""
 "したがってこのエンジンでパースに対応しても見た目は変わらないため、意図的に実"
 "装していない。 flexで特定のアイテムだけを寄せたい場合は`margin: auto`を使う"
@@ -5310,21 +5324,21 @@ msgstr ""
 "deliberately left unimplemented. To push a particular flex item to one side, "
 "use `margin: auto`, which is supported:"
 
-#: src/supports/properties.md:202
+#: src/supports/properties.md:207
 msgid "/* justify-self: end 相当(主軸の終端へ) */"
 msgstr ""
 "/* the equivalent of justify-self: end, pushing to the end of the main axis "
 "*/"
 
-#: src/supports/properties.md:203
+#: src/supports/properties.md:208
 msgid "/* justify-self: center 相当 */"
 msgstr "/* the equivalent of justify-self: center */"
 
-#: src/supports/properties.md:206
+#: src/supports/properties.md:211
 msgid "Grid"
 msgstr "Grid"
 
-#: src/supports/properties.md:208
+#: src/supports/properties.md:213
 msgid ""
 "`display: grid`のレイアウトはFlexboxと同じくtaffyへ委譲する。 Flexboxと違い、"
 "1ページに収まらないグリッドは行単位でページ分割される(テーブルと同じ方針。複"
@@ -5335,11 +5349,11 @@ msgstr ""
 "same approach as tables; no break is taken at a boundary crossed by an item "
 "that spans several rows."
 
-#: src/supports/properties.md:213
+#: src/supports/properties.md:218
 msgid "`grid-template-columns` / `grid-template-rows`"
 msgstr "`grid-template-columns`, `grid-template-rows`"
 
-#: src/supports/properties.md:213
+#: src/supports/properties.md:218
 msgid ""
 "`none`/`<length>`/`<percentage>`/`fr`/`auto`/`min-content`/`max-content`/"
 "`minmax()`/`fit-content()`/`repeat(<整数>\\|auto-fill\\|auto-fit)`/"
@@ -5349,11 +5363,11 @@ msgstr ""
 "content`, `minmax()`, `fit-content()`, `repeat(<integer>\\|auto-fill\\|auto-"
 "fit)`, and `[name]` for line names. `calc()` is not supported in a track size"
 
-#: src/supports/properties.md:214
+#: src/supports/properties.md:219
 msgid "`grid-template-areas`"
 msgstr "`grid-template-areas`"
 
-#: src/supports/properties.md:214
+#: src/supports/properties.md:219
 msgid ""
 "文字列マトリクス。列数の不一致・非矩形のエリアは不正な値として宣言ごと無視す"
 "る(仕様通り)。`.`は名前なしセル"
@@ -5362,43 +5376,43 @@ msgstr ""
 "makes the value invalid and the whole declaration is ignored, as the "
 "specification says. A `.` is an unnamed cell"
 
-#: src/supports/properties.md:215
+#: src/supports/properties.md:220
 msgid "`grid-auto-columns` / `grid-auto-rows`"
 msgstr "`grid-auto-columns`, `grid-auto-rows`"
 
-#: src/supports/properties.md:215
+#: src/supports/properties.md:220
 msgid "`<track-size>+`"
 msgstr "`<track-size>+`"
 
-#: src/supports/properties.md:216
+#: src/supports/properties.md:221
 msgid "`grid-auto-flow`"
 msgstr "`grid-auto-flow`"
 
-#: src/supports/properties.md:216
+#: src/supports/properties.md:221
 msgid "`row`/`column`/`dense`(併記可)"
 msgstr "`row`, `column`, and `dense`, which may be combined"
 
-#: src/supports/properties.md:217
+#: src/supports/properties.md:222
 msgid "`grid-row-start` / `-end` / `grid-column-start` / `-end`"
 msgstr "`grid-row-start`, `-end`, `grid-column-start`, `-end`"
 
-#: src/supports/properties.md:217
+#: src/supports/properties.md:222
 msgid ""
 "`auto`/`<integer>`/`span <integer>`/`<custom-ident>`/`span <custom-ident>`"
 msgstr ""
 "`auto`, `<integer>`, `span <integer>`, `<custom-ident>`, and `span <custom-"
 "ident>`"
 
-#: src/supports/properties.md:218
+#: src/supports/properties.md:223
 msgid "`grid-row` / `grid-column` / `grid-area`"
 msgstr "`grid-row`, `grid-column`, `grid-area`"
 
-#: src/supports/properties.md:218
+#: src/supports/properties.md:223
 msgid ""
 "`/`区切りのショートハンド。`grid-area: <name>`で名前付きエリアを指定できる"
 msgstr "The shorthands, separated by `/`. `grid-area: <name>` names an area"
 
-#: src/supports/properties.md:219
+#: src/supports/properties.md:224
 msgid ""
 "Gridでのみ意味を持つ(flexアイテムには適用されない、[上記](#justify-"
 "itemsjustify-selfがflexで効かないのは仕様))"
@@ -5406,20 +5420,20 @@ msgstr ""
 "Meaningful in Grid only; they do not apply to flex items, as [noted above]"
 "(#justify-items-and-justify-self-having-no-effect-in-flex-is-by-design)"
 
-#: src/supports/properties.md:220
+#: src/supports/properties.md:225
 msgid ""
 "`align-items` / `align-self` / `justify-content` / `align-content` / `gap`"
 msgstr "`align-items`, `align-self`, `justify-content`, `align-content`, `gap`"
 
-#: src/supports/properties.md:220
+#: src/supports/properties.md:225
 msgid "Flexboxと共有(値の範囲は[Flexbox](#flexbox)節を参照)"
 msgstr "Ranges"
 
-#: src/supports/properties.md:221
+#: src/supports/properties.md:226
 msgid "`grid` / `grid-template`(ショートハンド)"
 msgstr "`grid`, `grid-template`, the shorthands"
 
-#: src/supports/properties.md:221
+#: src/supports/properties.md:226
 msgid ""
 "個別のロングハンドを使う。トラック定義とエリア定義を1つの構文へ詰め込む複雑な"
 "文法のため非対応"
@@ -5427,19 +5441,19 @@ msgstr ""
 "Use the individual longhands. These pack track and area definitions into one "
 "syntax, and that grammar is too involved to support"
 
-#: src/supports/properties.md:222
+#: src/supports/properties.md:227
 msgid "`display: inline-grid`"
 msgstr "`display: inline-grid`"
 
-#: src/supports/properties.md:222
+#: src/supports/properties.md:227
 msgid "`inline-flex`と同じ理由で非対応"
 msgstr "Not supported, for the same reason as `inline-flex`"
 
-#: src/supports/properties.md:223
+#: src/supports/properties.md:228
 msgid "subgrid / masonry"
 msgstr "subgrid, masonry"
 
-#: src/supports/properties.md:225
+#: src/supports/properties.md:230
 msgid ""
 "`auto`トラックだけで構成したグリッドにコンテナ幅の指定がある場合、余った幅は"
 "`auto`トラックへ配分されますが、その配分比率はCSSの規定(`auto`トラックへ均等)"
@@ -5450,29 +5464,29 @@ msgstr ""
 "proportion CSS prescribes (an equal share to each `auto` track). Use `fr` or "
 "a length if the column widths need to be exact."
 
-#: src/supports/properties.md:228
+#: src/supports/properties.md:233
 msgid "置換要素(画像)"
 msgstr "Replaced elements: images"
 
-#: src/supports/properties.md:232
+#: src/supports/properties.md:237
 msgid "`object-fit`"
 msgstr "`object-fit`"
 
-#: src/supports/properties.md:232
+#: src/supports/properties.md:237
 msgid "`fill`/`contain`/`cover`/`none`/`scale-down`。`<img>`にのみ意味を持つ"
 msgstr ""
 "`fill`, `contain`, `cover`, `none`, and `scale-down`. Meaningful on `<img>` "
 "only"
 
-#: src/supports/properties.md:233
+#: src/supports/properties.md:238
 msgid "`object-position`"
 msgstr "`object-position`"
 
-#: src/supports/properties.md:233
+#: src/supports/properties.md:238
 msgid "`background-position`と同じ値文法。初期値`50% 50%`"
 msgstr "The same syntax as `background-position`. `50% 50%` by default"
 
-#: src/supports/properties.md:235
+#: src/supports/properties.md:240
 msgid ""
 "`<img>`はインライン配置・`width`/`height`属性/CSSによるサイズ指定に対応。 対"
 "応フォーマットはPNG/JPEG/WebP。 CSSで`width`/`height`の片方だけを指定した場合"
@@ -5483,11 +5497,11 @@ msgstr ""
 "When CSS gives only one of `width` and `height`, the other is derived from "
 "the intrinsic aspect ratio (see [`aspect-ratio`](#box-model))."
 
-#: src/supports/properties.md:239
+#: src/supports/properties.md:244
 msgid "非対応プロパティ一覧"
 msgstr "List of unsupported properties"
 
-#: src/supports/properties.md:241
+#: src/supports/properties.md:246
 msgid ""
 "以下は宣言ごと無視される(パースエラー)。 実装が無いだけで、意図的に永久除外と"
 "決めたものだけではない。 カテゴリ表の`❌`行も参照。"
@@ -5496,24 +5510,25 @@ msgstr ""
 "are simply unimplemented, not all deliberately ruled out forever. See the "
 "`❌` rows in the tables above as well."
 
-#: src/supports/properties.md:245
+#: src/supports/properties.md:250
 msgid ""
-"ショートハンド: `font`/`place-content`/`place-items`/`place-self`/"
-"`text-decoration`の色・線種部分"
+"ショートハンド: `font`/`place-content`/`place-items`/`place-self`/`text-"
+"decoration`の色・線種部分"
 msgstr ""
-"Shorthands: `font`, `place-content`, `place-items`, `place-self`, "
-"and the colour and line-style parts of `text-decoration`"
+"Shorthands: `font`, `place-content`, `place-items`, `place-self`, and the "
+"colour and line-style parts of `text-decoration`"
 
-#: src/supports/properties.md:246
+#: src/supports/properties.md:251
 msgid ""
 "論理プロパティのうち寸法系: `inline-size`/`block-size`/`min-inline-size`/"
-"`max-block-size`等(`margin`/`padding`/`inset`/`border`の論理プロパティは対応済み)"
+"`max-block-size`等(`margin`/`padding`/`inset`/`border`の論理プロパティは対応"
+"済み)"
 msgstr ""
-"The sizing logical properties: `inline-size`, `block-size`, `min-inline-size`, "
-"`max-block-size` and so on (the `margin`, `padding`, `inset` and `border` "
-"logical properties are supported)"
+"The sizing logical properties: `inline-size`, `block-size`, `min-inline-"
+"size`, `max-block-size` and so on (the `margin`, `padding`, `inset` and "
+"`border` logical properties are supported)"
 
-#: src/supports/properties.md:247
+#: src/supports/properties.md:252
 msgid ""
 "書字方向: `direction`/`unicode-bidi`/`writing-mode`/`text-orientation`/`text-"
 "combine-upright`"
@@ -5521,7 +5536,7 @@ msgstr ""
 "Writing direction: `direction`, `unicode-bidi`, `writing-mode`, `text-"
 "orientation`, `text-combine-upright`"
 
-#: src/supports/properties.md:248
+#: src/supports/properties.md:253
 msgid ""
 "テキスト詳細: `text-decoration-color`/`-style`/`-thickness`/`text-underline-"
 "offset`/`text-emphasis-skip`/`tab-size`/`ruby-*`/`text-justify`/`line-break`"
@@ -5530,7 +5545,7 @@ msgstr ""
 "underline-offset`, `text-emphasis-skip`, `tab-size`, `ruby-*`, `text-"
 "justify`, `line-break`"
 
-#: src/supports/properties.md:249
+#: src/supports/properties.md:254
 msgid ""
 "フォント詳細: `font-variant`/`font-stretch`/`font-feature-settings`/`font-"
 "variation-settings`/`font-kerning`/`font-display`"
@@ -5538,7 +5553,7 @@ msgstr ""
 "Font details: `font-variant`, `font-stretch`, `font-feature-settings`, `font-"
 "variation-settings`, `font-kerning`, `font-display`"
 
-#: src/supports/properties.md:250
+#: src/supports/properties.md:255
 msgid ""
 "多段組み: `columns`/`column-count`/`column-width`/`column-rule`/`column-"
 "span`/`column-fill`"
@@ -5546,7 +5561,7 @@ msgstr ""
 "Multi-column: `columns`, `column-count`, `column-width`, `column-rule`, "
 "`column-span`, `column-fill`"
 
-#: src/supports/properties.md:251
+#: src/supports/properties.md:256
 msgid ""
 "視覚効果: `filter`/`backdrop-filter`/`mix-blend-mode`/`background-blend-"
 "mode`/`clip`/`clip-path`/`mask`/`isolation`"
@@ -5554,7 +5569,7 @@ msgstr ""
 "Visual effects: `filter`, `backdrop-filter`, `mix-blend-mode`, `background-"
 "blend-mode`, `clip`, `clip-path`, `mask`, `isolation`"
 
-#: src/supports/properties.md:252
+#: src/supports/properties.md:257
 msgid ""
 "3D/アニメーション: `perspective`/`transform-style`/`backface-visibility`/"
 "`translate`/`rotate`/`scale`(個別プロパティ版)/`transition-*`/`animation-*`/"
@@ -5564,7 +5579,7 @@ msgstr ""
 "the individual `translate`, `rotate`, and `scale` properties, `transition-"
 "*`, `animation-*`, `will-change`"
 
-#: src/supports/properties.md:253
+#: src/supports/properties.md:258
 msgid ""
 "枠線・背景の拡張: `border-image-*`/`background-clip`/`background-origin`/"
 "`outline-offset`"
@@ -5572,7 +5587,7 @@ msgstr ""
 "Border and background extensions: `border-image-*`, `background-clip`, "
 "`background-origin`, `outline-offset`"
 
-#: src/supports/properties.md:254
+#: src/supports/properties.md:259
 msgid ""
 "オーバーフロー: `overflow-x`/`overflow-y`/`resize`/`scroll-*`/`overscroll-"
 "behavior`"
@@ -5580,7 +5595,7 @@ msgstr ""
 "Overflow: `overflow-x`, `overflow-y`, `resize`, `scroll-*`, `overscroll-"
 "behavior`"
 
-#: src/supports/properties.md:255
+#: src/supports/properties.md:260
 msgid ""
 "UI/対話: `cursor`/`pointer-events`/`user-select`/`caret-color`/`accent-"
 "color`/`appearance`"
@@ -5588,7 +5603,7 @@ msgstr ""
 "UI and interaction: `cursor`, `pointer-events`, `user-select`, `caret-"
 "color`, `accent-color`, `appearance`"
 
-#: src/supports/properties.md:256
+#: src/supports/properties.md:261
 msgid ""
 "その他: `all`/`content-visibility`/`counter-set`/`page`(名前付きページ)/"
 "`speak`等の音声メディア系/`zoom`"
@@ -5673,35 +5688,52 @@ msgid "セレクタリスト(`,`)"
 msgstr "Selector lists (`,`)"
 
 #: src/supports/selectors.md:23
+msgid "ネスト(`.a { .b { } }` / `& .b` / `&.b` / `> .b`)"
+msgstr "Nesting (`.a { .b { } }`, `& .b`, `&.b`, `> .b`)"
+
+#: src/supports/selectors.md:23
+msgid ""
+"CSS Nesting。`&`を省いたセレクタは`& .b`、先頭がコンビネータのものは`& > .b`"
+"として扱う。`&`は`:is(親)`に置き換わるので詳細度は親のうち最も高いものにな"
+"る。ネストしたルールの後ろに書いた宣言は、そのルールより後ろの順序でカスケー"
+"ドに参加する。ネストした`@media`等のat-ruleは非対応(ブロックごと無視)"
+msgstr ""
+"CSS Nesting. A selector without `&` is treated as `& .b`, and one starting "
+"with a combinator as `& > .b`. `&` is replaced by `:is(parent)`, so the "
+"specificity becomes that of the most specific parent selector. Declarations "
+"written after a nested rule join the cascade after that rule. Nested at-"
+"rules such as `@media` are not supported (the whole block is ignored)"
+
+#: src/supports/selectors.md:24
 msgid "名前空間(`ns\\|E`)"
 msgstr "Namespaces (`ns\\|E`)"
 
-#: src/supports/selectors.md:23
+#: src/supports/selectors.md:24
 msgid "`@namespace`自体が非対応"
 msgstr "`@namespace` itself is not supported"
 
-#: src/supports/selectors.md:25 src/supports/selectors.md:27
+#: src/supports/selectors.md:26 src/supports/selectors.md:28
 msgid "擬似クラス"
 msgstr "Pseudo-classes"
 
-#: src/supports/selectors.md:29
+#: src/supports/selectors.md:30
 msgid "`:root`"
 msgstr "`:root`"
 
-#: src/supports/selectors.md:30
+#: src/supports/selectors.md:31
 msgid "`:first-child` / `:last-child` / `:only-child`"
 msgstr "`:first-child`, `:last-child`, `:only-child`"
 
-#: src/supports/selectors.md:31
+#: src/supports/selectors.md:32
 msgid "`:nth-child()` / `:nth-last-child()`"
 msgstr "`:nth-child()`, `:nth-last-child()`"
 
-#: src/supports/selectors.md:31
+#: src/supports/selectors.md:32
 msgid "ストリーミングモードでは`:nth-last-child()`の結果が変わる(下記参照)"
 msgstr ""
 "In streaming mode `:nth-last-child()` gives a different result; see below"
 
-#: src/supports/selectors.md:32
+#: src/supports/selectors.md:33
 msgid ""
 "`:first-of-type` / `:last-of-type` / `:only-of-type` / `:nth-of-type()` / `:"
 "nth-last-of-type()`"
@@ -5709,7 +5741,7 @@ msgstr ""
 "`:first-of-type`, `:last-of-type`, `:only-of-type`, `:nth-of-type()`, `:nth-"
 "last-of-type()`"
 
-#: src/supports/selectors.md:32
+#: src/supports/selectors.md:33
 msgid ""
 "ストリーミングモードでは`:first-of-type`/`:nth-of-type()`以外の結果が変わる"
 "(下記参照)"
@@ -5717,19 +5749,19 @@ msgstr ""
 "In streaming mode every one of these except `:first-of-type` and `:nth-of-"
 "type()` gives a different result; see below"
 
-#: src/supports/selectors.md:33
+#: src/supports/selectors.md:34
 msgid "`:empty`"
 msgstr "`:empty`"
 
-#: src/supports/selectors.md:34
+#: src/supports/selectors.md:35
 msgid "`:not()`"
 msgstr "`:not()`"
 
-#: src/supports/selectors.md:35
+#: src/supports/selectors.md:36
 msgid "`:is()` / `:where()`"
 msgstr "`:is()`, `:where()`"
 
-#: src/supports/selectors.md:35
+#: src/supports/selectors.md:36
 msgid ""
 "引数リストは寛容(未対応のセレクタが混ざっていてもその項だけを捨てる)。詳細度"
 "は`:is()`が引数のうち最も高いもの、`:where()`は常に0"
@@ -5738,11 +5770,11 @@ msgstr ""
 "drops only that argument. For specificity, `:is()` counts as its most "
 "specific argument and `:where()` always counts as zero"
 
-#: src/supports/selectors.md:36
+#: src/supports/selectors.md:37
 msgid "`:has()`"
 msgstr "`:has()`"
 
-#: src/supports/selectors.md:36
+#: src/supports/selectors.md:37
 msgid ""
 "子孫・`>`・`+`・`~`のいずれも書ける。詳細度は`:is()`と同じ規則。入れ子(`:"
 "has()`の中の`:has()`)と擬似要素は仕様どおり書けない。ストリーミングモードでは"
@@ -5753,7 +5785,7 @@ msgstr ""
 "are not allowed, per the spec. In streaming mode `:has(~ ...)` never matches "
 "(see below)"
 
-#: src/supports/selectors.md:37
+#: src/supports/selectors.md:38
 msgid ""
 "`:hover` / `:active` / `:focus` / `:focus-within` / `:focus-visible` / `:"
 "target` / `:enabled` / `:disabled` / `:checked` / `:visited`"
@@ -5761,7 +5793,7 @@ msgstr ""
 "`:hover`, `:active`, `:focus`, `:focus-within`, `:focus-visible`, `:target`, "
 "`:enabled`, `:disabled`, `:checked`, `:visited`"
 
-#: src/supports/selectors.md:37
+#: src/supports/selectors.md:38
 msgid ""
 "パースは通るが常に非マッチ。対話状態を持たない静的なPDF出力では意味を持たない"
 "ため"
@@ -5769,15 +5801,15 @@ msgstr ""
 "They parse but never match, since a static PDF has no interaction state for "
 "them to describe"
 
-#: src/supports/selectors.md:38
+#: src/supports/selectors.md:39
 msgid "`:link` / `:any-link`"
 msgstr "`:link`, `:any-link`"
 
-#: src/supports/selectors.md:38
+#: src/supports/selectors.md:39
 msgid "`href`を持つ`<a>`にマッチする"
 msgstr "Matches an `<a>` that has an `href`"
 
-#: src/supports/selectors.md:40
+#: src/supports/selectors.md:41
 msgid ""
 "非対応の擬似要素(`::first-line`等)がセレクタに含まれるとルール全体が捨てられ"
 "る。 一方`:hover`のようにパースが通るものは、ルールとしては生き残った上でマッ"
@@ -5790,15 +5822,15 @@ msgstr ""
 "where()` is the one exception: an unsupported argument is dropped on its own "
 "and the rule survives."
 
-#: src/supports/selectors.md:44 src/supports/selectors.md:46
+#: src/supports/selectors.md:45 src/supports/selectors.md:47
 msgid "擬似要素"
 msgstr "Pseudo-elements"
 
-#: src/supports/selectors.md:48
+#: src/supports/selectors.md:49
 msgid "`::before` / `::after`"
 msgstr "`::before`, `::after`"
 
-#: src/supports/selectors.md:48
+#: src/supports/selectors.md:49
 msgid ""
 "`content`による生成テキストのみ。ホスト要素の計算スタイルをそのまま流用して描"
 "画し、擬似要素専用のボックススタイル(margin/padding/display等)は持たない。ブ"
@@ -5809,11 +5841,11 @@ msgstr ""
 "display, and the like do not apply. Nothing is generated on an element that "
 "has block children"
 
-#: src/supports/selectors.md:49
+#: src/supports/selectors.md:50
 msgid "`::first-letter`"
 msgstr "`::first-letter`"
 
-#: src/supports/selectors.md:49
+#: src/supports/selectors.md:50
 msgid ""
 "`font-family`/`font-size`/`font-weight`/`font-style`/`color`/`text-"
 "decoration-line`/`text-transform`のみ上書きできる(`float`・box model系は非対"
@@ -5823,51 +5855,51 @@ msgstr ""
 "decoration-line`, and `text-transform` can be overridden; `float` and the "
 "box model properties are not supported"
 
-#: src/supports/selectors.md:50
+#: src/supports/selectors.md:51
 msgid "`::first-line`"
 msgstr "`::first-line`"
 
-#: src/supports/selectors.md:50 src/supports/selectors.md:51
+#: src/supports/selectors.md:51 src/supports/selectors.md:52
 msgid "パースエラー"
 msgstr "A parse error"
 
-#: src/supports/selectors.md:51
+#: src/supports/selectors.md:52
 msgid "`::marker` / `::selection` / `::placeholder`"
 msgstr "`::marker`, `::selection`, `::placeholder`"
 
-#: src/supports/selectors.md:53
+#: src/supports/selectors.md:54
 msgid "値・単位・関数"
 msgstr "Values, units, and functions"
 
-#: src/supports/selectors.md:55
+#: src/supports/selectors.md:56
 msgid "長さ"
 msgstr "Lengths"
 
-#: src/supports/selectors.md:57
+#: src/supports/selectors.md:58
 msgid "単位"
 msgstr "Unit"
 
-#: src/supports/selectors.md:59
+#: src/supports/selectors.md:60
 msgid "`px` / `em` / `rem`"
 msgstr "`px`, `em`, `rem`"
 
-#: src/supports/selectors.md:60
+#: src/supports/selectors.md:61
 msgid "`mm` / `cm` / `in` / `pt` / `pc` / `Q`"
 msgstr "`mm`, `cm`, `in`, `pt`, `pc`, `Q`"
 
-#: src/supports/selectors.md:61
+#: src/supports/selectors.md:62
 msgid "`%`(パーセンテージを取るプロパティで)"
 msgstr "`%`, on properties that take a percentage"
 
-#: src/supports/selectors.md:62
+#: src/supports/selectors.md:63
 msgid "単位なしの`0`"
 msgstr "A bare `0`"
 
-#: src/supports/selectors.md:63
+#: src/supports/selectors.md:64
 msgid "`ex` / `ch` / `vw` / `vh` / `vmin` / `vmax` / `lh`"
 msgstr "`ex`, `ch`, `vw`, `vh`, `vmin`, `vmax`, `lh`"
 
-#: src/supports/selectors.md:65
+#: src/supports/selectors.md:66
 msgid ""
 "絶対単位は1インチ = 96pxとして解釈する(`10mm`は37.795px)。 印刷向けに寸法を実"
 "寸で書けるので、`@page { size: 210mm 297mm; margin: 15mm; }`のような指定がそ"
@@ -5877,7 +5909,7 @@ msgstr ""
 "Physical dimensions can be written directly for print, which means `@page "
 "{ size: 210mm 297mm; margin: 15mm; }` works as written."
 
-#: src/supports/selectors.md:68
+#: src/supports/selectors.md:69
 msgid ""
 "`@page`の`size`だけは例外的にページサイズのキーワード(`a4`/`letter`等)と"
 "`landscape`/`portrait`を受け付ける。"
@@ -5885,40 +5917,40 @@ msgstr ""
 "As an exception, `size` in `@page` also accepts page size keywords such as "
 "`a4` and `letter`, and `landscape` or `portrait`."
 
-#: src/supports/selectors.md:70
+#: src/supports/selectors.md:71
 msgid "角度(`transform`専用)"
 msgstr "Angles, used only by `transform`"
 
-#: src/supports/selectors.md:72
+#: src/supports/selectors.md:73
 msgid "`deg` / `rad` / `grad` / `turn`、および単位なしの`0`に対応 ✅。"
 msgstr "`deg`, `rad`, `grad`, and `turn` are supported, as is a bare `0` ✅."
 
-#: src/supports/selectors.md:74 src/supports/selectors.md:76
+#: src/supports/selectors.md:75 src/supports/selectors.md:77
 msgid "関数"
 msgstr "Function"
 
-#: src/supports/selectors.md:78
+#: src/supports/selectors.md:79
 msgid "`calc()`"
 msgstr "`calc()`"
 
-#: src/supports/selectors.md:78
-msgid ""
-"`+`/`-`/`*`/`/`と括弧のネスト。項に使えるのは長さ(絶対単位・`em`/`rem`)・"
-"`%`・数値のみ。長さ・パーセンテージを取るプロパティ全般で使える"
-msgstr ""
-"`+`, `-`, `*`, `/`, and nested parentheses. The terms may be lengths, "
-"whether absolute units or `em` and `rem`, percentages, and numbers. It works "
-"on any property that takes a length or a percentage"
-
 #: src/supports/selectors.md:79
+msgid ""
+"`+`/`-`/`*`/`/`と括弧・`calc()`のネスト。項に使えるのは長さ(絶対単位・`em`/"
+"`rem`)・`%`・数値のみ。長さ・パーセンテージを取るプロパティ全般で使える"
+msgstr ""
+"`+`, `-`, `*`, `/`, and nesting with parentheses or `calc()`. The terms may "
+"be lengths, whether absolute units or `em` and `rem`, percentages, and "
+"numbers. It works on any property that takes a length or a percentage"
+
+#: src/supports/selectors.md:80
 msgid "`min()` / `max()` / `clamp()`"
 msgstr "`min()`, `max()`, `clamp()`"
 
-#: src/supports/selectors.md:80
+#: src/supports/selectors.md:81
 msgid "`var()`"
 msgstr "`var()`"
 
-#: src/supports/selectors.md:80
+#: src/supports/selectors.md:81
 msgid ""
 "カスタムプロパティ(`--foo`)をパース前のテキスト置換で解決する。フォールバック"
 "(`var(--x, 10px)`)・カスタムプロパティ同士の参照に対応。カスケードや継承には"
@@ -5931,11 +5963,11 @@ msgstr ""
 "or inheritance; it is a simple resolution in which the last declaration in "
 "the document wins"
 
-#: src/supports/selectors.md:81
+#: src/supports/selectors.md:82
 msgid "`url()`"
 msgstr "`url()`"
 
-#: src/supports/selectors.md:81
+#: src/supports/selectors.md:82
 msgid ""
 "`background-image`/`list-style-image`/`@font-face`の`src`/`@import`。相対URL"
 "は`<base href>`または入力元を基準に解決する"
@@ -5944,91 +5976,91 @@ msgstr ""
 "`@import`. Relative URLs are resolved against `<base href>` or the location "
 "of the input"
 
-#: src/supports/selectors.md:82
+#: src/supports/selectors.md:83
 msgid "`attr()`"
 msgstr "`attr()`"
 
-#: src/supports/selectors.md:82
+#: src/supports/selectors.md:83
 msgid "`content`の中でのみ使える"
 msgstr "Only inside `content`"
 
-#: src/supports/selectors.md:83
+#: src/supports/selectors.md:84
 msgid "`counter()` / `counters()`"
 msgstr "`counter()`, `counters()`"
 
-#: src/supports/selectors.md:83
+#: src/supports/selectors.md:84
 msgid "`content`の中。第2引数のスタイルは`list-style-type`の値集合"
 msgstr ""
 "Inside `content`. The style in the second argument comes from the `list-"
 "style-type` values"
 
-#: src/supports/selectors.md:84
+#: src/supports/selectors.md:85
 msgid "`linear-gradient()`等のグラデーション"
 msgstr "Gradients such as `linear-gradient()`"
 
-#: src/supports/selectors.md:85
+#: src/supports/selectors.md:86
 msgid "`env()` / `image-set()` / `element()`"
 msgstr "`env()`, `image-set()`, `element()`"
 
-#: src/supports/selectors.md:87
+#: src/supports/selectors.md:88
 msgid "色"
 msgstr "Colours"
 
-#: src/supports/selectors.md:89
+#: src/supports/selectors.md:90
 msgid "記法"
 msgstr "Notation"
 
-#: src/supports/selectors.md:91
+#: src/supports/selectors.md:92
 msgid "名前付き色(`red`等のCSS色キーワード)"
 msgstr "Named colours, the CSS colour keywords such as `red`"
 
-#: src/supports/selectors.md:92
+#: src/supports/selectors.md:93
 msgid "`#rgb` / `#rgba` / `#rrggbb` / `#rrggbbaa`"
 msgstr "`#rgb`, `#rgba`, `#rrggbb`, `#rrggbbaa`"
 
-#: src/supports/selectors.md:93
+#: src/supports/selectors.md:94
 msgid "`rgb()` / `rgba()`(カンマ区切り・スペース区切りとも)"
 msgstr "`rgb()`, `rgba()`, both comma separated and space separated"
 
-#: src/supports/selectors.md:94
+#: src/supports/selectors.md:95
 msgid "`hsl()` / `hsla()` / `hwb()`"
 msgstr "`hsl()`, `hsla()`, `hwb()`"
 
-#: src/supports/selectors.md:95
+#: src/supports/selectors.md:96
 msgid "`lab()` / `lch()` / `oklab()` / `oklch()`"
 msgstr "`lab()`, `lch()`, `oklab()`, `oklch()`"
 
-#: src/supports/selectors.md:95
+#: src/supports/selectors.md:96
 msgid "✅ (sRGBへ変換して描画)"
 msgstr "✅ (converted to sRGB for drawing)"
 
-#: src/supports/selectors.md:96
+#: src/supports/selectors.md:97
 msgid "`currentcolor` / `transparent`"
 msgstr "`currentcolor`, `transparent`"
 
-#: src/supports/selectors.md:97
+#: src/supports/selectors.md:98
 msgid "`color()`(`color(display-p3 ...)`等)"
 msgstr "`color()`, such as `color(display-p3 ...)`"
 
-#: src/supports/selectors.md:98 src/supports/selectors.md:103
+#: src/supports/selectors.md:99 src/supports/selectors.md:104
 msgid "`color-mix()`"
 msgstr "`color-mix()`"
 
-#: src/supports/selectors.md:98
+#: src/supports/selectors.md:99
 msgid "⚠️ (下記)"
 msgstr "⚠️ (see below)"
 
-#: src/supports/selectors.md:99
+#: src/supports/selectors.md:100
 msgid "相対色構文(`rgb(from ...)`)"
 msgstr "The relative colour syntax `rgb(from ...)`"
 
-#: src/supports/selectors.md:101
+#: src/supports/selectors.md:102
 msgid "アルファ付きの色は塗り・背景ともPDFのExtGStateで透過描画する。"
 msgstr ""
 "Colours with alpha are drawn through a PDF ExtGState, for both fills and "
 "backgrounds."
 
-#: src/supports/selectors.md:105
+#: src/supports/selectors.md:106
 msgid ""
 "`color-mix(in <色空間> [<色相の回し方> hue]?, <色> <割合>?, <色> <割合>?)`に"
 "対応する。 割合の正規化(合計が100%を超えるときは比率だけが効き、満たないとき"
@@ -6040,7 +6072,7 @@ msgstr ""
 "result becomes transparent by the shortfall — and alpha is premultiplied "
 "before interpolating."
 
-#: src/supports/selectors.md:108
+#: src/supports/selectors.md:109
 msgid ""
 "色空間: `srgb` / `srgb-linear` / `lab` / `oklab` / `xyz`(`xyz-d65`) / "
 "`hsl` / `hwb` / `lch` / `oklch`"
@@ -6048,21 +6080,22 @@ msgstr ""
 "Colour spaces: `srgb`, `srgb-linear`, `lab`, `oklab`, `xyz` (`xyz-d65`), "
 "`hsl`, `hwb`, `lch` and `oklch`"
 
-#: src/supports/selectors.md:109
+#: src/supports/selectors.md:110
 msgid "色相の回し方: `shorter`(既定) / `longer` / `increasing` / `decreasing`"
 msgstr ""
 "Hue interpolation: `shorter` (the default), `longer`, `increasing` and "
 "`decreasing`"
 
-#: src/supports/selectors.md:110
+#: src/supports/selectors.md:111
 msgid "入れ子にできる(深さ16まで)"
 msgstr "It can be nested (up to 16 levels)"
 
-#: src/supports/selectors.md:112
+#: src/supports/selectors.md:113
 msgid "以下は非対応で、書くとその宣言だけが無視される。"
-msgstr "The following are not supported; using one drops that declaration alone."
+msgstr ""
+"The following are not supported; using one drops that declaration alone."
 
-#: src/supports/selectors.md:114
+#: src/supports/selectors.md:115
 msgid ""
 "`display-p3` / `a98-rgb` / `prophoto-rgb` / `rec2020`。出力先がPDFのDeviceRGB"
 "なので、受け付けてもsRGBへ丸められるだけで指定した意味にならない"
@@ -6071,7 +6104,7 @@ msgstr ""
 "DeviceRGB, so accepting them would only round the result back to sRGB and "
 "the request would not mean what it says"
 
-#: src/supports/selectors.md:115
+#: src/supports/selectors.md:116
 msgid ""
 "オペランドの`currentcolor`。`currentcolor`はカスケードの後(その要素の`color`"
 "が決まってから)解決するのに対し、混色はパース時に済ませるため、この時点では値"
@@ -6081,19 +6114,19 @@ msgstr ""
 "once the element's own `color` is known, whereas the mixing happens at parse "
 "time, so the value is not available yet"
 
-#: src/supports/selectors.md:116
+#: src/supports/selectors.md:117
 msgid "`xyz-d50`(白色点の変換が要るため)"
 msgstr "`xyz-d50` (it would need a white point conversion)"
 
-#: src/supports/selectors.md:118 src/supports/selectors.md:120
+#: src/supports/selectors.md:119 src/supports/selectors.md:121
 msgid "at-rule"
 msgstr "At-rules"
 
-#: src/supports/selectors.md:122
+#: src/supports/selectors.md:123
 msgid "`@media`"
 msgstr "`@media`"
 
-#: src/supports/selectors.md:122
+#: src/supports/selectors.md:123
 msgid ""
 "メディアタイプのみを評価する。`screen`(および`not screen`以外の否定)はブロッ"
 "クごと無視し、`print`/`all`/タイプ省略は適用する。`(min-width: ...)`のような"
@@ -6104,11 +6137,11 @@ msgstr ""
 "type are applied. Feature queries such as `(min-width: ...)` are skipped "
 "without being evaluated, so the contents apply as long as the type matches"
 
-#: src/supports/selectors.md:123
+#: src/supports/selectors.md:124
 msgid "`@page`"
 msgstr "`@page`"
 
-#: src/supports/selectors.md:123
+#: src/supports/selectors.md:124
 msgid ""
 "`size`(キーワード/`<length>{1,2}`/`landscape`/`portrait`)と`margin`系に対応。"
 "`:first`/`:left`/`:right`擬似クラス単体に対応し、名前付きページ(`@page "
@@ -6119,11 +6152,11 @@ msgstr ""
 "left`, and `:right` are supported on their own; named pages such as `@page "
 "intro`, `:blank`, and compound pseudo-classes such as `:first:left` are not"
 
-#: src/supports/selectors.md:124
+#: src/supports/selectors.md:125
 msgid "`@page`内のmargin box"
 msgstr "The margin boxes inside `@page`"
 
-#: src/supports/selectors.md:124
+#: src/supports/selectors.md:125
 msgid ""
 "`@top-left-corner`/`@top-left`/`@top-center`/`@top-right`…の16種すべて。"
 "`content`のテキスト描画のみで、背景色・枠線等の装飾は非対応。`counter(page)`/"
@@ -6136,11 +6169,11 @@ msgstr ""
 "with `counter(page)` and `counter(pages)`, though `counter(pages)` is "
 "unavailable in streaming mode"
 
-#: src/supports/selectors.md:125 src/supports/fonts.md:44
+#: src/supports/selectors.md:126 src/supports/fonts.md:44
 msgid "`@font-face`"
 msgstr "`@font-face`"
 
-#: src/supports/selectors.md:125
+#: src/supports/selectors.md:126
 msgid ""
 "`font-family`/`src`/`unicode-range`/`font-weight`/`font-style`ディスクリプタ"
 "に対応(`src`の`local()`・`format()`/`tech()`付き`url()`も受理)。`font-"
@@ -6152,11 +6185,11 @@ msgstr ""
 "or `tech()` inside `src`. Other descriptors such as `font-display` are "
 "ignored. Font files may be TTF or OTF only; WOFF and WOFF2 are not supported"
 
-#: src/supports/selectors.md:126
+#: src/supports/selectors.md:127
 msgid "`@import`"
 msgstr "`@import`"
 
-#: src/supports/selectors.md:126
+#: src/supports/selectors.md:127
 msgid ""
 "ネスト(深さ上限16、超過分はその1件だけ無視)・循環参照の検出に対応。`@import "
 "url(...) screen;`のようなメディアクエリ条件は評価せず常に取り込む"
@@ -6165,15 +6198,15 @@ msgstr ""
 "alone is ignored, and cycles are detected. A media condition such as "
 "`@import url(...) screen;` is not evaluated; the file is always imported"
 
-#: src/supports/selectors.md:127
+#: src/supports/selectors.md:128
 msgid "`@charset`"
 msgstr "`@charset`"
 
-#: src/supports/selectors.md:127
+#: src/supports/selectors.md:128
 msgid "入力はUTF-8前提"
 msgstr "The input is assumed to be UTF-8"
 
-#: src/supports/selectors.md:128
+#: src/supports/selectors.md:129
 msgid ""
 "`@supports` / `@keyframes` / `@namespace` / `@counter-style` / `@layer` / "
 "`@container` / `@property`"
@@ -6181,15 +6214,15 @@ msgstr ""
 "`@supports`, `@keyframes`, `@namespace`, `@counter-style`, `@layer`, "
 "`@container`, `@property`"
 
-#: src/supports/selectors.md:128
+#: src/supports/selectors.md:129
 msgid "ブロックごと無視される"
 msgstr "The whole block is ignored"
 
-#: src/supports/selectors.md:130
+#: src/supports/selectors.md:131
 msgid "ストリーミングモード固有の制約"
 msgstr "Restrictions specific to streaming mode"
 
-#: src/supports/selectors.md:132
+#: src/supports/selectors.md:133
 msgid ""
 "`Mode::Batch`(一括処理)ではDOM全体が揃っているため下記の制約は無い。 `Mode::"
 "Streaming`でのみ以下が適用される。"
@@ -6197,7 +6230,7 @@ msgstr ""
 "In `Mode::Batch` the whole DOM is available, so none of this applies. The "
 "following holds only in `Mode::Streaming`."
 
-#: src/supports/selectors.md:135
+#: src/supports/selectors.md:136
 msgid ""
 "`<body>`直下のトップレベル要素は、次の兄弟が現れた時点で確定として処理しま"
 "す。 そのため「この先に同じ型の要素が続くか」が要るセレクタだけ、`<body>`直下"
@@ -6210,7 +6243,7 @@ msgstr ""
 "for those top-level elements — inside one of them the subtree is complete, "
 "so nothing changes."
 
-#: src/supports/selectors.md:138
+#: src/supports/selectors.md:139
 msgid ""
 "`:last-of-type`/`:only-of-type`/`:nth-last-child()`/`:nth-last-of-type()`/`:"
 "has(~ ...)`は、余分にマッチしたり取りこぼしたりします。 これらを使うと警告が"
@@ -6220,7 +6253,7 @@ msgstr ""
 "and `:has(~ ...)` match too much or miss altogether. Using any of them "
 "prints a warning"
 
-#: src/supports/selectors.md:140
+#: src/supports/selectors.md:141
 msgid ""
 "`:last-child`・`:empty`・`:has()`の子孫/直後の兄弟は、確定の条件と一致するの"
 "でバッチと同じ結果になります"
@@ -6229,7 +6262,7 @@ msgstr ""
 "next sibling, on the other hand, line up with what settling already "
 "guarantees, so they give the same result as batch mode"
 
-#: src/supports/selectors.md:141
+#: src/supports/selectors.md:142
 msgid ""
 "`+`/`~`・`:first-child`/`:nth-child()`/`:first-of-type`/`:nth-of-type()`/`:"
 "only-child`もバッチと同じ結果になります。 これらを使っている文書では、処理済"
@@ -6243,7 +6276,7 @@ msgstr ""
 "descendants released, so the element itself stays visible as a sibling (what "
 "remains is one node per top-level element, so almost as much is still freed)"
 
-#: src/supports/selectors.md:144
+#: src/supports/selectors.md:145
 msgid ""
 "`<body>`開始後の`<style>`タグはエラー: `EngineError::"
 "UnsupportedInStreamingMode`を返す。 黙って見た目が崩れるのを避けるため、"
@@ -6253,11 +6286,11 @@ msgstr ""
 "UnsupportedInStreamingMode`. Keep all `<style>` in `<head>`, so that the "
 "layout does not quietly fall apart"
 
-#: src/supports/selectors.md:146
+#: src/supports/selectors.md:147
 msgid "`position: absolute`/`fixed`は無視される"
 msgstr "`position: absolute` and `fixed` are ignored"
 
-#: src/supports/selectors.md:147
+#: src/supports/selectors.md:148
 msgid "`counter(pages)`(総ページ数)は使えない"
 msgstr "`counter(pages)`, the total page count, is unavailable"
 
@@ -6623,8 +6656,8 @@ msgid "対応フォーマット"
 msgstr "Supported formats"
 
 #: src/supports/images.md:5
-msgid "PNG / JPEG / WebP"
-msgstr "PNG, JPEG, WebP"
+msgid "PNG / JPEG / WebP / SVG"
+msgstr "PNG, JPEG, WebP, and SVG"
 
 #: src/supports/images.md:7
 msgid "`src`に書けるもの"
@@ -6635,30 +6668,364 @@ msgid "ローカルの相対パス・絶対パス、`http(s)`のURL、`data:` UR
 msgstr "A local relative or absolute path, an `http(s)` URL, or a `data:` URI"
 
 #: src/supports/images.md:9
-msgid "SVGとGIFは非対応です。"
-msgstr "SVG and GIF are not supported."
+msgid "GIFは非対応です。"
+msgstr "GIF is not supported."
 
 #: src/supports/images.md:11
-msgid "`<img>`"
-msgstr "`<img>`"
+msgid "SVG"
+msgstr "SVG"
 
-#: src/supports/images.md:14
+#: src/supports/images.md:13
+msgid ""
+"SVG(`.svg`と、gzip圧縮された`.svgz`)はラスタライズせず、ベクタのままPDFへ 埋"
+"め込みます。拡大しても解像度に依存せず、PDFのサイズもピクセル数ではなく 図形"
+"の数で決まります。パース・正規化は[usvg](https://github.com/linebender/"
+"resvg)、PDFの描画命令への変換は [svg2pdf](どちらも[typst]由来)が行います。"
+msgstr ""
+"SVG (`.svg`, and gzip-compressed `.svgz`) is embedded into the PDF as "
+"vectors rather than being rasterised. It stays resolution-independent when "
+"scaled up, and the size of the PDF depends on the number of shapes rather "
+"than on a pixel count. Parsing and normalisation are done by [usvg](https://"
+"github.com/linebender/resvg), and the translation into PDF drawing operators "
+"by [svg2pdf](both come from [typst])."
+
+#: src/supports/images.md:18
+msgid ""
+"**参照して使う形だけに対応します。** `<img src>`と`background-image: url()`"
+"の どちらでも使えますが、HTMLに直接書いたインラインの`<svg>`要素は描画しませ"
+"ん (後述)。"
+msgstr ""
+"Only referenced SVG is supported. It works from both `<img src>` and "
+"`background-image: url()`, but an inline `<svg>` element written directly in "
+"the HTML is not drawn (see below)."
+
+#: src/supports/images.md:23 src/supports/images.md:116
+msgid "\"logo.svg\""
+msgstr "\"logo.svg\""
+
+#: src/supports/images.md:23 src/supports/images.md:148
 msgid "\"120\""
 msgstr "\"120\""
 
-#: src/supports/images.md:15
+#: src/supports/images.md:24
+msgid "\""
+msgstr "\""
+
+#: src/supports/images.md:24
+msgid "pattern.svg"
+msgstr "pattern.svg"
+
+#: src/supports/images.md:27
+msgid ""
+"`data:` URIも使えます。SVGでは`;base64`を付けない書き方(パーセント エンコー"
+"ド)が一般的なので、どちらの形も受け付けます。"
+msgstr ""
+"`data:` URIs work too. SVG is commonly written without `;base64` (percent-"
+"encoded), so both forms are accepted."
+
+#: src/supports/images.md:31
+msgid "\"data:image/svg+xml,%3Csvg%20xmlns%3D...%3E\""
+msgstr "\"data:image/svg+xml,%3Csvg%20xmlns%3D...%3E\""
+
+#: src/supports/images.md:32
+msgid "\"data:image/svg+xml;base64,PHN2ZyB4bWxucz0...\""
+msgstr "\"data:image/svg+xml;base64,PHN2ZyB4bWxucz0...\""
+
+#: src/supports/images.md:36
+msgid "/* CSSの url() でも同じ */"
+msgstr "/* the same works in CSS url() */"
+
+#: src/supports/images.md:40
+msgid ""
+"フォーマットの判定は**中身のバイト列**で行います。拡張子や`data:`が名乗る "
+"mime typeは見ないので、`.txt`に入ったSVGも描けますし、`image/png`と名乗った "
+"SVGも描けます(逆に、`.svg`という名前のPNGはPNGとして扱います)。"
+msgstr ""
+"The format is detected from the bytes themselves. Neither the file extension "
+"nor the mime type a `data:` URI claims is used, so an SVG stored in a `.txt` "
+"file is drawn, and so is an SVG that claims to be `image/png` (conversely, a "
+"PNG named `.svg` is treated as a PNG)."
+
+#: src/supports/images.md:44
+msgid ""
+"寸法の決め方・キャッシュ・エラー時の扱いはラスタ画像と同じです。SVGの "
+"`width`/`height`(無ければ`viewBox`)が内在サイズになります。ラスタ画像と 違っ"
+"て内在サイズは小数になりうるので、そのまま(丸めずに)扱います。 `object-fit: "
+"contain`のようにアスペクト比で決まる指定が、`width=\"40.6\"`の ようなSVGでも"
+"ずれません。"
+msgstr ""
+"Sizing, caching, and error handling work exactly as they do for raster "
+"images. The SVG's `width`/`height` (or its `viewBox` if they are absent) "
+"becomes the intrinsic size. Unlike raster images the intrinsic size may be "
+"fractional, and it is kept as it is (not rounded). That way a ratio-driven "
+"value such as `object-fit: contain` stays exact even for an SVG with "
+"`width=\"40.6\"`."
+
+#: src/supports/images.md:50
+msgid "object-fit / object-position"
+msgstr "`object-fit` and `object-position`"
+
+#: src/supports/images.md:52
+msgid ""
+"ラスタ画像と同じように効きます。SVGはPDFへ単位正方形に正規化された形で 入るた"
+"め、`fill`/`contain`/`cover`/`none`/`scale-down`と`object-position`の 計算は"
+"ラスタ画像と完全に共通の実装が使われます。"
+msgstr ""
+"They work just as they do for raster images. An SVG enters the PDF "
+"normalised to the unit square, so `fill`, `contain`, `cover`, `none`, `scale-"
+"down`, and `object-position` all go through exactly the same implementation "
+"as raster images."
+
+#: src/supports/images.md:59
+msgid "/* 比を保って収める(余白ができる) */"
+msgstr "/* fit while keeping the ratio (leaves empty space) */"
+
+#: src/supports/images.md:60
+msgid "/* 左寄せ */"
+msgstr "/* align to the left */"
+
+#: src/supports/images.md:64
+msgid "`cover`のようにはみ出す指定でも、描画はcontent boxでクリップされます。"
+msgstr ""
+"Even a value that overflows, such as `cover`, is clipped to the content box "
+"when drawn."
+
+#: src/supports/images.md:66
+msgid "SVG内のテキストとフォント"
+msgstr "Text and fonts inside an SVG"
+
+#: src/supports/images.md:68
+msgid ""
+"**既定では、SVG内の`<text>`は描画されません。** パスにもならず、何も出ません "
+"(そのSVGの他の図形は描かれます)。`<text>`を含むSVGを見つけたら警告します。"
+msgstr ""
+"By default, `<text>` inside an SVG is not drawn. It is not converted to "
+"paths either, so nothing appears (the other shapes in that SVG are still "
+"drawn). A warning is printed when an SVG containing `<text>` is found."
+
+#: src/supports/images.md:71
+msgid ""
+"`svg-text` featureを有効にすると、グリフのまま(選択・検索できるテキストと し"
+"て)埋め込みます。使えるフォントは**文書が使うフォントそのもの**で、 解決の仕"
+"方はHTML側と揃えてあります。"
+msgstr ""
+"Enabling the `svg-text` feature embeds it as glyphs (as selectable, "
+"searchable text). The fonts available to it are exactly the fonts the "
+"document uses, and they are resolved the same way as on the HTML side."
+
+#: src/supports/images.md:75
+msgid "SVGの`font-family`"
+msgstr "`font-family` in the SVG"
+
+#: src/supports/images.md:77
+msgid "フォント内部のfamily名(`DejaVu Sans`等)"
+msgstr "A family name from inside the font file (`DejaVu Sans` and the like)"
+
+#: src/supports/images.md:77 src/supports/images.md:78
+msgid "そのフォント"
+msgstr "That font"
+
+#: src/supports/images.md:78
+msgid "`@font-face`で宣言した名前"
+msgstr "A name declared with `@font-face`"
+
+#: src/supports/images.md:79
+msgid "`serif` / `sans-serif` / `monospace`"
+msgstr "`serif` / `sans-serif` / `monospace`"
+
+#: src/supports/images.md:79
+msgid ""
+"`--serif-font` / `--gothic-font` / `--mono-font`(未指定なら既定フォント)"
+msgstr ""
+"`--serif-font` / `--gothic-font` / `--mono-font` (the default font if none "
+"is given)"
+
+#: src/supports/images.md:80
+msgid "指定なし"
+msgstr "Not specified"
+
+#: src/supports/images.md:80
+msgid "文書の既定フォント(`--font`で最初に渡したもの)"
+msgstr "The document's default font (the first one passed with `--font`)"
+
+#: src/supports/images.md:81
+msgid "文書が持っていない名前"
+msgstr "A name the document does not have"
+
+#: src/supports/images.md:81
+msgid "文書の既定フォント"
+msgstr "The document's default font"
+
+#: src/supports/images.md:84
+msgid "BrandFace"
+msgstr "BrandFace"
+
+#: src/supports/images.md:84
+msgid "brand.ttf"
+msgstr "brand.ttf"
+
+#: src/supports/images.md:88
+msgid ""
+"<!-- `@font-face`で宣言した名前でも、フォント内部のfamily名でも引ける -->"
+msgstr ""
+"<!-- both the name declared with `@font-face` and the family name inside the "
+"font work -->"
+
+#: src/supports/images.md:89
+msgid "\"BrandFace\""
+msgstr "\"BrandFace\""
+
+#: src/supports/images.md:92
+msgid ""
+"**SVGのためにシステムフォントを探し直すことはしません。** 文書が持って いない"
+"フォントがSVGにだけ現れることはなく、代わりに文書の既定フォントへ 落ちます"
+msgstr ""
+"System fonts are never looked up again for the sake of an SVG. A font the "
+"document does not have will not appear only inside an SVG; it falls back to "
+"the document's default font instead"
+
+#: src/supports/images.md:95
+msgid ""
+"文書側とSVG側では、同じフォントファイルでもサブセットは別になります (必要なグ"
+"リフが違うため)。埋め込みはフォント1つにつき1回です"
+msgstr ""
+"The document side and the SVG side get separate subsets of the same font "
+"file (they need different glyphs). Each font is embedded once"
+
+#: src/supports/images.md:97
+msgid ""
+"`svg-text`が既定オフなのは、有効にすると[rustybuzz](https://github.com/"
+"harfbuzz/rustybuzz)・resvg等25クレートが 依存に加わるためです(svg2pdfの"
+"`text` featureがそれらを要求します)。 SVGにテキストが無いなら足す必要はありま"
+"せん"
+msgstr ""
+"`svg-text` is off by default because enabling it adds 25 crates such as "
+"[rustybuzz](https://github.com/harfbuzz/rustybuzz) and resvg to the "
+"dependencies (svg2pdf's `text` feature requires them). There is no need to "
+"add them if your SVG has no text"
+
+#: src/supports/images.md:103
+msgid "インラインSVGは描画しません"
+msgstr "Inline SVG is not drawn"
+
+#: src/supports/images.md:105
+msgid ""
+"HTMLに直接書いた`<svg>`要素は、サブツリーごと描画対象から外します (UAスタイル"
+"シートの`svg { display: none }`)。中のテキストが本文へ 流れ込むこともありませ"
+"ん。文書内に1つでもあれば警告します。"
+msgstr ""
+"An `<svg>` element written directly in the HTML is dropped along with its "
+"subtree (through `svg { display: none }` in the user agent stylesheet). Its "
+"text does not leak into the body text either. A warning is printed if the "
+"document contains even one."
+
+#: src/supports/images.md:110
+msgid "<!-- 描画されない -->"
+msgstr "<!-- not drawn -->"
+
+#: src/supports/images.md:111
+msgid "\"http://www.w3.org/2000/svg\""
+msgstr "\"http://www.w3.org/2000/svg\""
+
+#: src/supports/images.md:111 src/supports/images.md:112
+#: src/supports/images.md:116 src/supports/images.md:117
+msgid "\"40\""
+msgstr "\"40\""
+
+#: src/supports/images.md:111 src/supports/images.md:112
+#: src/supports/images.md:116 src/supports/images.md:117
+msgid "\"20\""
+msgstr "\"20\""
+
+#: src/supports/images.md:112
+msgid "\"red\""
+msgstr "\"red\""
+
+#: src/supports/images.md:114
+msgid "<!-- こう書けば描画される -->"
+msgstr "<!-- written this way it is drawn -->"
+
+#: src/supports/images.md:117
+msgid "\"data:image/svg+xml,%3Csvg%20...%3E\""
+msgstr "\"data:image/svg+xml,%3Csvg%20...%3E\""
+
+#: src/supports/images.md:120
+msgid ""
+"対応させるにはHTMLのDOMからSVGのXMLを組み直してusvgへ渡す必要があり、 属性名"
+"の大小(`viewBox`等)・CSSの継承・`currentColor`をどう扱うかが 外部ファイルの参"
+"照とは別の問題になります。今のところ「参照して使う」形に 絞っています。"
+msgstr ""
+"Supporting it would mean rebuilding the SVG XML from the HTML DOM and "
+"handing that to usvg, and the case of attribute names (`viewBox` and "
+"friends), CSS inheritance, and how to treat `currentColor` all become "
+"questions separate from simply referencing an external file. For now it is "
+"limited to referencing an external SVG."
+
+#: src/supports/images.md:125
+msgid "その他の制限"
+msgstr "Other limitations"
+
+#: src/supports/images.md:127
+msgid ""
+"SVGフィルタ(`<filter>`)は非対応です。ラスタライズを避けるため、 フィルタを解"
+"決するための機能を入れていません"
+msgstr ""
+"SVG filters (`<filter>`) are not supported. Resolving them would require "
+"rasterisation, so the machinery for it is not included"
+
+#: src/supports/images.md:129
+msgid "SVG内に埋め込まれたラスタ画像(`<image>`)は描画されません"
+msgstr "A raster image embedded inside an SVG (`<image>`) is not drawn"
+
+#: src/supports/images.md:130
+msgid ""
+"`--grayscale`はSVGには効きません(色が個々の描画命令の中にあるため)。 指定する"
+"と警告し、SVGだけ色のまま残ります"
+msgstr ""
+"`--grayscale` does not apply to SVG (the colours live inside the individual "
+"drawing operators). Passing it prints a warning, and only the SVG stays in "
+"colour"
+
+#: src/supports/images.md:132
+msgid ""
+"SVGの中の`<image href=\"...\">`のような外部参照は解決しません。参照ごとに 警"
+"告を出して無視します。SVGの中からのファイル読み出しは`<img>`側の 封じ込め(基"
+"準ディレクトリ・`--allow`・`--disable-local-file-access`)を 迂回してしまうた"
+"め、経路自体を塞いでいます。`data:` URIは対象外 (SVG自身の中で完結しているた"
+"め許可されます)"
+msgstr ""
+"External references from inside an SVG, such as `<image href=\"...\">`, are "
+"not resolved. Each one is ignored with a warning. Reading a file from inside "
+"an SVG would bypass the containment that applies to `<img>` (the base "
+"directory, `--allow`, and `--disable-local-file-access`), so the path is "
+"closed off entirely. `data:` URIs are exempt (they are self-contained within "
+"the SVG itself)"
+
+#: src/supports/images.md:138
+msgid ""
+"`svg` featureを切る(`--no-default-features`)とusvgを引き込まなくなり、 SVGの"
+"参照はデコード失敗として扱われます。"
+msgstr ""
+"Turning off the `svg` feature (`--no-default-features`) drops usvg from the "
+"build, and a reference to an SVG is then treated as a decoding failure."
+
+#: src/supports/images.md:145
+msgid "`<img>`"
+msgstr "`<img>`"
+
+#: src/supports/images.md:149
 msgid "\"https://example.com/chart.png\""
 msgstr "\"https://example.com/chart.png\""
 
-#: src/supports/images.md:15
+#: src/supports/images.md:149
 msgid "\"売上推移\""
 msgstr "\"Sales over time\""
 
-#: src/supports/images.md:16
+#: src/supports/images.md:150
 msgid "\"data:image/png;base64,iVBORw0…\""
 msgstr "\"data:image/png;base64,iVBORw0…\""
 
-#: src/supports/images.md:19
+#: src/supports/images.md:153
 msgid ""
 "`<img>`はインラインの置換要素として行に載ります。独立した行にしたい場合は"
 "`display: block`を指定してください"
@@ -6666,7 +7033,7 @@ msgstr ""
 "An `<img>` sits on the line as an inline replaced element. Give it `display: "
 "block` to put it on a line of its own"
 
-#: src/supports/images.md:20
+#: src/supports/images.md:154
 msgid ""
 "`width`/`height`属性とCSSの`width`/`height`に対応します。どちらも無指定なら画"
 "像の内在サイズを使い、片方だけ指定すればアスペクト比を保って他方を導出します"
@@ -6675,7 +7042,7 @@ msgstr ""
 "both honoured. With neither, the intrinsic size is used; with only one, the "
 "other is derived while keeping the aspect ratio"
 
-#: src/supports/images.md:21
+#: src/supports/images.md:155
 msgid ""
 "取得やデコードに失敗した画像は、その要素だけ空として扱い、文書全体の生成は止"
 "めません(`--load-media-error-handling abort`で中断させることもできます)"
@@ -6684,34 +7051,34 @@ msgstr ""
 "it does not stop the document from being produced. Pass `--load-media-error-"
 "handling abort` to stop instead"
 
-#: src/supports/images.md:22
+#: src/supports/images.md:156
 msgid ""
 "同じ画像を何度使っても、取得・デコード・PDFへの埋め込みは初回の1回だけです"
 msgstr ""
 "However many times the same image is used, it is fetched, decoded, and "
 "embedded once"
 
-#: src/supports/images.md:24
+#: src/supports/images.md:158
 msgid "`object-fit` / `object-position`"
 msgstr "`object-fit` and `object-position`"
 
-#: src/supports/images.md:26
+#: src/supports/images.md:160
 msgid "指定した枠に対して画像をどう収めるかを制御します。"
 msgstr "These control how the image is fitted into the box you give it."
 
-#: src/supports/images.md:32
+#: src/supports/images.md:166
 msgid "/* fill | contain | cover | none | scale-down */"
 msgstr "/* fill | contain | cover | none | scale-down */"
 
-#: src/supports/images.md:37
+#: src/supports/images.md:171
 msgid "背景画像"
 msgstr "Background images"
 
-#: src/supports/images.md:41
+#: src/supports/images.md:175
 msgid "\"stamp.png\""
 msgstr "\"stamp.png\""
 
-#: src/supports/images.md:48
+#: src/supports/images.md:182
 msgid ""
 "`background-image`に書けるのは`url()`だけです。 `linear-gradient()`などのグラ"
 "デーション関数と、カンマ区切りの複数背景は非対応です。 既定では画像の内在サイ"
@@ -6721,7 +7088,7 @@ msgstr ""
 "`linear-gradient()` and comma separated multiple backgrounds are not "
 "supported. By default the image is tiled at its intrinsic size."
 
-#: src/supports/images.md:52
+#: src/supports/images.md:186
 msgid ""
 "`border-radius`と背景画像を併用した場合、角丸によるクリップは行われません(角"
 "丸は背景色の塗りにのみ効きます)。"
@@ -6730,16 +7097,16 @@ msgstr ""
 "clipped to the rounded corners; the radius applies only to the background "
 "colour."
 
-#: src/supports/images.md:54
+#: src/supports/images.md:188
 msgid "リモート画像の取得"
 msgstr "Fetching remote images"
 
-#: src/supports/images.md:56
+#: src/supports/images.md:190
 msgid "既定では無効です。 `--allow-remote-assets`で明示的に有効化します。"
 msgstr ""
 "This is off by default. Turn it on explicitly with `--allow-remote-assets`."
 
-#: src/supports/images.md:63
+#: src/supports/images.md:197
 msgid ""
 "有効にした場合も、グローバルに到達可能でない宛先へのリクエストは常にブロック"
 "されます。 判定は「グローバルなユニキャストだけを通す」方針で、次を拒否しま"
@@ -6749,53 +7116,53 @@ msgstr ""
 "are always blocked. The rule is to allow only global unicast; the following "
 "are rejected."
 
-#: src/supports/images.md:66
+#: src/supports/images.md:200
 msgid "種別"
 msgstr "Kind"
 
-#: src/supports/images.md:66
+#: src/supports/images.md:200
 msgid "範囲"
 msgstr "Ranges"
 
-#: src/supports/images.md:68
+#: src/supports/images.md:202
 msgid "ループバック"
 msgstr "Loopback"
 
-#: src/supports/images.md:68
+#: src/supports/images.md:202
 msgid "`127.0.0.0/8`、`::1`"
 msgstr "`127.0.0.0/8`, `::1`"
 
-#: src/supports/images.md:69
+#: src/supports/images.md:203
 msgid "プライベート"
 msgstr "Private"
 
-#: src/supports/images.md:69
+#: src/supports/images.md:203
 msgid "`10/8`、`172.16/12`、`192.168/16`、`fc00::/7`"
 msgstr "`10/8`, `172.16/12`, `192.168/16`, `fc00::/7`"
 
-#: src/supports/images.md:70
+#: src/supports/images.md:204
 msgid "リンクローカル"
 msgstr "Link-local"
 
-#: src/supports/images.md:70
+#: src/supports/images.md:204
 msgid "`169.254/16`(クラウドのメタデータ`169.254.169.254`を含む)、`fe80::/10`"
 msgstr ""
 "`169.254/16` (including the cloud metadata endpoint `169.254.169.254`), "
 "`fe80::/10`"
 
-#: src/supports/images.md:71
+#: src/supports/images.md:205
 msgid "CGNAT"
 msgstr "CGNAT"
 
-#: src/supports/images.md:71
+#: src/supports/images.md:205
 msgid "`100.64.0.0/10`(クラウドの内部ロードバランサ等)"
 msgstr "`100.64.0.0/10` (cloud-internal load balancers and the like)"
 
-#: src/supports/images.md:72
+#: src/supports/images.md:206
 msgid "その他の非グローバル"
 msgstr "Other non-global"
 
-#: src/supports/images.md:72
+#: src/supports/images.md:206
 msgid ""
 "`0.0.0.0/8`、`192.0.0.0/24`、`198.18.0.0/15`、`240.0.0.0/4`、マルチキャスト、"
 "ドキュメント用"
@@ -6803,17 +7170,17 @@ msgstr ""
 "`0.0.0.0/8`, `192.0.0.0/24`, `198.18.0.0/15`, `240.0.0.0/4`, multicast, "
 "documentation"
 
-#: src/supports/images.md:73
+#: src/supports/images.md:207
 msgid "IPv6の特殊用途"
 msgstr "IPv6 special-purpose"
 
-#: src/supports/images.md:73
+#: src/supports/images.md:207
 msgid ""
 "Teredo `2001::/32`、`2001:db8::/32`、ORCHIDv2 `2001:20::/28`、`100::/64`"
 msgstr ""
 "Teredo `2001::/32`, `2001:db8::/32`, ORCHIDv2 `2001:20::/28`, `100::/64`"
 
-#: src/supports/images.md:75
+#: src/supports/images.md:209
 msgid ""
 "IPv4を埋め込むIPv6表記(IPv4-mapped `::ffff:a.b.c.d`、IPv4-compatible `::a.b."
 "c.d`、NAT64 `64:ff9b::/96`、6to4 `2002::/16`)は、埋め込まれたIPv4側で判定しま"
@@ -6824,7 +7191,7 @@ msgstr ""
 "by the embedded IPv4 address. Letting them through would allow the IPv4 "
 "filter to be bypassed."
 
-#: src/supports/images.md:78
+#: src/supports/images.md:212
 msgid ""
 "判定は名前解決の結果に対して行うため、DNSリバインディングやリダイレクト経由の"
 "迂回も同じ仕組みで防いでいます。"
@@ -6832,24 +7199,24 @@ msgstr ""
 "The check is applied to the result of name resolution, so DNS rebinding and "
 "redirect-based bypasses are prevented by the same mechanism."
 
-#: src/supports/images.md:80
+#: src/supports/images.md:214
 msgid ""
 "ポート番号は制限しません。 内部サービスはプライベートIP上にあり、そこは上の判"
 "定で塞がっています。 公開IPに対する非標準ポート(CDNやAPIの`8080`など)は正当な"
 "用途があるため、塞ぐと実用を損なうわりに得るものがありません。"
 msgstr "Private"
 
-#: src/supports/images.md:84
+#: src/supports/images.md:218
 msgid ""
 "信頼できないHTMLを変換する場合は、`--allow`でローカル参照の範囲も併せて絞って"
 "ください。"
 msgstr "Ranges"
 
-#: src/supports/images.md:90
+#: src/supports/images.md:224
 msgid "JPEGはそのまま埋め込まれる"
 msgstr "JPEG is embedded as is"
 
-#: src/supports/images.md:92
+#: src/supports/images.md:226
 msgid ""
 "JPEGはデコードせず、サイズ情報だけを読んでPDFへそのまま(DCTDecodeとして)埋め"
 "込みます。 再エンコードしないので画質は落ちず、変換も速くなります。"
@@ -6858,7 +7225,7 @@ msgstr ""
 "goes into the PDF unchanged, as `DCTDecode`. Nothing is re-encoded, so "
 "quality is preserved and conversion is faster."
 
-#: src/supports/images.md:95
+#: src/supports/images.md:229
 msgid ""
 "その代わり、`--grayscale`を指定してもJPEGとCMYK画像はカラーのまま残ります(デ"
 "コーダを持たないため)。 グレースケール化が必要な場合は、変換前の画像をグレー"
@@ -6868,7 +7235,7 @@ msgstr ""
 "since there is no decoder for them. If you need them in greyscale, convert "
 "the images before rendering."
 
-#: src/supports/images.md:98
+#: src/supports/images.md:232
 msgid ""
 "PNGとWebPはフルデコードし、アルファチャンネルがあれば透過画像として埋め込みま"
 "す。"
@@ -6876,11 +7243,11 @@ msgstr ""
 "PNG and WebP are fully decoded, and an alpha channel is carried through as "
 "transparency."
 
-#: src/supports/images.md:100
+#: src/supports/images.md:234
 msgid "画像を一切読み込まない"
 msgstr "Loading no images at all"
 
-#: src/supports/images.md:106
+#: src/supports/images.md:240
 msgid "`<img>`とCSSの`background-image`の両方を読み込まなくなります。"
 msgstr ""
 "This stops both `<img>` and the CSS `background-image` from being loaded."
@@ -7957,9 +8324,12 @@ msgstr ""
 "radiobutton-svg`"
 
 #: src/migration/wkhtmltopdf-options.md:82
-msgid "SVG描画が非対応。フォーム要素の見た目は内蔵の描画で再現する"
+msgid ""
+"SVG自体は描画できるが、フォーム要素の見た目の差し替えには対応しない(内蔵の描"
+"画で再現する)"
 msgstr ""
-"SVG cannot be drawn. Form controls are drawn with built-in shapes instead"
+"SVG itself can be drawn, but replacing the appearance of form controls is "
+"not supported (they are drawn with built-in shapes instead)"
 
 #: src/migration/wkhtmltopdf-options.md:83
 msgid "`--cookie <name> <value>`"
@@ -9016,14 +9386,35 @@ msgid "画像・フォントの形式"
 msgstr "Image and font formats"
 
 #: src/appendix/limitations.md:39
-msgid "画像はPNG / JPEG / WebPのみ。SVGとGIFは非対応です"
-msgstr "Images may be PNG, JPEG, or WebP only; SVG and GIF are not supported"
+msgid "画像はPNG / JPEG / WebP / SVGのみ。GIFは非対応です"
+msgstr "Images may be PNG, JPEG, WebP, or SVG only; GIF is not supported"
 
 #: src/appendix/limitations.md:40
+msgid ""
+"SVGは`<img>`と`background-image`からの参照のみ(ファイル・`data:` URIどちらも"
+"可)。HTMLに直接書いたインラインの`<svg>`要素は描画せず、見つけたら警告します"
+msgstr ""
+"SVG can only be referenced from `<img>` and `background-image` (either a "
+"file or a `data:` URI). An inline `<svg>` element written directly in the "
+"HTML is not drawn, and a warning is printed when one is found"
+
+#: src/appendix/limitations.md:41
+msgid ""
+"SVG内の`<text>`は`svg-text` featureを有効にした場合だけ描画します(使えるフォ"
+"ントは文書と同じもので、SVGのためにシステムフォントを探し直すことはしませ"
+"ん)。`<filter>`と`<image>`は非対応です([画像](../supports/images.md#svg)を参"
+"照)"
+msgstr ""
+"`<text>` inside an SVG is drawn only when the `svg-text` feature is enabled "
+"(the fonts available to it are the same as the document's, and system fonts "
+"are never looked up again for the sake of an SVG). `<filter>` and `<image>` "
+"are not supported (see [Images](../supports/images.md#svg))"
+
+#: src/appendix/limitations.md:42
 msgid "フォントはTTF / OTFのみ。WOFF / WOFF2は非対応です"
 msgstr "Fonts may be TTF or OTF only; WOFF and WOFF2 are not supported"
 
-#: src/appendix/limitations.md:41
+#: src/appendix/limitations.md:43
 msgid ""
 "カラーフォント(`CBDT`/`CBLC`・`COLR`/`CPAL`・`sbix`)は非対応です。絵文字は"
 "[フォント](../supports/fonts.md#絵文字)を参照してください"
@@ -9031,61 +9422,72 @@ msgstr ""
 "Colour fonts (`CBDT`/`CBLC`, `COLR`/`CPAL`, `sbix`) are not supported. For "
 "emoji see [Fonts](../supports/fonts.md#絵文字)"
 
-#: src/appendix/limitations.md:42
-msgid "`--grayscale`を指定しても、JPEGとCMYK画像はカラーのまま残ります"
-msgstr "Even with `--grayscale`, JPEG and CMYK images stay in colour"
-
 #: src/appendix/limitations.md:44
+msgid "`--grayscale`を指定しても、JPEGとCMYK画像・SVGはカラーのまま残ります"
+msgstr "Even with `--grayscale`, JPEG and CMYK images and SVG stay in colour"
+
+#: src/appendix/limitations.md:46
 msgid "CSSの主な制限"
 msgstr "The main CSS limitations"
 
-#: src/appendix/limitations.md:46
+#: src/appendix/limitations.md:48
 msgid "機能単位では以下が非対応です。"
 msgstr "Taken feature by feature, the following are not supported."
 
-#: src/appendix/limitations.md:48
+#: src/appendix/limitations.md:50
 msgid ""
-"縦書き(`writing-mode`/`text-orientation`)と`direction`による右横書き"
-"(`margin-inline`等の論理プロパティは`horizontal-tb`+LTRの固定写像としてのみ対応)"
+"縦書き(`writing-mode`/`text-orientation`)と`direction`による右横書き(`margin-"
+"inline`等の論理プロパティは`horizontal-tb`+LTRの固定写像としてのみ対応)"
 msgstr ""
-"Vertical writing with `writing-mode` and `text-orientation`, and right-to-left "
-"text through `direction` (logical properties such as `margin-inline` are "
-"supported only as a fixed mapping for `horizontal-tb` and LTR)"
+"Vertical writing with `writing-mode` and `text-orientation`, and right-to-"
+"left text through `direction` (logical properties such as `margin-inline` "
+"are supported only as a fixed mapping for `horizontal-tb` and LTR)"
 
-#: src/appendix/limitations.md:49
+#: src/appendix/limitations.md:51
 msgid "多段組み(`columns`/`column-count`)"
 msgstr "Multi-column layout, `columns` and `column-count`"
 
-#: src/appendix/limitations.md:50
+#: src/appendix/limitations.md:52
 msgid "グラデーション(`linear-gradient()`等)と複数背景"
 msgstr "Gradients such as `linear-gradient()`, and multiple backgrounds"
 
-#: src/appendix/limitations.md:51
+#: src/appendix/limitations.md:53
 msgid "相対色構文(`rgb(from ...)`)と`color()`(`color-mix()`は対応済み)"
 msgstr ""
 "The relative colour syntax (`rgb(from ...)`) and `color()` (`color-mix()` is "
 "supported)"
 
-#: src/appendix/limitations.md:52
+#: src/appendix/limitations.md:54
 msgid "アニメーション・トランジション・`filter`(静的な出力のため)"
 msgstr "Animations, transitions, and `filter`, since the output is static"
 
-#: src/appendix/limitations.md:53
+#: src/appendix/limitations.md:55
 msgid "`position: sticky`、`display: inline-flex`/`inline-grid`、subgrid"
 msgstr ""
 "`position: sticky`, `display: inline-flex` and `inline-grid`, and subgrid"
 
-#: src/appendix/limitations.md:54
+#: src/appendix/limitations.md:56
 msgid "`::first-line`、`::marker`(`:is()`/`:where()`/`:has()`は対応済み)"
 msgstr ""
 "`::first-line` and `::marker` (`:is()`, `:where()` and `:has()` are "
 "supported)"
 
-#: src/appendix/limitations.md:56
+#: src/appendix/limitations.md:58
+msgid ""
+"値の文法では、`calc()`と括弧のネストが32段までです。 それより深い値は無効とし"
+"て宣言ごと無視します。 再帰的にパースするため、深さの上限を設けないと信頼でき"
+"ないCSSでスタックを使い切らせることができてしまうためです。"
+msgstr ""
+"In value syntax, `calc()` and parentheses may be nested up to 32 levels "
+"deep. A value deeper than that is invalid and its declaration is ignored. "
+"Values are parsed recursively, so without a depth limit an untrusted "
+"stylesheet could exhaust the stack."
+
+#: src/appendix/limitations.md:62
 msgid "空白文字の扱い"
 msgstr "How whitespace is treated"
 
-#: src/appendix/limitations.md:58
+#: src/appendix/limitations.md:64
 msgid ""
 "畳み込みの対象はCSS Text 3が定める空白(space・tab・改行)だけです。 `&nbsp;"
 "`(U+00A0)やthin space(U+2009)などは畳み込まれない普通の文字として、 フォント"
@@ -9101,7 +9503,7 @@ msgstr ""
 "space, figure space or word joiner (this holds under `word-break: break-all` "
 "as well)."
 
-#: src/appendix/limitations.md:64
+#: src/appendix/limitations.md:70
 msgid ""
 "`<wbr>`(と、それと同じ意味を持つU+200B ZERO WIDTH SPACE)は「ここで改行してよ"
 "い」という 指定として扱います。幅は増えず、PDFのテキスト層にも文字は残りませ"
@@ -9112,11 +9514,11 @@ msgstr ""
 "character in the PDF text layer (text extraction runs the two sides together "
 "even with a `<wbr>` between them)."
 
-#: src/appendix/limitations.md:68
+#: src/appendix/limitations.md:74
 msgid "この範囲での既知の制限は以下です。"
 msgstr "Within that scope, the known limitations are:"
 
-#: src/appendix/limitations.md:70
+#: src/appendix/limitations.md:76
 msgid ""
 "`text-align: justify`が行を伸ばす際、`&nbsp;`は伸縮の対象になりません(通常の"
 "空白のみ)"
@@ -9124,22 +9526,22 @@ msgstr ""
 "When `text-align: justify` stretches a line, `&nbsp;` is not one of the gaps "
 "it stretches (only ordinary spaces are)"
 
-#: src/appendix/limitations.md:71
+#: src/appendix/limitations.md:77
 msgid "U+2028/U+2029は本来の強制改行ではなく、通常の空白と同じ扱いになります"
 msgstr ""
 "U+2028 and U+2029 are treated as ordinary whitespace rather than as the "
 "forced breaks they are meant to be"
 
-#: src/appendix/limitations.md:72
+#: src/appendix/limitations.md:78
 msgid "行末に来た空白の「ぶら下がり」(hanging)は行いません"
 msgstr ""
 "Whitespace that lands at the end of a line is not hung outside the line box"
 
-#: src/appendix/limitations.md:74
+#: src/appendix/limitations.md:80
 msgid "ストリーミングモード固有の制限"
 msgstr "Limitations specific to streaming mode"
 
-#: src/appendix/limitations.md:76
+#: src/appendix/limitations.md:82
 msgid ""
 "`--streaming`を使う場合は、総ページ数(`counter(pages)`・`[topage]`)や目次(`--"
 "toc`)などが使えなくなります。 詳細は[ストリーミングモード](../usage/cli/"
@@ -9149,11 +9551,11 @@ msgstr ""
 "`[topage]`, and the table of contents, `--toc`, become unavailable. See "
 "[Streaming mode](../usage/cli/streaming.md) for the details."
 
-#: src/appendix/limitations.md:79
+#: src/appendix/limitations.md:85
 msgid "今後について"
 msgstr "Looking ahead"
 
-#: src/appendix/limitations.md:81
+#: src/appendix/limitations.md:87
 msgid ""
 "JavaScriptエンジンの組み込みは、必要性が出てきた段階での検討事項として残して"
 "あります。 上記のうちPDFのアウトラインなど、設計上の非目標ではないものは将来"
@@ -9162,6 +9564,9 @@ msgstr ""
 "Embedding a JavaScript engine remains something to consider if the need "
 "arises. Items above that are not deliberate non-goals, such as PDF outlines, "
 "may well be supported later."
+
+#~ msgid "個別の`top`/`right`/`bottom`/`left`を使う"
+#~ msgstr "Use `top`, `right`, `bottom`, and `left` individually"
 
 #~ msgid ""
 #~ "`:last-child`・`:nth-last-child`・`:last-of-type`・`:nth-last-of-type`・`:"

--- a/docs/po/en.po
+++ b/docs/po/en.po
@@ -2295,7 +2295,8 @@ msgid ""
 msgstr ""
 "Every other sibling selector — `+`, `~`, `:first-child`, `:nth-child()`, `:"
 "last-child` and so on — gives the same result as batch mode. See [Selectors]"
-"(../../supports/selectors.md#ストリーミングモード固有の制約) for the details."
+"(../../supports/selectors.md#restrictions-specific-to-streaming-mode) for "
+"the details."
 
 #: src/usage/cli/streaming.md:40
 msgid "使えるもの"
@@ -9420,7 +9421,7 @@ msgid ""
 "[フォント](../supports/fonts.md#絵文字)を参照してください"
 msgstr ""
 "Colour fonts (`CBDT`/`CBLC`, `COLR`/`CPAL`, `sbix`) are not supported. For "
-"emoji see [Fonts](../supports/fonts.md#絵文字)"
+"emoji see [Fonts](../supports/fonts.md#emoji)"
 
 #: src/appendix/limitations.md:44
 msgid "`--grayscale`を指定しても、JPEGとCMYK画像・SVGはカラーのまま残ります"

--- a/docs/po/messages.pot
+++ b/docs/po/messages.pot
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: sghtmltopdf\n"
-"POT-Creation-Date: 2026-08-16T19:53:45+09:00\n"
+"POT-Creation-Date: 2026-08-30T16:06:58+09:00\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -680,7 +680,7 @@ msgstr ""
 msgid "CSSの指定"
 msgstr ""
 
-#: src/getting-started/docker.md:71
+#: src/getting-started/docker.md:71 src/supports/images.md:75
 msgid "使われるフォント"
 msgstr ""
 
@@ -2449,16 +2449,16 @@ msgid "ビルド済み(precompiled)のgemを配布するため、Rustのツー�
 msgstr ""
 
 #: src/usage/ruby_rails.md:21 src/supports/properties.md:20
-#: src/supports/properties.md:31 src/supports/properties.md:44
-#: src/supports/properties.md:61 src/supports/properties.md:81
-#: src/supports/properties.md:108 src/supports/properties.md:123
-#: src/supports/properties.md:141 src/supports/properties.md:150
-#: src/supports/properties.md:161 src/supports/properties.md:176
-#: src/supports/properties.md:211 src/supports/properties.md:230
-#: src/supports/selectors.md:15 src/supports/selectors.md:27
-#: src/supports/selectors.md:46 src/supports/selectors.md:57
-#: src/supports/selectors.md:76 src/supports/selectors.md:89
-#: src/supports/selectors.md:120
+#: src/supports/properties.md:31 src/supports/properties.md:46
+#: src/supports/properties.md:65 src/supports/properties.md:86
+#: src/supports/properties.md:113 src/supports/properties.md:128
+#: src/supports/properties.md:146 src/supports/properties.md:155
+#: src/supports/properties.md:166 src/supports/properties.md:181
+#: src/supports/properties.md:216 src/supports/properties.md:235
+#: src/supports/selectors.md:15 src/supports/selectors.md:28
+#: src/supports/selectors.md:47 src/supports/selectors.md:58
+#: src/supports/selectors.md:77 src/supports/selectors.md:90
+#: src/supports/selectors.md:121
 msgid "対応"
 msgstr ""
 
@@ -2900,7 +2900,7 @@ msgid "開発環境のようにアセットがまだ`public/`へ書き出され�
 msgstr ""
 
 #: src/usage/ruby_rails.md:177 src/usage/ruby_rails.md:178
-#: src/supports/images.md:14
+#: src/supports/images.md:148
 msgid "\"logo.png\""
 msgstr ""
 
@@ -3127,24 +3127,24 @@ msgid "表示・可視性"
 msgstr ""
 
 #: src/supports/properties.md:20 src/supports/properties.md:31
-#: src/supports/properties.md:44 src/supports/properties.md:61
-#: src/supports/properties.md:81 src/supports/properties.md:108
-#: src/supports/properties.md:123 src/supports/properties.md:141
-#: src/supports/properties.md:150 src/supports/properties.md:161
-#: src/supports/properties.md:176 src/supports/properties.md:211
-#: src/supports/properties.md:230 src/supports/pagination.md:13
+#: src/supports/properties.md:46 src/supports/properties.md:65
+#: src/supports/properties.md:86 src/supports/properties.md:113
+#: src/supports/properties.md:128 src/supports/properties.md:146
+#: src/supports/properties.md:155 src/supports/properties.md:166
+#: src/supports/properties.md:181 src/supports/properties.md:216
+#: src/supports/properties.md:235 src/supports/pagination.md:13
 msgid "プロパティ"
 msgstr ""
 
 #: src/supports/properties.md:20 src/supports/properties.md:31
-#: src/supports/properties.md:44 src/supports/properties.md:61
-#: src/supports/properties.md:81 src/supports/properties.md:108
-#: src/supports/properties.md:123 src/supports/properties.md:141
-#: src/supports/properties.md:150 src/supports/properties.md:161
-#: src/supports/properties.md:176 src/supports/properties.md:211
-#: src/supports/properties.md:230 src/supports/selectors.md:15
-#: src/supports/selectors.md:27 src/supports/selectors.md:46
-#: src/supports/selectors.md:76 src/supports/selectors.md:120
+#: src/supports/properties.md:46 src/supports/properties.md:65
+#: src/supports/properties.md:86 src/supports/properties.md:113
+#: src/supports/properties.md:128 src/supports/properties.md:146
+#: src/supports/properties.md:155 src/supports/properties.md:166
+#: src/supports/properties.md:181 src/supports/properties.md:216
+#: src/supports/properties.md:235 src/supports/selectors.md:15
+#: src/supports/selectors.md:28 src/supports/selectors.md:47
+#: src/supports/selectors.md:77 src/supports/selectors.md:121
 #: src/migration/wkhtmltopdf-options.md:29
 #: src/migration/wkhtmltopdf-options.md:67
 #: src/migration/wkhtmltopdf-options.md:76
@@ -3162,32 +3162,34 @@ msgstr ""
 #: src/supports/properties.md:26 src/supports/properties.md:27
 #: src/supports/properties.md:33 src/supports/properties.md:34
 #: src/supports/properties.md:35 src/supports/properties.md:36
-#: src/supports/properties.md:49 src/supports/properties.md:50
-#: src/supports/properties.md:52 src/supports/properties.md:53
-#: src/supports/properties.md:55 src/supports/properties.md:57
-#: src/supports/properties.md:65 src/supports/properties.md:66
-#: src/supports/properties.md:68 src/supports/properties.md:69
-#: src/supports/properties.md:83 src/supports/properties.md:84
-#: src/supports/properties.md:85 src/supports/properties.md:86
-#: src/supports/properties.md:90 src/supports/properties.md:91
-#: src/supports/properties.md:92 src/supports/properties.md:93
-#: src/supports/properties.md:94 src/supports/properties.md:95
-#: src/supports/properties.md:97 src/supports/properties.md:98
-#: src/supports/properties.md:99 src/supports/properties.md:100
-#: src/supports/properties.md:101 src/supports/properties.md:102
-#: src/supports/properties.md:104 src/supports/properties.md:110
-#: src/supports/properties.md:112 src/supports/properties.md:115
-#: src/supports/properties.md:116 src/supports/properties.md:126
-#: src/supports/properties.md:128 src/supports/properties.md:144
-#: src/supports/properties.md:146 src/supports/properties.md:152
-#: src/supports/properties.md:163 src/supports/properties.md:164
-#: src/supports/properties.md:180 src/supports/properties.md:185
-#: src/supports/properties.md:187 src/supports/selectors.md:37
-#: src/supports/selectors.md:48 src/supports/selectors.md:49
-#: src/supports/selectors.md:78 src/supports/selectors.md:80
-#: src/supports/selectors.md:82 src/supports/selectors.md:122
+#: src/supports/properties.md:41 src/supports/properties.md:42
+#: src/supports/properties.md:50 src/supports/properties.md:52
+#: src/supports/properties.md:53 src/supports/properties.md:55
+#: src/supports/properties.md:56 src/supports/properties.md:57
+#: src/supports/properties.md:59 src/supports/properties.md:61
+#: src/supports/properties.md:69 src/supports/properties.md:70
+#: src/supports/properties.md:72 src/supports/properties.md:73
+#: src/supports/properties.md:74 src/supports/properties.md:88
+#: src/supports/properties.md:89 src/supports/properties.md:90
+#: src/supports/properties.md:91 src/supports/properties.md:95
+#: src/supports/properties.md:96 src/supports/properties.md:97
+#: src/supports/properties.md:98 src/supports/properties.md:99
+#: src/supports/properties.md:100 src/supports/properties.md:102
+#: src/supports/properties.md:103 src/supports/properties.md:104
+#: src/supports/properties.md:105 src/supports/properties.md:106
+#: src/supports/properties.md:107 src/supports/properties.md:109
+#: src/supports/properties.md:115 src/supports/properties.md:117
+#: src/supports/properties.md:120 src/supports/properties.md:121
+#: src/supports/properties.md:131 src/supports/properties.md:133
+#: src/supports/properties.md:149 src/supports/properties.md:151
+#: src/supports/properties.md:157 src/supports/properties.md:168
+#: src/supports/properties.md:169 src/supports/properties.md:185
+#: src/supports/properties.md:190 src/supports/properties.md:192
+#: src/supports/selectors.md:38 src/supports/selectors.md:49
+#: src/supports/selectors.md:50 src/supports/selectors.md:79
+#: src/supports/selectors.md:81 src/supports/selectors.md:83
 #: src/supports/selectors.md:123 src/supports/selectors.md:124
-#: src/supports/selectors.md:125
+#: src/supports/selectors.md:125 src/supports/selectors.md:126
 msgid "⚠️"
 msgstr ""
 
@@ -3291,40 +3293,41 @@ msgstr ""
 
 #: src/supports/properties.md:37 src/supports/properties.md:38
 #: src/supports/properties.md:39 src/supports/properties.md:40
-#: src/supports/properties.md:46 src/supports/properties.md:47
-#: src/supports/properties.md:48 src/supports/properties.md:51
-#: src/supports/properties.md:54 src/supports/properties.md:63
-#: src/supports/properties.md:64 src/supports/properties.md:88
-#: src/supports/properties.md:89 src/supports/properties.md:96
-#: src/supports/properties.md:103 src/supports/properties.md:111
-#: src/supports/properties.md:113 src/supports/properties.md:114
-#: src/supports/properties.md:125 src/supports/properties.md:127
-#: src/supports/properties.md:129 src/supports/properties.md:130
-#: src/supports/properties.md:143 src/supports/properties.md:145
-#: src/supports/properties.md:153 src/supports/properties.md:154
-#: src/supports/properties.md:165 src/supports/properties.md:166
-#: src/supports/properties.md:178 src/supports/properties.md:179
-#: src/supports/properties.md:181 src/supports/properties.md:182
-#: src/supports/properties.md:183 src/supports/properties.md:184
-#: src/supports/properties.md:186 src/supports/properties.md:213
-#: src/supports/properties.md:214 src/supports/properties.md:215
-#: src/supports/properties.md:216 src/supports/properties.md:217
+#: src/supports/properties.md:48 src/supports/properties.md:49
+#: src/supports/properties.md:51 src/supports/properties.md:54
+#: src/supports/properties.md:58 src/supports/properties.md:67
+#: src/supports/properties.md:68 src/supports/properties.md:71
+#: src/supports/properties.md:93 src/supports/properties.md:94
+#: src/supports/properties.md:101 src/supports/properties.md:108
+#: src/supports/properties.md:116 src/supports/properties.md:118
+#: src/supports/properties.md:119 src/supports/properties.md:130
+#: src/supports/properties.md:132 src/supports/properties.md:134
+#: src/supports/properties.md:135 src/supports/properties.md:148
+#: src/supports/properties.md:150 src/supports/properties.md:158
+#: src/supports/properties.md:159 src/supports/properties.md:170
+#: src/supports/properties.md:171 src/supports/properties.md:183
+#: src/supports/properties.md:184 src/supports/properties.md:186
+#: src/supports/properties.md:187 src/supports/properties.md:188
+#: src/supports/properties.md:189 src/supports/properties.md:191
 #: src/supports/properties.md:218 src/supports/properties.md:219
-#: src/supports/properties.md:220 src/supports/properties.md:232
-#: src/supports/properties.md:233 src/supports/selectors.md:17
-#: src/supports/selectors.md:18 src/supports/selectors.md:19
-#: src/supports/selectors.md:20 src/supports/selectors.md:21
-#: src/supports/selectors.md:22 src/supports/selectors.md:29
-#: src/supports/selectors.md:30 src/supports/selectors.md:31
-#: src/supports/selectors.md:32 src/supports/selectors.md:33
-#: src/supports/selectors.md:34 src/supports/selectors.md:35
-#: src/supports/selectors.md:36 src/supports/selectors.md:38
-#: src/supports/selectors.md:59 src/supports/selectors.md:60
-#: src/supports/selectors.md:61 src/supports/selectors.md:62
-#: src/supports/selectors.md:81 src/supports/selectors.md:83
-#: src/supports/selectors.md:91 src/supports/selectors.md:92
-#: src/supports/selectors.md:93 src/supports/selectors.md:94
-#: src/supports/selectors.md:96 src/supports/selectors.md:126
+#: src/supports/properties.md:220 src/supports/properties.md:221
+#: src/supports/properties.md:222 src/supports/properties.md:223
+#: src/supports/properties.md:224 src/supports/properties.md:225
+#: src/supports/properties.md:237 src/supports/properties.md:238
+#: src/supports/selectors.md:17 src/supports/selectors.md:18
+#: src/supports/selectors.md:19 src/supports/selectors.md:20
+#: src/supports/selectors.md:21 src/supports/selectors.md:22
+#: src/supports/selectors.md:23 src/supports/selectors.md:30
+#: src/supports/selectors.md:31 src/supports/selectors.md:32
+#: src/supports/selectors.md:33 src/supports/selectors.md:34
+#: src/supports/selectors.md:35 src/supports/selectors.md:36
+#: src/supports/selectors.md:37 src/supports/selectors.md:39
+#: src/supports/selectors.md:60 src/supports/selectors.md:61
+#: src/supports/selectors.md:62 src/supports/selectors.md:63
+#: src/supports/selectors.md:82 src/supports/selectors.md:84
+#: src/supports/selectors.md:92 src/supports/selectors.md:93
+#: src/supports/selectors.md:94 src/supports/selectors.md:95
+#: src/supports/selectors.md:97 src/supports/selectors.md:127
 msgid "✅"
 msgstr ""
 
@@ -3344,7 +3347,7 @@ msgstr ""
 msgid "`padding`"
 msgstr ""
 
-#: src/supports/properties.md:39 src/supports/properties.md:48
+#: src/supports/properties.md:39 src/supports/properties.md:51
 msgid "1〜4値ショートハンド"
 msgstr ""
 
@@ -3356,811 +3359,852 @@ msgstr ""
 msgid "パーセンテージはcontaining block幅基準(仕様通り)"
 msgstr ""
 
+#: src/supports/properties.md:41
+msgid "`margin-inline` / `margin-block` / `margin-inline-start`等"
+msgstr ""
+
+#: src/supports/properties.md:41
+msgid ""
+"論理プロパティ。対応する書字方向が`horizontal-tb`+LTRのみなので、`inline-start`=左、`inline-end`=右、`block-start`=上、`block-end`=下へ固定で写像する(`writing-mode`/`direction`は非対応)。2辺ショートハンドは1〜2値(`start "
+"end`の順)。`auto`も通るので`margin-inline: auto`で中央寄せできる"
+msgstr ""
+
 #: src/supports/properties.md:42
+msgid "`padding-inline` / `padding-block` / `padding-inline-start`等"
+msgstr ""
+
+#: src/supports/properties.md:42
+msgid "論理プロパティ。写像規則は`margin-inline`と同じ"
+msgstr ""
+
+#: src/supports/properties.md:44
 msgid "枠線・角丸・アウトライン・影"
 msgstr ""
 
-#: src/supports/properties.md:46
+#: src/supports/properties.md:48
 msgid "`border`"
 msgstr ""
 
-#: src/supports/properties.md:46
+#: src/supports/properties.md:48
 msgid "`<width> \\|\\| <style> \\|\\| <color>`を任意順・任意省略で受け付け、4辺へ適用"
 msgstr ""
 
-#: src/supports/properties.md:47
+#: src/supports/properties.md:49
 msgid "`border-top` / `-right` / `-bottom` / `-left`"
 msgstr ""
 
-#: src/supports/properties.md:47
+#: src/supports/properties.md:49
 msgid "辺別ショートハンド(値文法は`border`と同じ)"
 msgstr ""
 
-#: src/supports/properties.md:48
+#: src/supports/properties.md:50
+msgid ""
+"`border-inline` / `border-block` / "
+"`border-inline-start`等(`-width`/`-style`/`-color`のロングハンドを含む)"
+msgstr ""
+
+#: src/supports/properties.md:50 src/supports/properties.md:72
+msgid "論理プロパティ。写像規則は[`margin-inline`](#ボックスモデル)と同じ"
+msgstr ""
+
+#: src/supports/properties.md:51
 msgid "`border-width` / `border-style` / `border-color`"
 msgstr ""
 
-#: src/supports/properties.md:49
+#: src/supports/properties.md:52
 msgid "`border-*-width`"
 msgstr ""
 
-#: src/supports/properties.md:49
+#: src/supports/properties.md:52
 msgid "`<length>`のみ。`thin`/`medium`/`thick`キーワードは非対応"
 msgstr ""
 
-#: src/supports/properties.md:50
+#: src/supports/properties.md:53
 msgid "`border-*-style`"
 msgstr ""
 
-#: src/supports/properties.md:50
+#: src/supports/properties.md:53
 msgid ""
 "`none`/`hidden`/`solid`/`dashed`/`dotted`/`double`/`groove`/`ridge`/`inset`/`outset`。`hidden`は`none`と同一視(テーブルの枠線競合解決でも区別しない)。`groove`/`ridge`/`inset`/`outset`は`border-color`から2階調の陰影を算出して描画"
 msgstr ""
 
-#: src/supports/properties.md:51
+#: src/supports/properties.md:54
 msgid "`border-*-color`"
 msgstr ""
 
-#: src/supports/properties.md:51
+#: src/supports/properties.md:54
 msgid "初期値は`currentcolor`"
 msgstr ""
 
-#: src/supports/properties.md:52
+#: src/supports/properties.md:55
 msgid "`border-radius`"
 msgstr ""
 
-#: src/supports/properties.md:52
+#: src/supports/properties.md:55
 msgid ""
 "1〜4値+`/`区切りの楕円構文に対応。パーセンテージ指定は非対応(`<length>`のみ)。4辺の太さ・スタイル・色が揃っていない場合は角丸を諦めて直線4辺へフォールバックする。`groove`/`ridge`/`inset`/`outset`との併用も同様にフォールバック"
 msgstr ""
 
-#: src/supports/properties.md:53
+#: src/supports/properties.md:56
 msgid "`border-top-left-radius`ほか3隅"
 msgstr ""
 
-#: src/supports/properties.md:53
+#: src/supports/properties.md:56
 msgid "`<length>{1,2}`(水平/垂直半径)。制約は`border-radius`と同じ"
 msgstr ""
 
-#: src/supports/properties.md:54
+#: src/supports/properties.md:57
+msgid "`border-start-start-radius`ほか3隅"
+msgstr ""
+
+#: src/supports/properties.md:57
+msgid ""
+"論理プロパティ。1つ目がblock方向、2つ目がinline方向を指す(`border-start-end-radius`=右上)。写像規則は[`margin-inline`](#ボックスモデル)と同じ"
+msgstr ""
+
+#: src/supports/properties.md:58
 msgid "`outline`"
 msgstr ""
 
-#: src/supports/properties.md:54
+#: src/supports/properties.md:58
 msgid "`<width> \\|\\| <style> \\|\\| <color>`。border-boxの外側に描画し、レイアウトには影響しない"
 msgstr ""
 
-#: src/supports/properties.md:55
+#: src/supports/properties.md:59
 msgid "`outline-width` / `outline-style` / `outline-color`"
 msgstr ""
 
-#: src/supports/properties.md:55
+#: src/supports/properties.md:59
 msgid "`outline-style`は`border-style`と同じ値集合。UA依存の`auto`は非対応"
 msgstr ""
 
-#: src/supports/properties.md:56
+#: src/supports/properties.md:60
 msgid "`outline-offset`"
 msgstr ""
 
-#: src/supports/properties.md:56 src/supports/properties.md:67
-#: src/supports/properties.md:87 src/supports/properties.md:117
-#: src/supports/properties.md:155 src/supports/properties.md:167
-#: src/supports/properties.md:188 src/supports/properties.md:189
-#: src/supports/properties.md:221 src/supports/properties.md:222
-#: src/supports/properties.md:223 src/supports/selectors.md:23
-#: src/supports/selectors.md:50 src/supports/selectors.md:51
-#: src/supports/selectors.md:63 src/supports/selectors.md:79
-#: src/supports/selectors.md:84 src/supports/selectors.md:85
-#: src/supports/selectors.md:97 src/supports/selectors.md:99
-#: src/supports/selectors.md:127 src/supports/selectors.md:128
+#: src/supports/properties.md:60 src/supports/properties.md:92
+#: src/supports/properties.md:122 src/supports/properties.md:160
+#: src/supports/properties.md:172 src/supports/properties.md:193
+#: src/supports/properties.md:194 src/supports/properties.md:226
+#: src/supports/properties.md:227 src/supports/properties.md:228
+#: src/supports/selectors.md:24 src/supports/selectors.md:51
+#: src/supports/selectors.md:52 src/supports/selectors.md:64
+#: src/supports/selectors.md:80 src/supports/selectors.md:85
+#: src/supports/selectors.md:86 src/supports/selectors.md:98
+#: src/supports/selectors.md:100 src/supports/selectors.md:128
+#: src/supports/selectors.md:129
 msgid "❌"
 msgstr ""
 
-#: src/supports/properties.md:56
+#: src/supports/properties.md:60
 msgid "常に0固定"
 msgstr ""
 
-#: src/supports/properties.md:57
+#: src/supports/properties.md:61
 msgid "`box-shadow`"
 msgstr ""
 
-#: src/supports/properties.md:57
+#: src/supports/properties.md:61
 msgid ""
 "`none \\| "
 "<shadow>#`(カンマ区切りで複数指定可、先頭が最前面)。`inset`はパースするが描画は非対応。ぼかしは4段階の同心矩形による近似"
 msgstr ""
 
-#: src/supports/properties.md:59
+#: src/supports/properties.md:63
 msgid "配置(positioning / float / transform)"
 msgstr ""
 
-#: src/supports/properties.md:63
+#: src/supports/properties.md:67
 msgid "`float`"
 msgstr ""
 
-#: src/supports/properties.md:63
+#: src/supports/properties.md:67
 msgid "`none`/`left`/`right`。`width: auto`のshrink-to-fitに対応"
 msgstr ""
 
-#: src/supports/properties.md:64
+#: src/supports/properties.md:68
 msgid "`clear`"
 msgstr ""
 
-#: src/supports/properties.md:64
+#: src/supports/properties.md:68
 msgid "`none`/`left`/`right`/`both`"
 msgstr ""
 
-#: src/supports/properties.md:65
+#: src/supports/properties.md:69
 msgid "`position`"
 msgstr ""
 
-#: src/supports/properties.md:65
+#: src/supports/properties.md:69
 msgid ""
 "`static`/`relative`/`absolute`/`fixed`。`sticky`は非対応。`absolute`/`fixed`には後述の制約あり"
 msgstr ""
 
-#: src/supports/properties.md:66
+#: src/supports/properties.md:70
 msgid "`top` / `right` / `bottom` / `left`"
 msgstr ""
 
-#: src/supports/properties.md:66
+#: src/supports/properties.md:70
 msgid ""
 "`absolute`/`fixed`では`bottom`単独指定による下端揃えが非対応(高さの循環参照を避けるため`top`基準に解決する)。`relative`ではオフセットとして機能する"
 msgstr ""
 
-#: src/supports/properties.md:67
+#: src/supports/properties.md:71
 msgid "`inset`(ショートハンド)"
 msgstr ""
 
-#: src/supports/properties.md:67
-msgid "個別の`top`/`right`/`bottom`/`left`を使う"
+#: src/supports/properties.md:71
+msgid "1〜4値ショートハンド(展開規則は`margin`と同じ)"
 msgstr ""
 
-#: src/supports/properties.md:68
+#: src/supports/properties.md:72
+msgid "`inset-inline` / `inset-block` / `inset-inline-start`等"
+msgstr ""
+
+#: src/supports/properties.md:73
 msgid "`transform`"
 msgstr ""
 
-#: src/supports/properties.md:68
+#: src/supports/properties.md:73
 msgid ""
 "`translate`/`translateX`/`translateY`/`scale`/`scaleX`/`scaleY`/`rotate`/`skew`/`skewX`/`skewY`/`matrix`。3D系(`translate3d`/`rotate3d`/`perspective()`等)は非対応。PDFのCTM変換で実装するため、変換後の内容はページ分割の判定に影響しない"
 msgstr ""
 
-#: src/supports/properties.md:69
+#: src/supports/properties.md:74
 msgid "`transform-origin`"
 msgstr ""
 
-#: src/supports/properties.md:69
+#: src/supports/properties.md:74
 msgid ""
 "`background-position`と同じ値文法(キーワード/長さ/パーセンテージの1〜2値)。初期値`50% 50%`。3値目(Z軸)は非対応"
 msgstr ""
 
-#: src/supports/properties.md:71
+#: src/supports/properties.md:76
 msgid "`position: absolute`/`fixed`の既知の制約:"
 msgstr ""
 
-#: src/supports/properties.md:73
+#: src/supports/properties.md:78
 msgid "絶対配置要素は「通常フローから外し、確定したページへ後付けするオーバーレイ」として配置する"
 msgstr ""
 
-#: src/supports/properties.md:74
+#: src/supports/properties.md:79
 msgid "containing blockになれるのは、単一ページに収まっているpositioned祖先(またはページ領域)"
 msgstr ""
 
-#: src/supports/properties.md:75
+#: src/supports/properties.md:80
 msgid "テキストの途中に置いた`absolute`は、その前後のテキストが別々の行に分かれる(ブラウザのように1行のまま残らない)"
 msgstr ""
 
-#: src/supports/properties.md:76
+#: src/supports/properties.md:81
 msgid "絶対配置要素自身がページを跨ぐ分割は非対応(1ページにbest-effortで置く)"
 msgstr ""
 
-#: src/supports/properties.md:77
+#: src/supports/properties.md:82
 msgid "ストリーミングモード(`Mode::Streaming`)では絶対配置を無視する"
 msgstr ""
 
-#: src/supports/properties.md:79
+#: src/supports/properties.md:84
 msgid "フォント・テキスト"
 msgstr ""
 
-#: src/supports/properties.md:83
+#: src/supports/properties.md:88
 msgid "`font-family`"
 msgstr ""
 
-#: src/supports/properties.md:83
+#: src/supports/properties.md:88
 msgid ""
 "カンマ区切りリスト。汎用family名は`serif`/`sans-serif`/`monospace`をシステムフォントから解決する(`cursive`/`fantasy`は解決しない)。`sans-serif`の解決先はCLIの`--gothic-font`で決定的に上書きできる"
 msgstr ""
 
-#: src/supports/properties.md:84
+#: src/supports/properties.md:89
 msgid "`font-size`"
 msgstr ""
 
-#: src/supports/properties.md:84
+#: src/supports/properties.md:89
 msgid ""
 "`<length>`(`px`/`em`/`rem`)のみ。`smaller`/`larger`/`medium`等のキーワード、パーセンテージ指定は非対応"
 msgstr ""
 
-#: src/supports/properties.md:85 src/supports/fonts.md:107
+#: src/supports/properties.md:90 src/supports/fonts.md:107
 msgid "`font-weight`"
 msgstr ""
 
-#: src/supports/properties.md:85
+#: src/supports/properties.md:90
 msgid ""
 "`normal`/`bold`/`100`〜`900`。数値は600以上を`bold`とみなす2値化。太字フォントが無い場合は塗り+縁取りの疑似ボールドで描画"
 msgstr ""
 
-#: src/supports/properties.md:86 src/supports/fonts.md:108
+#: src/supports/properties.md:91 src/supports/fonts.md:108
 msgid "`font-style`"
 msgstr ""
 
-#: src/supports/properties.md:86
+#: src/supports/properties.md:91
 msgid ""
 "`normal`/`italic`/`oblique`(`oblique`は`italic`と同一視、傾斜角の指定は不可)。イタリック字形が無い場合はテキスト行列のせん断による疑似イタリック"
 msgstr ""
 
-#: src/supports/properties.md:87
+#: src/supports/properties.md:92
 msgid "`font`(ショートハンド)"
 msgstr ""
 
-#: src/supports/properties.md:87
+#: src/supports/properties.md:92
 msgid "個別のロングハンドを使う"
 msgstr ""
 
-#: src/supports/properties.md:88
+#: src/supports/properties.md:93
 msgid "`color`"
 msgstr ""
 
-#: src/supports/properties.md:88
+#: src/supports/properties.md:93
 msgid "継承プロパティ。指定できる色の記法は[セレクタ・値・at-rule](selectors.md#色)を参照"
 msgstr ""
 
-#: src/supports/properties.md:89
+#: src/supports/properties.md:94
 msgid "`line-height`"
 msgstr ""
 
-#: src/supports/properties.md:89
+#: src/supports/properties.md:94
 msgid "`normal`/`<number>`/`<length>`/`<percentage>`"
 msgstr ""
 
-#: src/supports/properties.md:90
+#: src/supports/properties.md:95
 msgid "`text-align`"
 msgstr ""
 
-#: src/supports/properties.md:90
+#: src/supports/properties.md:95
 msgid ""
 "`left`/`right`/`center`/`justify`。`justify`は最終行以外の単語間で余白を配分する。`start`/`end`は非対応(`direction`自体が非対応のため)"
 msgstr ""
 
-#: src/supports/properties.md:91
+#: src/supports/properties.md:96
 msgid "`text-indent`"
 msgstr ""
 
-#: src/supports/properties.md:91
+#: src/supports/properties.md:96
 msgid "`<length>`/`<percentage>`。`hanging`/`each-line`は非対応"
 msgstr ""
 
-#: src/supports/properties.md:92
+#: src/supports/properties.md:97
 msgid "`text-transform`"
 msgstr ""
 
-#: src/supports/properties.md:92
+#: src/supports/properties.md:97
 msgid ""
 "`none`/`uppercase`/`lowercase`/`capitalize`(語頭のみ変換)。`full-width`/`full-size-kana`は非対応"
 msgstr ""
 
-#: src/supports/properties.md:93
+#: src/supports/properties.md:98
 msgid "`text-decoration` / `text-decoration-line`"
 msgstr ""
 
-#: src/supports/properties.md:93
+#: src/supports/properties.md:98
 msgid ""
 "`none`/`underline`/`line-through`(併記可)。`overline`/`blink`は非対応。ショートハンドの`text-decoration-color`/`-style`/`-thickness`部分も非対応。祖先から子孫への伝播は「継承プロパティとして扱う」簡略実装"
 msgstr ""
 
-#: src/supports/properties.md:94
+#: src/supports/properties.md:99
 msgid "`text-shadow`"
 msgstr ""
 
-#: src/supports/properties.md:94
+#: src/supports/properties.md:99
 msgid ""
 "`none \\| <shadow>#`(`<offset-x> <offset-y> <blur>? "
 "<color>?`)。PDFにぼかしフィルタが無いため、blurはアルファを下げた多重描画による近似。継承プロパティ"
 msgstr ""
 
-#: src/supports/properties.md:95
+#: src/supports/properties.md:100
 msgid "`text-overflow`"
 msgstr ""
 
-#: src/supports/properties.md:95
+#: src/supports/properties.md:100
 msgid ""
 "`clip`/`ellipsis`。`overflow`が`visible`以外のときのみ有効。幅方向にはみ出した行のみが対象(ブロック全体のオーバーフローは扱わない)。`<string>`指定は非対応"
 msgstr ""
 
-#: src/supports/properties.md:96
+#: src/supports/properties.md:101
 msgid "`word-break`"
 msgstr ""
 
-#: src/supports/properties.md:96
+#: src/supports/properties.md:101
 msgid "`normal`(CJK文字が隣接する境界のみ改行可)/`break-all`/`keep-all`。非推奨値`break-word`は非対応"
 msgstr ""
 
-#: src/supports/properties.md:97
+#: src/supports/properties.md:102
 msgid "`overflow-wrap` / `word-wrap`"
 msgstr ""
 
-#: src/supports/properties.md:97
+#: src/supports/properties.md:102
 msgid ""
 "`normal`/`break-word`/`anywhere`(`anywhere`は`break-word`と同一視)。改行機会は増やさず、行頭に置いても収まらない語だけを文字単位で割る"
 msgstr ""
 
-#: src/supports/properties.md:98
+#: src/supports/properties.md:103
 msgid "`hyphens`"
 msgstr ""
 
-#: src/supports/properties.md:98
+#: src/supports/properties.md:103
 msgid ""
 "`none`/`manual`/`auto`。soft "
 "hyphen(U+00AD)でのみ分割し、分割時に行末へハイフンを表示する。`auto`は辞書を持たないため`manual`と同じ挙動(自動ハイフネーションはしない)"
 msgstr ""
 
-#: src/supports/properties.md:99
+#: src/supports/properties.md:104
 msgid "`text-emphasis` / `-style` / `-color` / `-position`"
 msgstr ""
 
-#: src/supports/properties.md:99
+#: src/supports/properties.md:104
 msgid ""
 "`dot`/`circle`/`double-circle`/`triangle`/`sesame`(`filled`/`open`)と`<string>`。キーワードのマークはPDFのパスで描くためフォントの字形に依存しない(`<string>`はグリフ描画で、字形が無ければ描かれない)。`position`は`over`/`under`のみ(`right`/`left`は読み飛ばし)。マーク分だけ行の高さが広がる。句読点をスキップする`text-emphasis-skip`は非対応"
 msgstr ""
 
-#: src/supports/properties.md:100
+#: src/supports/properties.md:105
 msgid "`letter-spacing`"
 msgstr ""
 
-#: src/supports/properties.md:100
+#: src/supports/properties.md:105
 msgid "`normal`/`<length>`。パーセンテージは非対応"
 msgstr ""
 
-#: src/supports/properties.md:101
+#: src/supports/properties.md:106
 msgid "`word-spacing`"
 msgstr ""
 
-#: src/supports/properties.md:101
+#: src/supports/properties.md:106
 msgid "`normal`/`<length>`"
 msgstr ""
 
-#: src/supports/properties.md:102
+#: src/supports/properties.md:107
 msgid "`white-space`"
 msgstr ""
 
-#: src/supports/properties.md:102
+#: src/supports/properties.md:107
 msgid "`normal`/`nowrap`/`pre`。`pre-wrap`/`pre-line`/`break-spaces`は非対応"
 msgstr ""
 
-#: src/supports/properties.md:103
+#: src/supports/properties.md:108
 msgid "`vertical-align`"
 msgstr ""
 
-#: src/supports/properties.md:103
+#: src/supports/properties.md:108
 msgid ""
 "`baseline`/`sub`/`super`/`text-top`/`text-bottom`/`top`/`middle`/`bottom`/`<length>`/`<percentage>`。テーブルセル文脈では`top`/`middle`/`bottom`(と`baseline`)が意味を持つ"
 msgstr ""
 
-#: src/supports/properties.md:104
+#: src/supports/properties.md:109
 msgid "`quotes`"
 msgstr ""
 
-#: src/supports/properties.md:104
+#: src/supports/properties.md:109
 msgid ""
 "`none`または`\"開き\" "
 "\"閉じ\"`のペアの繰り返し。`content`の`open-quote`/`close-quote`と組で使う。継承プロパティ"
 msgstr ""
 
-#: src/supports/properties.md:106
+#: src/supports/properties.md:111
 msgid "背景"
 msgstr ""
 
-#: src/supports/properties.md:110
+#: src/supports/properties.md:115
 msgid "`background`(ショートハンド)"
 msgstr ""
 
-#: src/supports/properties.md:110
+#: src/supports/properties.md:115
 msgid ""
 "`<color>`/`<image>`/`<repeat>`/`<attachment>`/`<position>[ / "
 "<size>]`を任意順で受け付ける。指定しなかったロングハンドは仕様通り初期値へリセットされる。`background-clip`/`-origin`(`padding-box`等のキーワード)を含むとパースエラーになり宣言ごと無視される点に注意"
 msgstr ""
 
-#: src/supports/properties.md:111
+#: src/supports/properties.md:116
 msgid "`background-color`"
 msgstr ""
 
-#: src/supports/properties.md:111
+#: src/supports/properties.md:116
 msgid "アルファ付きの色はExtGStateで透過描画"
 msgstr ""
 
-#: src/supports/properties.md:112
+#: src/supports/properties.md:117
 msgid "`background-image`"
 msgstr ""
 
-#: src/supports/properties.md:112
+#: src/supports/properties.md:117
 msgid ""
 "`none \\| "
 "url(...)`のみ。`linear-gradient()`等のグラデーション関数、カンマ区切りの複数背景は非対応。既定ではintrinsicサイズでタイル配置"
 msgstr ""
 
-#: src/supports/properties.md:113
+#: src/supports/properties.md:118
 msgid "`background-position`"
 msgstr ""
 
-#: src/supports/properties.md:113
+#: src/supports/properties.md:118
 msgid ""
 "キーワード(`left`/`center`/`right`/`top`/`bottom`)と長さ/パーセンテージの1〜2値。3〜4値構文(`right "
 "10px bottom 20px`)は非対応"
 msgstr ""
 
-#: src/supports/properties.md:114
+#: src/supports/properties.md:119
 msgid "`background-size`"
 msgstr ""
 
-#: src/supports/properties.md:114
+#: src/supports/properties.md:119
 msgid "`cover`/`contain`/`<length-percentage> \\| auto`の1〜2値"
 msgstr ""
 
-#: src/supports/properties.md:115
+#: src/supports/properties.md:120
 msgid "`background-repeat`"
 msgstr ""
 
-#: src/supports/properties.md:115
+#: src/supports/properties.md:120
 msgid "`repeat`/`repeat-x`/`repeat-y`/`no-repeat`。CSS3の`round`/`space`、2値構文は非対応"
 msgstr ""
 
-#: src/supports/properties.md:116
+#: src/supports/properties.md:121
 msgid "`background-attachment`"
 msgstr ""
 
-#: src/supports/properties.md:116
+#: src/supports/properties.md:121
 msgid "`scroll`/`fixed`(スクロールの概念が無いため`fixed`は`scroll`と同一視)"
 msgstr ""
 
-#: src/supports/properties.md:117
+#: src/supports/properties.md:122
 msgid "`background-clip` / `background-origin` / `background-blend-mode`"
 msgstr ""
 
-#: src/supports/properties.md:117
+#: src/supports/properties.md:122
 msgid "未実装。背景はborder-box基準で描画する"
 msgstr ""
 
-#: src/supports/properties.md:119
+#: src/supports/properties.md:124
 msgid "`border-radius`と`background-image`を併用した場合、角丸によるクリップは行わない(角丸は背景色の塗りにのみ効く)。"
 msgstr ""
 
-#: src/supports/properties.md:121
+#: src/supports/properties.md:126
 msgid "テーブル"
 msgstr ""
 
-#: src/supports/properties.md:125
+#: src/supports/properties.md:130
 msgid "`table-layout`"
 msgstr ""
 
-#: src/supports/properties.md:125
+#: src/supports/properties.md:130
 msgid "`auto`/`fixed`。`auto`ではセル内容の自然幅を測って列幅を決める(ネストしたテーブル・flexの自然幅測定のみ非対応で0扱い)"
 msgstr ""
 
-#: src/supports/properties.md:126
+#: src/supports/properties.md:131
 msgid "`border-collapse`"
 msgstr ""
 
-#: src/supports/properties.md:126
+#: src/supports/properties.md:131
 msgid ""
 "`separate`/`collapse`。`collapse`は見た目の枠線統合のみを行う(CSS2.1 "
 "§17.6.2の競合解決を「太い方が勝ち、同幅ならスタイル優先順」で簡略化)。継承プロパティ"
 msgstr ""
 
-#: src/supports/properties.md:127
+#: src/supports/properties.md:132
 msgid "`border-spacing`"
 msgstr ""
 
-#: src/supports/properties.md:127
+#: src/supports/properties.md:132
 msgid "`<length>{1,2}`。`border-collapse: collapse`時は0として扱う。継承プロパティ"
 msgstr ""
 
-#: src/supports/properties.md:128
+#: src/supports/properties.md:133
 msgid "`caption-side`"
 msgstr ""
 
-#: src/supports/properties.md:128
+#: src/supports/properties.md:133
 msgid "`top`/`bottom`。縦書き向けの`left`/`right`は非対応"
 msgstr ""
 
-#: src/supports/properties.md:129
+#: src/supports/properties.md:134
 msgid "`empty-cells`"
 msgstr ""
 
-#: src/supports/properties.md:129
+#: src/supports/properties.md:134
 msgid "`show`/`hide`。`border-collapse: separate`でのみ意味を持つ。継承プロパティ"
 msgstr ""
 
-#: src/supports/properties.md:130
+#: src/supports/properties.md:135
 msgid "`vertical-align`(セル)"
 msgstr ""
 
-#: src/supports/properties.md:130
+#: src/supports/properties.md:135
 msgid "上記[フォント・テキスト](#フォントテキスト)を参照"
 msgstr ""
 
-#: src/supports/properties.md:132
+#: src/supports/properties.md:137
 msgid ""
 "`<colgroup>`/`<col>`の`width`属性・CSS`width`による列幅指定、`rowspan`/`colspan`、`<thead>`のページまたぎ繰り返しに対応。 "
 "`rowspan=\"0\"`は1として扱う。"
 msgstr ""
 
-#: src/supports/properties.md:135
+#: src/supports/properties.md:140
 msgid ""
 "セルの`min-width`/`max-width`は列幅アルゴリズムに反映される。 `table-layout: "
 "auto`では列の自然幅をクランプする形で効くため、表を紙幅に収める比例縮尺の後は`min-width`が保証されない。 `table-layout: "
 "fixed`では1行目のセルの指定幅をクランプし、`width: auto`かつ`min-width`のみの指定はその値を列幅として使う。"
 msgstr ""
 
-#: src/supports/properties.md:139
+#: src/supports/properties.md:144
 msgid "リスト"
 msgstr ""
 
-#: src/supports/properties.md:143
+#: src/supports/properties.md:148
 msgid "`list-style`(ショートハンド)"
 msgstr ""
 
-#: src/supports/properties.md:143
+#: src/supports/properties.md:148
 msgid "`type`/`position`/`image`を任意順・任意省略で受け付ける"
 msgstr ""
 
-#: src/supports/properties.md:144
+#: src/supports/properties.md:149
 msgid "`list-style-type`"
 msgstr ""
 
-#: src/supports/properties.md:144
+#: src/supports/properties.md:149
 msgid ""
 "`disc`/`circle`/`square`/`decimal`/`decimal-leading-zero`/`lower-roman`/`upper-roman`/`lower-alpha`(`lower-latin`)/`upper-alpha`(`upper-latin`)/`none`。`cjk-*`/`hiragana`/`katakana`等は非対応。継承プロパティ"
 msgstr ""
 
-#: src/supports/properties.md:145
+#: src/supports/properties.md:150
 msgid "`list-style-position`"
 msgstr ""
 
-#: src/supports/properties.md:145
+#: src/supports/properties.md:150
 msgid "`outside`/`inside`。継承プロパティ"
 msgstr ""
 
-#: src/supports/properties.md:146
+#: src/supports/properties.md:151
 msgid "`list-style-image`"
 msgstr ""
 
-#: src/supports/properties.md:146
+#: src/supports/properties.md:151
 msgid "`none \\| url(...)`をパースするが描画には使わない(常に`list-style-type`のテキストマーカーへフォールバック)"
 msgstr ""
 
-#: src/supports/properties.md:148
+#: src/supports/properties.md:153
 msgid "生成コンテンツ・カウンタ"
 msgstr ""
 
-#: src/supports/properties.md:152
+#: src/supports/properties.md:157
 msgid "`content`"
 msgstr ""
 
-#: src/supports/properties.md:152
+#: src/supports/properties.md:157
 msgid ""
 "`::before`/`::after`/`::first-letter`および`@page`のmargin "
 "box用。文字列リテラル・`attr()`・`counter()`/`counters()`・`open-quote`/`close-quote`/`no-open-quote`/`no-close-quote`の連結に対応。`url()`による画像挿入は非対応。ブロック子を持つ要素の`::before`/`::after`は生成されない(簡略化)"
 msgstr ""
 
-#: src/supports/properties.md:153
+#: src/supports/properties.md:158
 msgid "`counter-reset`"
 msgstr ""
 
-#: src/supports/properties.md:153
+#: src/supports/properties.md:158
 msgid "`none`または`name [<integer>]`の繰り返し"
 msgstr ""
 
-#: src/supports/properties.md:154
+#: src/supports/properties.md:159
 msgid "`counter-increment`"
 msgstr ""
 
-#: src/supports/properties.md:154
+#: src/supports/properties.md:159
 msgid "`none`または`name [<integer>]`の繰り返し(値省略時は1)"
 msgstr ""
 
-#: src/supports/properties.md:155
+#: src/supports/properties.md:160
 msgid "`counter-set`"
 msgstr ""
 
-#: src/supports/properties.md:155 src/supports/properties.md:223
+#: src/supports/properties.md:160 src/supports/properties.md:228
 msgid "未実装"
 msgstr ""
 
-#: src/supports/properties.md:157
+#: src/supports/properties.md:162
 msgid ""
 "`counter(page)`/`counter(pages)`によるページ番号は`@page`のmargin "
 "box内で使える(`counter(pages)`はストリーミングモードでは総ページ数が確定しないためエラーになる)。"
 msgstr ""
 
-#: src/supports/properties.md:159
+#: src/supports/properties.md:164
 msgid "ページ分割(CSS Fragmentation)"
 msgstr ""
 
-#: src/supports/properties.md:163 src/supports/pagination.md:15
+#: src/supports/properties.md:168 src/supports/pagination.md:15
 msgid "`break-before` / `break-after`"
 msgstr ""
 
-#: src/supports/properties.md:163
+#: src/supports/properties.md:168
 msgid ""
 "`auto`/`avoid`(`avoid-page`/`avoid-column`も同義)/`always`(`page`も同義)。`left`/`right`/`recto`/`verso`(見開き制御)、多段組み関連の値は非対応"
 msgstr ""
 
-#: src/supports/properties.md:164 src/supports/pagination.md:16
+#: src/supports/properties.md:169 src/supports/pagination.md:16
 msgid "`break-inside`"
 msgstr ""
 
-#: src/supports/properties.md:164
+#: src/supports/properties.md:169
 msgid "`auto`/`avoid`(`avoid-page`/`avoid-column`も同義)"
 msgstr ""
 
-#: src/supports/properties.md:165
+#: src/supports/properties.md:170
 msgid "`page-break-before` / `page-break-after` / `page-break-inside`"
 msgstr ""
 
-#: src/supports/properties.md:165
+#: src/supports/properties.md:170
 msgid "上記`break-*`のエイリアス(wkhtmltopdf/wicked_pdf資産からの移行用)"
 msgstr ""
 
-#: src/supports/properties.md:166
+#: src/supports/properties.md:171
 msgid "`orphans` / `widows`"
 msgstr ""
 
-#: src/supports/properties.md:166
+#: src/supports/properties.md:171
 msgid "1以上の整数。初期値2"
 msgstr ""
 
-#: src/supports/properties.md:167
+#: src/supports/properties.md:172
 msgid "`page`(名前付きページ)"
 msgstr ""
 
-#: src/supports/properties.md:167
+#: src/supports/properties.md:172
 msgid "`@page intro`のような名前付きページ自体が非対応"
 msgstr ""
 
-#: src/supports/properties.md:169
+#: src/supports/properties.md:174
 msgid "HTML属性`data-page-break=\"before|after|avoid\"`によるシンタックスシュガーも利用できる。"
 msgstr ""
 
-#: src/supports/properties.md:171
+#: src/supports/properties.md:176
 msgid "Flexbox"
 msgstr ""
 
-#: src/supports/properties.md:173
+#: src/supports/properties.md:178
 msgid ""
 "`display: flex`のレイアウトは[taffy](https://github.com/DioxusLabs/taffy)へ委譲する。 "
 "flexコンテナはページ分割上アトミック(`display: table`と同じく途中で分割されない)。"
 msgstr ""
 
-#: src/supports/properties.md:178
+#: src/supports/properties.md:183
 msgid "`flex-direction`"
 msgstr ""
 
-#: src/supports/properties.md:178
+#: src/supports/properties.md:183
 msgid "`row`/`row-reverse`/`column`/`column-reverse`"
 msgstr ""
 
-#: src/supports/properties.md:179
+#: src/supports/properties.md:184
 msgid "`flex-wrap`"
 msgstr ""
 
-#: src/supports/properties.md:179
+#: src/supports/properties.md:184
 msgid "`nowrap`/`wrap`/`wrap-reverse`"
 msgstr ""
 
-#: src/supports/properties.md:180
+#: src/supports/properties.md:185
 msgid "`justify-content`"
 msgstr ""
 
-#: src/supports/properties.md:180
+#: src/supports/properties.md:185
 msgid ""
 "`normal`(初期値)/`flex-start`(`start`)/`flex-end`(`end`)/`center`/`space-between`/`space-around`/`space-evenly`。`safe`/`unsafe`オーバーフローキーワードは非対応"
 msgstr ""
 
-#: src/supports/properties.md:181
+#: src/supports/properties.md:186
 msgid "`align-items`"
 msgstr ""
 
-#: src/supports/properties.md:181
+#: src/supports/properties.md:186
 msgid "`flex-start`(`start`)/`flex-end`(`end`)/`center`/`baseline`/`stretch`"
 msgstr ""
 
-#: src/supports/properties.md:182
+#: src/supports/properties.md:187
 msgid "`align-content`"
 msgstr ""
 
-#: src/supports/properties.md:182
+#: src/supports/properties.md:187
 msgid ""
 "`flex-start`(`start`)/`flex-end`(`end`)/`center`/`stretch`/`space-between`/`space-around`/`space-evenly`"
 msgstr ""
 
-#: src/supports/properties.md:183
+#: src/supports/properties.md:188
 msgid "`align-self`"
 msgstr ""
 
-#: src/supports/properties.md:183
+#: src/supports/properties.md:188
 msgid ""
 "`auto`/`flex-start`(`start`)/`flex-end`(`end`)/`center`/`baseline`/`stretch`"
 msgstr ""
 
-#: src/supports/properties.md:184
+#: src/supports/properties.md:189
 msgid "`flex-grow` / `flex-shrink`"
 msgstr ""
 
-#: src/supports/properties.md:184
+#: src/supports/properties.md:189
 msgid "非負の`<number>`(負値は無効な宣言として無視)"
 msgstr ""
 
-#: src/supports/properties.md:185
+#: src/supports/properties.md:190
 msgid "`flex-basis`"
 msgstr ""
 
-#: src/supports/properties.md:185
+#: src/supports/properties.md:190
 msgid "`auto`/`content`/`<length-percentage>`。`content`は`auto`と同一視"
 msgstr ""
 
-#: src/supports/properties.md:186
+#: src/supports/properties.md:191
 msgid "`flex`(ショートハンド)"
 msgstr ""
 
-#: src/supports/properties.md:186
+#: src/supports/properties.md:191
 msgid ""
 "`none`および`<grow> [<shrink>] [<basis>]`。CSS仕様の既定値規則(`flex: "
 "1`のbasisは`0%`、`flex: <width>`のgrow/shrinkは1)を再現"
 msgstr ""
 
-#: src/supports/properties.md:187
+#: src/supports/properties.md:192
 msgid "`gap` / `row-gap` / `column-gap`"
 msgstr ""
 
-#: src/supports/properties.md:187
+#: src/supports/properties.md:192
 msgid "flexコンテナでのみ有効(多段組みの`column-gap`としては機能しない)"
 msgstr ""
 
-#: src/supports/properties.md:188
+#: src/supports/properties.md:193
 msgid "`order`"
 msgstr ""
 
-#: src/supports/properties.md:188
+#: src/supports/properties.md:193
 msgid "taffy 0.12系が未対応のため"
 msgstr ""
 
-#: src/supports/properties.md:189
+#: src/supports/properties.md:194
 msgid "`place-content` / `place-items` / `place-self`(ショートハンド)"
 msgstr ""
 
-#: src/supports/properties.md:189
+#: src/supports/properties.md:194
 msgid "未実装。個別のロングハンドを使う"
 msgstr ""
 
-#: src/supports/properties.md:190 src/supports/properties.md:219
+#: src/supports/properties.md:195 src/supports/properties.md:224
 msgid "`justify-items` / `justify-self`"
 msgstr ""
 
-#: src/supports/properties.md:190 src/migration/wicked-pdf.md:72
+#: src/supports/properties.md:195 src/migration/wicked-pdf.md:72
 #: src/migration/wicked-pdf.md:73 src/migration/wicked-pdf.md:74
 #: src/migration/wicked-pdf.md:75 src/migration/wicked-pdf.md:76
 #: src/migration/wicked-pdf.md:77
 msgid "—"
 msgstr ""
 
-#: src/supports/properties.md:190
+#: src/supports/properties.md:195
 msgid "flexアイテムには適用されない(下記)"
 msgstr ""
 
-#: src/supports/properties.md:192
+#: src/supports/properties.md:197
 msgid "`justify-items`/`justify-self`がflexで効かないのは仕様"
 msgstr ""
 
-#: src/supports/properties.md:194
+#: src/supports/properties.md:199
 msgid ""
 "CSS Box "
 "Alignmentでは`justify-items`/`justify-self`はGrid・ブロックレイアウト用のプロパティで、flexアイテムには適用されない(主軸方向のアイテム個別の配置は`justify-content`と`margin: "
@@ -4168,220 +4212,220 @@ msgid ""
 "レイアウトを委譲しているtaffyでも、これらを参照するのはGridのアルゴリズムだけで、flexboxのアルゴリズムは一切参照しない。"
 msgstr ""
 
-#: src/supports/properties.md:198
+#: src/supports/properties.md:203
 msgid ""
 "したがってこのエンジンでパースに対応しても見た目は変わらないため、意図的に実装していない。 flexで特定のアイテムだけを寄せたい場合は`margin: "
 "auto`を使う(こちらは対応済み):"
 msgstr ""
 
-#: src/supports/properties.md:202
+#: src/supports/properties.md:207
 msgid "/* justify-self: end 相当(主軸の終端へ) */"
 msgstr ""
 
-#: src/supports/properties.md:203
+#: src/supports/properties.md:208
 msgid "/* justify-self: center 相当 */"
 msgstr ""
 
-#: src/supports/properties.md:206
+#: src/supports/properties.md:211
 msgid "Grid"
 msgstr ""
 
-#: src/supports/properties.md:208
+#: src/supports/properties.md:213
 msgid ""
 "`display: grid`のレイアウトはFlexboxと同じくtaffyへ委譲する。 "
 "Flexboxと違い、1ページに収まらないグリッドは行単位でページ分割される(テーブルと同じ方針。複数行にまたがるアイテムがある境界では分割しない)。"
 msgstr ""
 
-#: src/supports/properties.md:213
+#: src/supports/properties.md:218
 msgid "`grid-template-columns` / `grid-template-rows`"
 msgstr ""
 
-#: src/supports/properties.md:213
+#: src/supports/properties.md:218
 msgid ""
 "`none`/`<length>`/`<percentage>`/`fr`/`auto`/`min-content`/`max-content`/`minmax()`/`fit-content()`/`repeat(<整数>\\|auto-fill\\|auto-fit)`/`[name]`(ライン名)。トラックサイズに`calc()`は非対応"
 msgstr ""
 
-#: src/supports/properties.md:214
+#: src/supports/properties.md:219
 msgid "`grid-template-areas`"
 msgstr ""
 
-#: src/supports/properties.md:214
+#: src/supports/properties.md:219
 msgid "文字列マトリクス。列数の不一致・非矩形のエリアは不正な値として宣言ごと無視する(仕様通り)。`.`は名前なしセル"
 msgstr ""
 
-#: src/supports/properties.md:215
+#: src/supports/properties.md:220
 msgid "`grid-auto-columns` / `grid-auto-rows`"
 msgstr ""
 
-#: src/supports/properties.md:215
+#: src/supports/properties.md:220
 msgid "`<track-size>+`"
 msgstr ""
 
-#: src/supports/properties.md:216
+#: src/supports/properties.md:221
 msgid "`grid-auto-flow`"
 msgstr ""
 
-#: src/supports/properties.md:216
+#: src/supports/properties.md:221
 msgid "`row`/`column`/`dense`(併記可)"
 msgstr ""
 
-#: src/supports/properties.md:217
+#: src/supports/properties.md:222
 msgid "`grid-row-start` / `-end` / `grid-column-start` / `-end`"
 msgstr ""
 
-#: src/supports/properties.md:217
+#: src/supports/properties.md:222
 msgid ""
 "`auto`/`<integer>`/`span <integer>`/`<custom-ident>`/`span <custom-ident>`"
 msgstr ""
 
-#: src/supports/properties.md:218
+#: src/supports/properties.md:223
 msgid "`grid-row` / `grid-column` / `grid-area`"
 msgstr ""
 
-#: src/supports/properties.md:218
+#: src/supports/properties.md:223
 msgid "`/`区切りのショートハンド。`grid-area: <name>`で名前付きエリアを指定できる"
 msgstr ""
 
-#: src/supports/properties.md:219
+#: src/supports/properties.md:224
 msgid ""
 "Gridでのみ意味を持つ(flexアイテムには適用されない、[上記](#justify-itemsjustify-selfがflexで効かないのは仕様))"
 msgstr ""
 
-#: src/supports/properties.md:220
+#: src/supports/properties.md:225
 msgid ""
 "`align-items` / `align-self` / `justify-content` / `align-content` / `gap`"
 msgstr ""
 
-#: src/supports/properties.md:220
+#: src/supports/properties.md:225
 msgid "Flexboxと共有(値の範囲は[Flexbox](#flexbox)節を参照)"
 msgstr ""
 
-#: src/supports/properties.md:221
+#: src/supports/properties.md:226
 msgid "`grid` / `grid-template`(ショートハンド)"
 msgstr ""
 
-#: src/supports/properties.md:221
+#: src/supports/properties.md:226
 msgid "個別のロングハンドを使う。トラック定義とエリア定義を1つの構文へ詰め込む複雑な文法のため非対応"
 msgstr ""
 
-#: src/supports/properties.md:222
+#: src/supports/properties.md:227
 msgid "`display: inline-grid`"
 msgstr ""
 
-#: src/supports/properties.md:222
+#: src/supports/properties.md:227
 msgid "`inline-flex`と同じ理由で非対応"
 msgstr ""
 
-#: src/supports/properties.md:223
+#: src/supports/properties.md:228
 msgid "subgrid / masonry"
 msgstr ""
 
-#: src/supports/properties.md:225
+#: src/supports/properties.md:230
 msgid ""
 "`auto`トラックだけで構成したグリッドにコンテナ幅の指定がある場合、余った幅は`auto`トラックへ配分されますが、その配分比率はCSSの規定(`auto`トラックへ均等)と一致しません。 "
 "列幅を厳密に決めたい場合は`fr`か長さで指定してください。"
 msgstr ""
 
-#: src/supports/properties.md:228
+#: src/supports/properties.md:233
 msgid "置換要素(画像)"
 msgstr ""
 
-#: src/supports/properties.md:232
+#: src/supports/properties.md:237
 msgid "`object-fit`"
 msgstr ""
 
-#: src/supports/properties.md:232
+#: src/supports/properties.md:237
 msgid "`fill`/`contain`/`cover`/`none`/`scale-down`。`<img>`にのみ意味を持つ"
 msgstr ""
 
-#: src/supports/properties.md:233
+#: src/supports/properties.md:238
 msgid "`object-position`"
 msgstr ""
 
-#: src/supports/properties.md:233
+#: src/supports/properties.md:238
 msgid "`background-position`と同じ値文法。初期値`50% 50%`"
 msgstr ""
 
-#: src/supports/properties.md:235
+#: src/supports/properties.md:240
 msgid ""
 "`<img>`はインライン配置・`width`/`height`属性/CSSによるサイズ指定に対応。 対応フォーマットはPNG/JPEG/WebP。 "
 "CSSで`width`/`height`の片方だけを指定した場合は内在アスペクト比でもう一方を導出する([`aspect-ratio`](#ボックスモデル)、)。"
 msgstr ""
 
-#: src/supports/properties.md:239
+#: src/supports/properties.md:244
 msgid "非対応プロパティ一覧"
 msgstr ""
 
-#: src/supports/properties.md:241
+#: src/supports/properties.md:246
 msgid "以下は宣言ごと無視される(パースエラー)。 実装が無いだけで、意図的に永久除外と決めたものだけではない。 カテゴリ表の`❌`行も参照。"
 msgstr ""
 
-#: src/supports/properties.md:245
+#: src/supports/properties.md:250
 msgid ""
 "ショートハンド: "
-"`font`/`inset`/`place-content`/`place-items`/`place-self`/`text-decoration`の色・線種部分"
+"`font`/`place-content`/`place-items`/`place-self`/`text-decoration`の色・線種部分"
 msgstr ""
 
-#: src/supports/properties.md:246
+#: src/supports/properties.md:251
 msgid ""
-"論理プロパティ: "
-"`inline-size`/`block-size`/`margin-inline`/`padding-block`/`border-inline`等すべて"
+"論理プロパティのうち寸法系: "
+"`inline-size`/`block-size`/`min-inline-size`/`max-block-size`等(`margin`/`padding`/`inset`/`border`の論理プロパティは対応済み)"
 msgstr ""
 
-#: src/supports/properties.md:247
+#: src/supports/properties.md:252
 msgid ""
 "書字方向: "
 "`direction`/`unicode-bidi`/`writing-mode`/`text-orientation`/`text-combine-upright`"
 msgstr ""
 
-#: src/supports/properties.md:248
+#: src/supports/properties.md:253
 msgid ""
 "テキスト詳細: "
 "`text-decoration-color`/`-style`/`-thickness`/`text-underline-offset`/`text-emphasis-skip`/`tab-size`/`ruby-*`/`text-justify`/`line-break`"
 msgstr ""
 
-#: src/supports/properties.md:249
+#: src/supports/properties.md:254
 msgid ""
 "フォント詳細: "
 "`font-variant`/`font-stretch`/`font-feature-settings`/`font-variation-settings`/`font-kerning`/`font-display`"
 msgstr ""
 
-#: src/supports/properties.md:250
+#: src/supports/properties.md:255
 msgid ""
 "多段組み: "
 "`columns`/`column-count`/`column-width`/`column-rule`/`column-span`/`column-fill`"
 msgstr ""
 
-#: src/supports/properties.md:251
+#: src/supports/properties.md:256
 msgid ""
 "視覚効果: "
 "`filter`/`backdrop-filter`/`mix-blend-mode`/`background-blend-mode`/`clip`/`clip-path`/`mask`/`isolation`"
 msgstr ""
 
-#: src/supports/properties.md:252
+#: src/supports/properties.md:257
 msgid ""
 "3D/アニメーション: "
 "`perspective`/`transform-style`/`backface-visibility`/`translate`/`rotate`/`scale`(個別プロパティ版)/`transition-*`/`animation-*`/`will-change`"
 msgstr ""
 
-#: src/supports/properties.md:253
+#: src/supports/properties.md:258
 msgid ""
 "枠線・背景の拡張: "
 "`border-image-*`/`background-clip`/`background-origin`/`outline-offset`"
 msgstr ""
 
-#: src/supports/properties.md:254
+#: src/supports/properties.md:259
 msgid ""
 "オーバーフロー: `overflow-x`/`overflow-y`/`resize`/`scroll-*`/`overscroll-behavior`"
 msgstr ""
 
-#: src/supports/properties.md:255
+#: src/supports/properties.md:260
 msgid ""
 "UI/対話: "
 "`cursor`/`pointer-events`/`user-select`/`caret-color`/`accent-color`/`appearance`"
 msgstr ""
 
-#: src/supports/properties.md:256
+#: src/supports/properties.md:261
 msgid ""
 "その他: "
 "`all`/`content-visibility`/`counter-set`/`page`(名前付きページ)/`speak`等の音声メディア系/`zoom`"
@@ -4457,450 +4501,460 @@ msgid "セレクタリスト(`,`)"
 msgstr ""
 
 #: src/supports/selectors.md:23
-msgid "名前空間(`ns\\|E`)"
+msgid "ネスト(`.a { .b { } }` / `& .b` / `&.b` / `> .b`)"
 msgstr ""
 
 #: src/supports/selectors.md:23
+msgid ""
+"CSS Nesting。`&`を省いたセレクタは`& .b`、先頭がコンビネータのものは`& > "
+".b`として扱う。`&`は`:is(親)`に置き換わるので詳細度は親のうち最も高いものになる。ネストしたルールの後ろに書いた宣言は、そのルールより後ろの順序でカスケードに参加する。ネストした`@media`等のat-ruleは非対応(ブロックごと無視)"
+msgstr ""
+
+#: src/supports/selectors.md:24
+msgid "名前空間(`ns\\|E`)"
+msgstr ""
+
+#: src/supports/selectors.md:24
 msgid "`@namespace`自体が非対応"
 msgstr ""
 
-#: src/supports/selectors.md:25 src/supports/selectors.md:27
+#: src/supports/selectors.md:26 src/supports/selectors.md:28
 msgid "擬似クラス"
 msgstr ""
 
-#: src/supports/selectors.md:29
+#: src/supports/selectors.md:30
 msgid "`:root`"
 msgstr ""
 
-#: src/supports/selectors.md:30
+#: src/supports/selectors.md:31
 msgid "`:first-child` / `:last-child` / `:only-child`"
 msgstr ""
 
-#: src/supports/selectors.md:31
+#: src/supports/selectors.md:32
 msgid "`:nth-child()` / `:nth-last-child()`"
 msgstr ""
 
-#: src/supports/selectors.md:31
+#: src/supports/selectors.md:32
 msgid "ストリーミングモードでは`:nth-last-child()`の結果が変わる(下記参照)"
 msgstr ""
 
-#: src/supports/selectors.md:32
+#: src/supports/selectors.md:33
 msgid ""
 "`:first-of-type` / `:last-of-type` / `:only-of-type` / `:nth-of-type()` / "
 "`:nth-last-of-type()`"
 msgstr ""
 
-#: src/supports/selectors.md:32
+#: src/supports/selectors.md:33
 msgid "ストリーミングモードでは`:first-of-type`/`:nth-of-type()`以外の結果が変わる(下記参照)"
 msgstr ""
 
-#: src/supports/selectors.md:33
+#: src/supports/selectors.md:34
 msgid "`:empty`"
 msgstr ""
 
-#: src/supports/selectors.md:34
+#: src/supports/selectors.md:35
 msgid "`:not()`"
 msgstr ""
 
-#: src/supports/selectors.md:35
+#: src/supports/selectors.md:36
 msgid "`:is()` / `:where()`"
 msgstr ""
 
-#: src/supports/selectors.md:35
+#: src/supports/selectors.md:36
 msgid ""
 "引数リストは寛容(未対応のセレクタが混ざっていてもその項だけを捨てる)。詳細度は`:is()`が引数のうち最も高いもの、`:where()`は常に0"
 msgstr ""
 
-#: src/supports/selectors.md:36
+#: src/supports/selectors.md:37
 msgid "`:has()`"
 msgstr ""
 
-#: src/supports/selectors.md:36
+#: src/supports/selectors.md:37
 msgid ""
 "子孫・`>`・`+`・`~`のいずれも書ける。詳細度は`:is()`と同じ規則。入れ子(`:has()`の中の`:has()`)と擬似要素は仕様どおり書けない。ストリーミングモードでは`:has(~ "
 "...)`が非マッチ(下記参照)"
 msgstr ""
 
-#: src/supports/selectors.md:37
+#: src/supports/selectors.md:38
 msgid ""
 "`:hover` / `:active` / `:focus` / `:focus-within` / `:focus-visible` / "
 "`:target` / `:enabled` / `:disabled` / `:checked` / `:visited`"
 msgstr ""
 
-#: src/supports/selectors.md:37
+#: src/supports/selectors.md:38
 msgid "パースは通るが常に非マッチ。対話状態を持たない静的なPDF出力では意味を持たないため"
 msgstr ""
 
-#: src/supports/selectors.md:38
+#: src/supports/selectors.md:39
 msgid "`:link` / `:any-link`"
 msgstr ""
 
-#: src/supports/selectors.md:38
+#: src/supports/selectors.md:39
 msgid "`href`を持つ`<a>`にマッチする"
 msgstr ""
 
-#: src/supports/selectors.md:40
+#: src/supports/selectors.md:41
 msgid ""
 "非対応の擬似要素(`::first-line`等)がセレクタに含まれるとルール全体が捨てられる。 "
 "一方`:hover`のようにパースが通るものは、ルールとしては生き残った上でマッチしない。 `:is()` / "
 "`:where()`の引数リストだけは例外で、未対応の項があってもその項が捨てられるだけでルールは生きる。"
 msgstr ""
 
-#: src/supports/selectors.md:44 src/supports/selectors.md:46
+#: src/supports/selectors.md:45 src/supports/selectors.md:47
 msgid "擬似要素"
 msgstr ""
 
-#: src/supports/selectors.md:48
+#: src/supports/selectors.md:49
 msgid "`::before` / `::after`"
 msgstr ""
 
-#: src/supports/selectors.md:48
+#: src/supports/selectors.md:49
 msgid ""
 "`content`による生成テキストのみ。ホスト要素の計算スタイルをそのまま流用して描画し、擬似要素専用のボックススタイル(margin/padding/display等)は持たない。ブロック子を持つ要素では生成されない"
 msgstr ""
 
-#: src/supports/selectors.md:49
+#: src/supports/selectors.md:50
 msgid "`::first-letter`"
 msgstr ""
 
-#: src/supports/selectors.md:49
+#: src/supports/selectors.md:50
 msgid ""
 "`font-family`/`font-size`/`font-weight`/`font-style`/`color`/`text-decoration-line`/`text-transform`のみ上書きできる(`float`・box "
 "model系は非対応)"
 msgstr ""
 
-#: src/supports/selectors.md:50
+#: src/supports/selectors.md:51
 msgid "`::first-line`"
 msgstr ""
 
-#: src/supports/selectors.md:50 src/supports/selectors.md:51
+#: src/supports/selectors.md:51 src/supports/selectors.md:52
 msgid "パースエラー"
 msgstr ""
 
-#: src/supports/selectors.md:51
+#: src/supports/selectors.md:52
 msgid "`::marker` / `::selection` / `::placeholder`"
 msgstr ""
 
-#: src/supports/selectors.md:53
+#: src/supports/selectors.md:54
 msgid "値・単位・関数"
 msgstr ""
 
-#: src/supports/selectors.md:55
+#: src/supports/selectors.md:56
 msgid "長さ"
 msgstr ""
 
-#: src/supports/selectors.md:57
+#: src/supports/selectors.md:58
 msgid "単位"
 msgstr ""
 
-#: src/supports/selectors.md:59
+#: src/supports/selectors.md:60
 msgid "`px` / `em` / `rem`"
 msgstr ""
 
-#: src/supports/selectors.md:60
+#: src/supports/selectors.md:61
 msgid "`mm` / `cm` / `in` / `pt` / `pc` / `Q`"
 msgstr ""
 
-#: src/supports/selectors.md:61
+#: src/supports/selectors.md:62
 msgid "`%`(パーセンテージを取るプロパティで)"
 msgstr ""
 
-#: src/supports/selectors.md:62
+#: src/supports/selectors.md:63
 msgid "単位なしの`0`"
 msgstr ""
 
-#: src/supports/selectors.md:63
+#: src/supports/selectors.md:64
 msgid "`ex` / `ch` / `vw` / `vh` / `vmin` / `vmax` / `lh`"
 msgstr ""
 
-#: src/supports/selectors.md:65
+#: src/supports/selectors.md:66
 msgid ""
 "絶対単位は1インチ = 96pxとして解釈する(`10mm`は37.795px)。 印刷向けに寸法を実寸で書けるので、`@page { size: "
 "210mm 297mm; margin: 15mm; }`のような指定がそのまま通る。"
 msgstr ""
 
-#: src/supports/selectors.md:68
+#: src/supports/selectors.md:69
 msgid ""
 "`@page`の`size`だけは例外的にページサイズのキーワード(`a4`/`letter`等)と`landscape`/`portrait`を受け付ける。"
 msgstr ""
 
-#: src/supports/selectors.md:70
+#: src/supports/selectors.md:71
 msgid "角度(`transform`専用)"
 msgstr ""
 
-#: src/supports/selectors.md:72
+#: src/supports/selectors.md:73
 msgid "`deg` / `rad` / `grad` / `turn`、および単位なしの`0`に対応 ✅。"
 msgstr ""
 
-#: src/supports/selectors.md:74 src/supports/selectors.md:76
+#: src/supports/selectors.md:75 src/supports/selectors.md:77
 msgid "関数"
 msgstr ""
 
-#: src/supports/selectors.md:78
+#: src/supports/selectors.md:79
 msgid "`calc()`"
 msgstr ""
 
-#: src/supports/selectors.md:78
+#: src/supports/selectors.md:79
 msgid ""
-"`+`/`-`/`*`/`/`と括弧のネスト。項に使えるのは長さ(絶対単位・`em`/`rem`)・`%`・数値のみ。長さ・パーセンテージを取るプロパティ全般で使える"
+"`+`/`-`/`*`/`/`と括弧・`calc()`のネスト。項に使えるのは長さ(絶対単位・`em`/`rem`)・`%`・数値のみ。長さ・パーセンテージを取るプロパティ全般で使える"
 msgstr ""
 
-#: src/supports/selectors.md:79
+#: src/supports/selectors.md:80
 msgid "`min()` / `max()` / `clamp()`"
 msgstr ""
 
-#: src/supports/selectors.md:80
+#: src/supports/selectors.md:81
 msgid "`var()`"
 msgstr ""
 
-#: src/supports/selectors.md:80
+#: src/supports/selectors.md:81
 msgid ""
 "カスタムプロパティ(`--foo`)をパース前のテキスト置換で解決する。フォールバック(`var(--x, "
 "10px)`)・カスタムプロパティ同士の参照に対応。カスケードや継承には従わず、文書全体で「最後に書かれた宣言が勝つ」単純な解決になる点が本来の仕様と異なる"
 msgstr ""
 
-#: src/supports/selectors.md:81
+#: src/supports/selectors.md:82
 msgid "`url()`"
 msgstr ""
 
-#: src/supports/selectors.md:81
+#: src/supports/selectors.md:82
 msgid ""
 "`background-image`/`list-style-image`/`@font-face`の`src`/`@import`。相対URLは`<base "
 "href>`または入力元を基準に解決する"
 msgstr ""
 
-#: src/supports/selectors.md:82
+#: src/supports/selectors.md:83
 msgid "`attr()`"
 msgstr ""
 
-#: src/supports/selectors.md:82
+#: src/supports/selectors.md:83
 msgid "`content`の中でのみ使える"
 msgstr ""
 
-#: src/supports/selectors.md:83
+#: src/supports/selectors.md:84
 msgid "`counter()` / `counters()`"
 msgstr ""
 
-#: src/supports/selectors.md:83
+#: src/supports/selectors.md:84
 msgid "`content`の中。第2引数のスタイルは`list-style-type`の値集合"
 msgstr ""
 
-#: src/supports/selectors.md:84
+#: src/supports/selectors.md:85
 msgid "`linear-gradient()`等のグラデーション"
 msgstr ""
 
-#: src/supports/selectors.md:85
+#: src/supports/selectors.md:86
 msgid "`env()` / `image-set()` / `element()`"
 msgstr ""
 
-#: src/supports/selectors.md:87
+#: src/supports/selectors.md:88
 msgid "色"
 msgstr ""
 
-#: src/supports/selectors.md:89
+#: src/supports/selectors.md:90
 msgid "記法"
 msgstr ""
 
-#: src/supports/selectors.md:91
+#: src/supports/selectors.md:92
 msgid "名前付き色(`red`等のCSS色キーワード)"
 msgstr ""
 
-#: src/supports/selectors.md:92
+#: src/supports/selectors.md:93
 msgid "`#rgb` / `#rgba` / `#rrggbb` / `#rrggbbaa`"
 msgstr ""
 
-#: src/supports/selectors.md:93
+#: src/supports/selectors.md:94
 msgid "`rgb()` / `rgba()`(カンマ区切り・スペース区切りとも)"
 msgstr ""
 
-#: src/supports/selectors.md:94
+#: src/supports/selectors.md:95
 msgid "`hsl()` / `hsla()` / `hwb()`"
 msgstr ""
 
-#: src/supports/selectors.md:95
+#: src/supports/selectors.md:96
 msgid "`lab()` / `lch()` / `oklab()` / `oklch()`"
 msgstr ""
 
-#: src/supports/selectors.md:95
+#: src/supports/selectors.md:96
 msgid "✅ (sRGBへ変換して描画)"
 msgstr ""
 
-#: src/supports/selectors.md:96
+#: src/supports/selectors.md:97
 msgid "`currentcolor` / `transparent`"
 msgstr ""
 
-#: src/supports/selectors.md:97
+#: src/supports/selectors.md:98
 msgid "`color()`(`color(display-p3 ...)`等)"
 msgstr ""
 
-#: src/supports/selectors.md:98 src/supports/selectors.md:103
+#: src/supports/selectors.md:99 src/supports/selectors.md:104
 msgid "`color-mix()`"
 msgstr ""
 
-#: src/supports/selectors.md:98
+#: src/supports/selectors.md:99
 msgid "⚠️ (下記)"
 msgstr ""
 
-#: src/supports/selectors.md:99
+#: src/supports/selectors.md:100
 msgid "相対色構文(`rgb(from ...)`)"
 msgstr ""
 
-#: src/supports/selectors.md:101
+#: src/supports/selectors.md:102
 msgid "アルファ付きの色は塗り・背景ともPDFのExtGStateで透過描画する。"
 msgstr ""
 
-#: src/supports/selectors.md:105
+#: src/supports/selectors.md:106
 msgid ""
 "`color-mix(in <色空間> [<色相の回し方> hue]?, <色> <割合>?, <色> <割合>?)`に対応する。 "
 "割合の正規化(合計が100%を超えるときは比率だけが効き、満たないときは足りないぶんだけ結果が透明になる)と、アルファの事前乗算も仕様どおり行う。"
 msgstr ""
 
-#: src/supports/selectors.md:108
+#: src/supports/selectors.md:109
 msgid ""
 "色空間: `srgb` / `srgb-linear` / `lab` / `oklab` / `xyz`(`xyz-d65`) / `hsl` / "
 "`hwb` / `lch` / `oklch`"
 msgstr ""
 
-#: src/supports/selectors.md:109
+#: src/supports/selectors.md:110
 msgid "色相の回し方: `shorter`(既定) / `longer` / `increasing` / `decreasing`"
 msgstr ""
 
-#: src/supports/selectors.md:110
+#: src/supports/selectors.md:111
 msgid "入れ子にできる(深さ16まで)"
 msgstr ""
 
-#: src/supports/selectors.md:112
+#: src/supports/selectors.md:113
 msgid "以下は非対応で、書くとその宣言だけが無視される。"
 msgstr ""
 
-#: src/supports/selectors.md:114
+#: src/supports/selectors.md:115
 msgid ""
 "`display-p3` / `a98-rgb` / `prophoto-rgb` / "
 "`rec2020`。出力先がPDFのDeviceRGBなので、受け付けてもsRGBへ丸められるだけで指定した意味にならない"
 msgstr ""
 
-#: src/supports/selectors.md:115
+#: src/supports/selectors.md:116
 msgid ""
 "オペランドの`currentcolor`。`currentcolor`はカスケードの後(その要素の`color`が決まってから)解決するのに対し、混色はパース時に済ませるため、この時点では値が分からない"
 msgstr ""
 
-#: src/supports/selectors.md:116
+#: src/supports/selectors.md:117
 msgid "`xyz-d50`(白色点の変換が要るため)"
 msgstr ""
 
-#: src/supports/selectors.md:118 src/supports/selectors.md:120
+#: src/supports/selectors.md:119 src/supports/selectors.md:121
 msgid "at-rule"
 msgstr ""
 
-#: src/supports/selectors.md:122
+#: src/supports/selectors.md:123
 msgid "`@media`"
 msgstr ""
 
-#: src/supports/selectors.md:122
+#: src/supports/selectors.md:123
 msgid ""
 "メディアタイプのみを評価する。`screen`(および`not "
 "screen`以外の否定)はブロックごと無視し、`print`/`all`/タイプ省略は適用する。`(min-width: "
 "...)`のような特性クエリは評価せず読み飛ばす(=タイプさえ合致すれば中身が適用される)"
 msgstr ""
 
-#: src/supports/selectors.md:123
+#: src/supports/selectors.md:124
 msgid "`@page`"
 msgstr ""
 
-#: src/supports/selectors.md:123
+#: src/supports/selectors.md:124
 msgid ""
 "`size`(キーワード/`<length>{1,2}`/`landscape`/`portrait`)と`margin`系に対応。`:first`/`:left`/`:right`擬似クラス単体に対応し、名前付きページ(`@page "
 "intro`)・`:blank`・複合擬似クラス(`:first:left`)は非対応"
 msgstr ""
 
-#: src/supports/selectors.md:124
+#: src/supports/selectors.md:125
 msgid "`@page`内のmargin box"
-msgstr ""
-
-#: src/supports/selectors.md:124
-msgid ""
-"`@top-left-corner`/`@top-left`/`@top-center`/`@top-right`…の16種すべて。`content`のテキスト描画のみで、背景色・枠線等の装飾は非対応。`counter(page)`/`counter(pages)`でページ番号を出力できる(`counter(pages)`はストリーミングモードでは非対応)"
-msgstr ""
-
-#: src/supports/selectors.md:125 src/supports/fonts.md:44
-msgid "`@font-face`"
 msgstr ""
 
 #: src/supports/selectors.md:125
 msgid ""
+"`@top-left-corner`/`@top-left`/`@top-center`/`@top-right`…の16種すべて。`content`のテキスト描画のみで、背景色・枠線等の装飾は非対応。`counter(page)`/`counter(pages)`でページ番号を出力できる(`counter(pages)`はストリーミングモードでは非対応)"
+msgstr ""
+
+#: src/supports/selectors.md:126 src/supports/fonts.md:44
+msgid "`@font-face`"
+msgstr ""
+
+#: src/supports/selectors.md:126
+msgid ""
 "`font-family`/`src`/`unicode-range`/`font-weight`/`font-style`ディスクリプタに対応(`src`の`local()`・`format()`/`tech()`付き`url()`も受理)。`font-display`等その他のディスクリプタは無視。フォントファイルはTTF/OTFのみで、WOFF/WOFF2は非対応"
 msgstr ""
 
-#: src/supports/selectors.md:126
+#: src/supports/selectors.md:127
 msgid "`@import`"
 msgstr ""
 
-#: src/supports/selectors.md:126
+#: src/supports/selectors.md:127
 msgid ""
 "ネスト(深さ上限16、超過分はその1件だけ無視)・循環参照の検出に対応。`@import url(...) "
 "screen;`のようなメディアクエリ条件は評価せず常に取り込む"
 msgstr ""
 
-#: src/supports/selectors.md:127
+#: src/supports/selectors.md:128
 msgid "`@charset`"
 msgstr ""
 
-#: src/supports/selectors.md:127
+#: src/supports/selectors.md:128
 msgid "入力はUTF-8前提"
 msgstr ""
 
-#: src/supports/selectors.md:128
+#: src/supports/selectors.md:129
 msgid ""
 "`@supports` / `@keyframes` / `@namespace` / `@counter-style` / `@layer` / "
 "`@container` / `@property`"
 msgstr ""
 
-#: src/supports/selectors.md:128
+#: src/supports/selectors.md:129
 msgid "ブロックごと無視される"
 msgstr ""
 
-#: src/supports/selectors.md:130
+#: src/supports/selectors.md:131
 msgid "ストリーミングモード固有の制約"
 msgstr ""
 
-#: src/supports/selectors.md:132
+#: src/supports/selectors.md:133
 msgid "`Mode::Batch`(一括処理)ではDOM全体が揃っているため下記の制約は無い。 `Mode::Streaming`でのみ以下が適用される。"
 msgstr ""
 
-#: src/supports/selectors.md:135
+#: src/supports/selectors.md:136
 msgid ""
 "`<body>`直下のトップレベル要素は、次の兄弟が現れた時点で確定として処理します。 "
 "そのため「この先に同じ型の要素が続くか」が要るセレクタだけ、`<body>`直下の要素に限って結果が変わります(その要素の内側は部分木が揃っているので変わりません)。"
 msgstr ""
 
-#: src/supports/selectors.md:138
+#: src/supports/selectors.md:139
 msgid ""
 "`:last-of-type`/`:only-of-type`/`:nth-last-child()`/`:nth-last-of-type()`/`:has(~ "
 "...)`は、余分にマッチしたり取りこぼしたりします。 これらを使うと警告が出ます"
 msgstr ""
 
-#: src/supports/selectors.md:140
+#: src/supports/selectors.md:141
 msgid "`:last-child`・`:empty`・`:has()`の子孫/直後の兄弟は、確定の条件と一致するのでバッチと同じ結果になります"
 msgstr ""
 
-#: src/supports/selectors.md:141
+#: src/supports/selectors.md:142
 msgid ""
 "`+`/`~`・`:first-child`/`:nth-child()`/`:first-of-type`/`:nth-of-type()`/`:only-child`もバッチと同じ結果になります。 "
 "これらを使っている文書では、処理済みのトップレベル要素を子孫だけ解放し、要素そのものを兄弟として残すためです "
 "(残るのはトップレベル要素1個につき1ノードなので、解放できる量はほぼ変わりません)"
 msgstr ""
 
-#: src/supports/selectors.md:144
+#: src/supports/selectors.md:145
 msgid ""
 "`<body>`開始後の`<style>`タグはエラー: `EngineError::UnsupportedInStreamingMode`を返す。 "
 "黙って見た目が崩れるのを避けるため、`<style>`は`<head>`に集約する"
 msgstr ""
 
-#: src/supports/selectors.md:146
+#: src/supports/selectors.md:147
 msgid "`position: absolute`/`fixed`は無視される"
 msgstr ""
 
-#: src/supports/selectors.md:147
+#: src/supports/selectors.md:148
 msgid "`counter(pages)`(総ページ数)は使えない"
 msgstr ""
 
@@ -5152,7 +5206,7 @@ msgid "対応フォーマット"
 msgstr ""
 
 #: src/supports/images.md:5
-msgid "PNG / JPEG / WebP"
+msgid "PNG / JPEG / WebP / SVG"
 msgstr ""
 
 #: src/supports/images.md:7
@@ -5164,194 +5218,443 @@ msgid "ローカルの相対パス・絶対パス、`http(s)`のURL、`data:` UR
 msgstr ""
 
 #: src/supports/images.md:9
-msgid "SVGとGIFは非対応です。"
+msgid "GIFは非対応です。"
 msgstr ""
 
 #: src/supports/images.md:11
-msgid "`<img>`"
+msgid "SVG"
 msgstr ""
 
-#: src/supports/images.md:14
+#: src/supports/images.md:13
+msgid ""
+"SVG(`.svg`と、gzip圧縮された`.svgz`)はラスタライズせず、ベクタのままPDFへ "
+"埋め込みます。拡大しても解像度に依存せず、PDFのサイズもピクセル数ではなく "
+"図形の数で決まります。パース・正規化は[usvg](https://github.com/linebender/resvg)、PDFの描画命令への変換は "
+"[svg2pdf](どちらも[typst]由来)が行います。"
+msgstr ""
+
+#: src/supports/images.md:18
+msgid ""
+"**参照して使う形だけに対応します。** `<img src>`と`background-image: url()`の "
+"どちらでも使えますが、HTMLに直接書いたインラインの`<svg>`要素は描画しません (後述)。"
+msgstr ""
+
+#: src/supports/images.md:23 src/supports/images.md:116
+msgid "\"logo.svg\""
+msgstr ""
+
+#: src/supports/images.md:23 src/supports/images.md:148
 msgid "\"120\""
 msgstr ""
 
-#: src/supports/images.md:15
+#: src/supports/images.md:24
+msgid "\""
+msgstr ""
+
+#: src/supports/images.md:24
+msgid "pattern.svg"
+msgstr ""
+
+#: src/supports/images.md:27
+msgid "`data:` URIも使えます。SVGでは`;base64`を付けない書き方(パーセント エンコード)が一般的なので、どちらの形も受け付けます。"
+msgstr ""
+
+#: src/supports/images.md:31
+msgid "\"data:image/svg+xml,%3Csvg%20xmlns%3D...%3E\""
+msgstr ""
+
+#: src/supports/images.md:32
+msgid "\"data:image/svg+xml;base64,PHN2ZyB4bWxucz0...\""
+msgstr ""
+
+#: src/supports/images.md:36
+msgid "/* CSSの url() でも同じ */"
+msgstr ""
+
+#: src/supports/images.md:40
+msgid ""
+"フォーマットの判定は**中身のバイト列**で行います。拡張子や`data:`が名乗る mime "
+"typeは見ないので、`.txt`に入ったSVGも描けますし、`image/png`と名乗った "
+"SVGも描けます(逆に、`.svg`という名前のPNGはPNGとして扱います)。"
+msgstr ""
+
+#: src/supports/images.md:44
+msgid ""
+"寸法の決め方・キャッシュ・エラー時の扱いはラスタ画像と同じです。SVGの "
+"`width`/`height`(無ければ`viewBox`)が内在サイズになります。ラスタ画像と "
+"違って内在サイズは小数になりうるので、そのまま(丸めずに)扱います。 `object-fit: "
+"contain`のようにアスペクト比で決まる指定が、`width=\"40.6\"`の ようなSVGでもずれません。"
+msgstr ""
+
+#: src/supports/images.md:50
+msgid "object-fit / object-position"
+msgstr ""
+
+#: src/supports/images.md:52
+msgid ""
+"ラスタ画像と同じように効きます。SVGはPDFへ単位正方形に正規化された形で "
+"入るため、`fill`/`contain`/`cover`/`none`/`scale-down`と`object-position`の "
+"計算はラスタ画像と完全に共通の実装が使われます。"
+msgstr ""
+
+#: src/supports/images.md:59
+msgid "/* 比を保って収める(余白ができる) */"
+msgstr ""
+
+#: src/supports/images.md:60
+msgid "/* 左寄せ */"
+msgstr ""
+
+#: src/supports/images.md:64
+msgid "`cover`のようにはみ出す指定でも、描画はcontent boxでクリップされます。"
+msgstr ""
+
+#: src/supports/images.md:66
+msgid "SVG内のテキストとフォント"
+msgstr ""
+
+#: src/supports/images.md:68
+msgid ""
+"**既定では、SVG内の`<text>`は描画されません。** パスにもならず、何も出ません "
+"(そのSVGの他の図形は描かれます)。`<text>`を含むSVGを見つけたら警告します。"
+msgstr ""
+
+#: src/supports/images.md:71
+msgid ""
+"`svg-text` featureを有効にすると、グリフのまま(選択・検索できるテキストと "
+"して)埋め込みます。使えるフォントは**文書が使うフォントそのもの**で、 解決の仕方はHTML側と揃えてあります。"
+msgstr ""
+
+#: src/supports/images.md:75
+msgid "SVGの`font-family`"
+msgstr ""
+
+#: src/supports/images.md:77
+msgid "フォント内部のfamily名(`DejaVu Sans`等)"
+msgstr ""
+
+#: src/supports/images.md:77 src/supports/images.md:78
+msgid "そのフォント"
+msgstr ""
+
+#: src/supports/images.md:78
+msgid "`@font-face`で宣言した名前"
+msgstr ""
+
+#: src/supports/images.md:79
+msgid "`serif` / `sans-serif` / `monospace`"
+msgstr ""
+
+#: src/supports/images.md:79
+msgid "`--serif-font` / `--gothic-font` / `--mono-font`(未指定なら既定フォント)"
+msgstr ""
+
+#: src/supports/images.md:80
+msgid "指定なし"
+msgstr ""
+
+#: src/supports/images.md:80
+msgid "文書の既定フォント(`--font`で最初に渡したもの)"
+msgstr ""
+
+#: src/supports/images.md:81
+msgid "文書が持っていない名前"
+msgstr ""
+
+#: src/supports/images.md:81
+msgid "文書の既定フォント"
+msgstr ""
+
+#: src/supports/images.md:84
+msgid "BrandFace"
+msgstr ""
+
+#: src/supports/images.md:84
+msgid "brand.ttf"
+msgstr ""
+
+#: src/supports/images.md:88
+msgid "<!-- `@font-face`で宣言した名前でも、フォント内部のfamily名でも引ける -->"
+msgstr ""
+
+#: src/supports/images.md:89
+msgid "\"BrandFace\""
+msgstr ""
+
+#: src/supports/images.md:92
+msgid ""
+"**SVGのためにシステムフォントを探し直すことはしません。** 文書が持って "
+"いないフォントがSVGにだけ現れることはなく、代わりに文書の既定フォントへ 落ちます"
+msgstr ""
+
+#: src/supports/images.md:95
+msgid "文書側とSVG側では、同じフォントファイルでもサブセットは別になります (必要なグリフが違うため)。埋め込みはフォント1つにつき1回です"
+msgstr ""
+
+#: src/supports/images.md:97
+msgid ""
+"`svg-text`が既定オフなのは、有効にすると[rustybuzz](https://github.com/harfbuzz/rustybuzz)・resvg等25クレートが "
+"依存に加わるためです(svg2pdfの`text` featureがそれらを要求します)。 SVGにテキストが無いなら足す必要はありません"
+msgstr ""
+
+#: src/supports/images.md:103
+msgid "インラインSVGは描画しません"
+msgstr ""
+
+#: src/supports/images.md:105
+msgid ""
+"HTMLに直接書いた`<svg>`要素は、サブツリーごと描画対象から外します (UAスタイルシートの`svg { display: none "
+"}`)。中のテキストが本文へ 流れ込むこともありません。文書内に1つでもあれば警告します。"
+msgstr ""
+
+#: src/supports/images.md:110
+msgid "<!-- 描画されない -->"
+msgstr ""
+
+#: src/supports/images.md:111
+msgid "\"http://www.w3.org/2000/svg\""
+msgstr ""
+
+#: src/supports/images.md:111 src/supports/images.md:112
+#: src/supports/images.md:116 src/supports/images.md:117
+msgid "\"40\""
+msgstr ""
+
+#: src/supports/images.md:111 src/supports/images.md:112
+#: src/supports/images.md:116 src/supports/images.md:117
+msgid "\"20\""
+msgstr ""
+
+#: src/supports/images.md:112
+msgid "\"red\""
+msgstr ""
+
+#: src/supports/images.md:114
+msgid "<!-- こう書けば描画される -->"
+msgstr ""
+
+#: src/supports/images.md:117
+msgid "\"data:image/svg+xml,%3Csvg%20...%3E\""
+msgstr ""
+
+#: src/supports/images.md:120
+msgid ""
+"対応させるにはHTMLのDOMからSVGのXMLを組み直してusvgへ渡す必要があり、 "
+"属性名の大小(`viewBox`等)・CSSの継承・`currentColor`をどう扱うかが "
+"外部ファイルの参照とは別の問題になります。今のところ「参照して使う」形に 絞っています。"
+msgstr ""
+
+#: src/supports/images.md:125
+msgid "その他の制限"
+msgstr ""
+
+#: src/supports/images.md:127
+msgid "SVGフィルタ(`<filter>`)は非対応です。ラスタライズを避けるため、 フィルタを解決するための機能を入れていません"
+msgstr ""
+
+#: src/supports/images.md:129
+msgid "SVG内に埋め込まれたラスタ画像(`<image>`)は描画されません"
+msgstr ""
+
+#: src/supports/images.md:130
+msgid "`--grayscale`はSVGには効きません(色が個々の描画命令の中にあるため)。 指定すると警告し、SVGだけ色のまま残ります"
+msgstr ""
+
+#: src/supports/images.md:132
+msgid ""
+"SVGの中の`<image href=\"...\">`のような外部参照は解決しません。参照ごとに "
+"警告を出して無視します。SVGの中からのファイル読み出しは`<img>`側の "
+"封じ込め(基準ディレクトリ・`--allow`・`--disable-local-file-access`)を "
+"迂回してしまうため、経路自体を塞いでいます。`data:` URIは対象外 (SVG自身の中で完結しているため許可されます)"
+msgstr ""
+
+#: src/supports/images.md:138
+msgid ""
+"`svg` featureを切る(`--no-default-features`)とusvgを引き込まなくなり、 "
+"SVGの参照はデコード失敗として扱われます。"
+msgstr ""
+
+#: src/supports/images.md:145
+msgid "`<img>`"
+msgstr ""
+
+#: src/supports/images.md:149
 msgid "\"https://example.com/chart.png\""
 msgstr ""
 
-#: src/supports/images.md:15
+#: src/supports/images.md:149
 msgid "\"売上推移\""
 msgstr ""
 
-#: src/supports/images.md:16
+#: src/supports/images.md:150
 msgid "\"data:image/png;base64,iVBORw0…\""
 msgstr ""
 
-#: src/supports/images.md:19
+#: src/supports/images.md:153
 msgid "`<img>`はインラインの置換要素として行に載ります。独立した行にしたい場合は`display: block`を指定してください"
 msgstr ""
 
-#: src/supports/images.md:20
+#: src/supports/images.md:154
 msgid ""
 "`width`/`height`属性とCSSの`width`/`height`に対応します。どちらも無指定なら画像の内在サイズを使い、片方だけ指定すればアスペクト比を保って他方を導出します"
 msgstr ""
 
-#: src/supports/images.md:21
+#: src/supports/images.md:155
 msgid ""
 "取得やデコードに失敗した画像は、その要素だけ空として扱い、文書全体の生成は止めません(`--load-media-error-handling "
 "abort`で中断させることもできます)"
 msgstr ""
 
-#: src/supports/images.md:22
+#: src/supports/images.md:156
 msgid "同じ画像を何度使っても、取得・デコード・PDFへの埋め込みは初回の1回だけです"
 msgstr ""
 
-#: src/supports/images.md:24
+#: src/supports/images.md:158
 msgid "`object-fit` / `object-position`"
 msgstr ""
 
-#: src/supports/images.md:26
+#: src/supports/images.md:160
 msgid "指定した枠に対して画像をどう収めるかを制御します。"
 msgstr ""
 
-#: src/supports/images.md:32
+#: src/supports/images.md:166
 msgid "/* fill | contain | cover | none | scale-down */"
 msgstr ""
 
-#: src/supports/images.md:37
+#: src/supports/images.md:171
 msgid "背景画像"
 msgstr ""
 
-#: src/supports/images.md:41
+#: src/supports/images.md:175
 msgid "\"stamp.png\""
 msgstr ""
 
-#: src/supports/images.md:48
+#: src/supports/images.md:182
 msgid ""
 "`background-image`に書けるのは`url()`だけです。 "
 "`linear-gradient()`などのグラデーション関数と、カンマ区切りの複数背景は非対応です。 既定では画像の内在サイズでタイル配置されます。"
 msgstr ""
 
-#: src/supports/images.md:52
+#: src/supports/images.md:186
 msgid "`border-radius`と背景画像を併用した場合、角丸によるクリップは行われません(角丸は背景色の塗りにのみ効きます)。"
 msgstr ""
 
-#: src/supports/images.md:54
+#: src/supports/images.md:188
 msgid "リモート画像の取得"
 msgstr ""
 
-#: src/supports/images.md:56
+#: src/supports/images.md:190
 msgid "既定では無効です。 `--allow-remote-assets`で明示的に有効化します。"
 msgstr ""
 
-#: src/supports/images.md:63
+#: src/supports/images.md:197
 msgid ""
 "有効にした場合も、グローバルに到達可能でない宛先へのリクエストは常にブロックされます。 "
 "判定は「グローバルなユニキャストだけを通す」方針で、次を拒否します。"
 msgstr ""
 
-#: src/supports/images.md:66
+#: src/supports/images.md:200
 msgid "種別"
 msgstr ""
 
-#: src/supports/images.md:66
+#: src/supports/images.md:200
 msgid "範囲"
 msgstr ""
 
-#: src/supports/images.md:68
+#: src/supports/images.md:202
 msgid "ループバック"
 msgstr ""
 
-#: src/supports/images.md:68
+#: src/supports/images.md:202
 msgid "`127.0.0.0/8`、`::1`"
 msgstr ""
 
-#: src/supports/images.md:69
+#: src/supports/images.md:203
 msgid "プライベート"
 msgstr ""
 
-#: src/supports/images.md:69
+#: src/supports/images.md:203
 msgid "`10/8`、`172.16/12`、`192.168/16`、`fc00::/7`"
 msgstr ""
 
-#: src/supports/images.md:70
+#: src/supports/images.md:204
 msgid "リンクローカル"
 msgstr ""
 
-#: src/supports/images.md:70
+#: src/supports/images.md:204
 msgid "`169.254/16`(クラウドのメタデータ`169.254.169.254`を含む)、`fe80::/10`"
 msgstr ""
 
-#: src/supports/images.md:71
+#: src/supports/images.md:205
 msgid "CGNAT"
 msgstr ""
 
-#: src/supports/images.md:71
+#: src/supports/images.md:205
 msgid "`100.64.0.0/10`(クラウドの内部ロードバランサ等)"
 msgstr ""
 
-#: src/supports/images.md:72
+#: src/supports/images.md:206
 msgid "その他の非グローバル"
 msgstr ""
 
-#: src/supports/images.md:72
+#: src/supports/images.md:206
 msgid "`0.0.0.0/8`、`192.0.0.0/24`、`198.18.0.0/15`、`240.0.0.0/4`、マルチキャスト、ドキュメント用"
 msgstr ""
 
-#: src/supports/images.md:73
+#: src/supports/images.md:207
 msgid "IPv6の特殊用途"
 msgstr ""
 
-#: src/supports/images.md:73
+#: src/supports/images.md:207
 msgid "Teredo `2001::/32`、`2001:db8::/32`、ORCHIDv2 `2001:20::/28`、`100::/64`"
 msgstr ""
 
-#: src/supports/images.md:75
+#: src/supports/images.md:209
 msgid ""
 "IPv4を埋め込むIPv6表記(IPv4-mapped `::ffff:a.b.c.d`、IPv4-compatible "
 "`::a.b.c.d`、NAT64 `64:ff9b::/96`、6to4 `2002::/16`)は、埋め込まれたIPv4側で判定します。 "
 "これらを素通しするとIPv4側のフィルタを迂回できてしまうためです。"
 msgstr ""
 
-#: src/supports/images.md:78
+#: src/supports/images.md:212
 msgid "判定は名前解決の結果に対して行うため、DNSリバインディングやリダイレクト経由の迂回も同じ仕組みで防いでいます。"
 msgstr ""
 
-#: src/supports/images.md:80
+#: src/supports/images.md:214
 msgid ""
 "ポート番号は制限しません。 内部サービスはプライベートIP上にあり、そこは上の判定で塞がっています。 "
 "公開IPに対する非標準ポート(CDNやAPIの`8080`など)は正当な用途があるため、塞ぐと実用を損なうわりに得るものがありません。"
 msgstr ""
 
-#: src/supports/images.md:84
+#: src/supports/images.md:218
 msgid "信頼できないHTMLを変換する場合は、`--allow`でローカル参照の範囲も併せて絞ってください。"
 msgstr ""
 
-#: src/supports/images.md:90
+#: src/supports/images.md:224
 msgid "JPEGはそのまま埋め込まれる"
 msgstr ""
 
-#: src/supports/images.md:92
+#: src/supports/images.md:226
 msgid ""
 "JPEGはデコードせず、サイズ情報だけを読んでPDFへそのまま(DCTDecodeとして)埋め込みます。 "
 "再エンコードしないので画質は落ちず、変換も速くなります。"
 msgstr ""
 
-#: src/supports/images.md:95
+#: src/supports/images.md:229
 msgid ""
 "その代わり、`--grayscale`を指定してもJPEGとCMYK画像はカラーのまま残ります(デコーダを持たないため)。 "
 "グレースケール化が必要な場合は、変換前の画像をグレースケールにしておいてください。"
 msgstr ""
 
-#: src/supports/images.md:98
+#: src/supports/images.md:232
 msgid "PNGとWebPはフルデコードし、アルファチャンネルがあれば透過画像として埋め込みます。"
 msgstr ""
 
-#: src/supports/images.md:100
+#: src/supports/images.md:234
 msgid "画像を一切読み込まない"
 msgstr ""
 
-#: src/supports/images.md:106
+#: src/supports/images.md:240
 msgid "`<img>`とCSSの`background-image`の両方を読み込まなくなります。"
 msgstr ""
 
@@ -6255,7 +6558,7 @@ msgid ""
 msgstr ""
 
 #: src/migration/wkhtmltopdf-options.md:82
-msgid "SVG描画が非対応。フォーム要素の見た目は内蔵の描画で再現する"
+msgid "SVG自体は描画できるが、フォーム要素の見た目の差し替えには対応しない(内蔵の描画で再現する)"
 msgstr ""
 
 #: src/migration/wkhtmltopdf-options.md:83
@@ -7172,64 +7475,82 @@ msgid "画像・フォントの形式"
 msgstr ""
 
 #: src/appendix/limitations.md:39
-msgid "画像はPNG / JPEG / WebPのみ。SVGとGIFは非対応です"
+msgid "画像はPNG / JPEG / WebP / SVGのみ。GIFは非対応です"
 msgstr ""
 
 #: src/appendix/limitations.md:40
-msgid "フォントはTTF / OTFのみ。WOFF / WOFF2は非対応です"
+msgid ""
+"SVGは`<img>`と`background-image`からの参照のみ(ファイル・`data:` "
+"URIどちらも可)。HTMLに直接書いたインラインの`<svg>`要素は描画せず、見つけたら警告します"
 msgstr ""
 
 #: src/appendix/limitations.md:41
 msgid ""
-"カラーフォント(`CBDT`/`CBLC`・`COLR`/`CPAL`・`sbix`)は非対応です。絵文字は[フォント](../supports/fonts.md#絵文字)を参照してください"
+"SVG内の`<text>`は`svg-text` "
+"featureを有効にした場合だけ描画します(使えるフォントは文書と同じもので、SVGのためにシステムフォントを探し直すことはしません)。`<filter>`と`<image>`は非対応です([画像](../supports/images.md#svg)を参照)"
 msgstr ""
 
 #: src/appendix/limitations.md:42
-msgid "`--grayscale`を指定しても、JPEGとCMYK画像はカラーのまま残ります"
+msgid "フォントはTTF / OTFのみ。WOFF / WOFF2は非対応です"
+msgstr ""
+
+#: src/appendix/limitations.md:43
+msgid ""
+"カラーフォント(`CBDT`/`CBLC`・`COLR`/`CPAL`・`sbix`)は非対応です。絵文字は[フォント](../supports/fonts.md#絵文字)を参照してください"
 msgstr ""
 
 #: src/appendix/limitations.md:44
-msgid "CSSの主な制限"
+msgid "`--grayscale`を指定しても、JPEGとCMYK画像・SVGはカラーのまま残ります"
 msgstr ""
 
 #: src/appendix/limitations.md:46
-msgid "機能単位では以下が非対応です。"
+msgid "CSSの主な制限"
 msgstr ""
 
 #: src/appendix/limitations.md:48
-msgid ""
-"縦書き(`writing-mode`/`text-orientation`)と論理プロパティ(`margin-inline`等)、`direction`による右横書き"
-msgstr ""
-
-#: src/appendix/limitations.md:49
-msgid "多段組み(`columns`/`column-count`)"
+msgid "機能単位では以下が非対応です。"
 msgstr ""
 
 #: src/appendix/limitations.md:50
-msgid "グラデーション(`linear-gradient()`等)と複数背景"
+msgid ""
+"縦書き(`writing-mode`/`text-orientation`)と`direction`による右横書き(`margin-inline`等の論理プロパティは`horizontal-tb`+LTRの固定写像としてのみ対応)"
 msgstr ""
 
 #: src/appendix/limitations.md:51
-msgid "相対色構文(`rgb(from ...)`)と`color()`(`color-mix()`は対応済み)"
+msgid "多段組み(`columns`/`column-count`)"
 msgstr ""
 
 #: src/appendix/limitations.md:52
-msgid "アニメーション・トランジション・`filter`(静的な出力のため)"
+msgid "グラデーション(`linear-gradient()`等)と複数背景"
 msgstr ""
 
 #: src/appendix/limitations.md:53
-msgid "`position: sticky`、`display: inline-flex`/`inline-grid`、subgrid"
+msgid "相対色構文(`rgb(from ...)`)と`color()`(`color-mix()`は対応済み)"
 msgstr ""
 
 #: src/appendix/limitations.md:54
-msgid "`::first-line`、`::marker`(`:is()`/`:where()`/`:has()`は対応済み)"
+msgid "アニメーション・トランジション・`filter`(静的な出力のため)"
+msgstr ""
+
+#: src/appendix/limitations.md:55
+msgid "`position: sticky`、`display: inline-flex`/`inline-grid`、subgrid"
 msgstr ""
 
 #: src/appendix/limitations.md:56
-msgid "空白文字の扱い"
+msgid "`::first-line`、`::marker`(`:is()`/`:where()`/`:has()`は対応済み)"
 msgstr ""
 
 #: src/appendix/limitations.md:58
+msgid ""
+"値の文法では、`calc()`と括弧のネストが32段までです。 それより深い値は無効として宣言ごと無視します。 "
+"再帰的にパースするため、深さの上限を設けないと信頼できないCSSでスタックを使い切らせることができてしまうためです。"
+msgstr ""
+
+#: src/appendix/limitations.md:62
+msgid "空白文字の扱い"
+msgstr ""
+
+#: src/appendix/limitations.md:64
 msgid ""
 "畳み込みの対象はCSS Text 3が定める空白(space・tab・改行)だけです。 `&nbsp;`(U+00A0)やthin "
 "space(U+2009)などは畳み込まれない普通の文字として、 フォント本来の字幅で描かれます。改行してよい位置はUAX #14の行分割クラスに従い、 "
@@ -7237,43 +7558,43 @@ msgid ""
 "(`word-break: break-all`を指定した場合も同様です)。"
 msgstr ""
 
-#: src/appendix/limitations.md:64
+#: src/appendix/limitations.md:70
 msgid ""
 "`<wbr>`(と、それと同じ意味を持つU+200B ZERO WIDTH SPACE)は「ここで改行してよい」という "
 "指定として扱います。幅は増えず、PDFのテキスト層にも文字は残りません (`<wbr>`を挟んでも抽出結果は繋がったままです)。"
 msgstr ""
 
-#: src/appendix/limitations.md:68
+#: src/appendix/limitations.md:74
 msgid "この範囲での既知の制限は以下です。"
 msgstr ""
 
-#: src/appendix/limitations.md:70
+#: src/appendix/limitations.md:76
 msgid "`text-align: justify`が行を伸ばす際、`&nbsp;`は伸縮の対象になりません(通常の空白のみ)"
 msgstr ""
 
-#: src/appendix/limitations.md:71
+#: src/appendix/limitations.md:77
 msgid "U+2028/U+2029は本来の強制改行ではなく、通常の空白と同じ扱いになります"
 msgstr ""
 
-#: src/appendix/limitations.md:72
+#: src/appendix/limitations.md:78
 msgid "行末に来た空白の「ぶら下がり」(hanging)は行いません"
 msgstr ""
 
-#: src/appendix/limitations.md:74
+#: src/appendix/limitations.md:80
 msgid "ストリーミングモード固有の制限"
 msgstr ""
 
-#: src/appendix/limitations.md:76
+#: src/appendix/limitations.md:82
 msgid ""
 "`--streaming`を使う場合は、総ページ数(`counter(pages)`・`[topage]`)や目次(`--toc`)などが使えなくなります。 "
 "詳細は[ストリーミングモード](../usage/cli/streaming.md)を参照してください。"
 msgstr ""
 
-#: src/appendix/limitations.md:79
+#: src/appendix/limitations.md:85
 msgid "今後について"
 msgstr ""
 
-#: src/appendix/limitations.md:81
+#: src/appendix/limitations.md:87
 msgid ""
 "JavaScriptエンジンの組み込みは、必要性が出てきた段階での検討事項として残してあります。 "
 "上記のうちPDFのアウトラインなど、設計上の非目標ではないものは将来対応する可能性があります。"

--- a/docs/src/appendix/limitations.md
+++ b/docs/src/appendix/limitations.md
@@ -55,6 +55,10 @@
 * `position: sticky`、`display: inline-flex`/`inline-grid`、subgrid
 * `::first-line`、`::marker`(`:is()`/`:where()`/`:has()`は対応済み)
 
+値の文法では、`calc()`と括弧のネストが32段までです。
+それより深い値は無効として宣言ごと無視します。
+再帰的にパースするため、深さの上限を設けないと信頼できないCSSでスタックを使い切らせることができてしまうためです。
+
 ## 空白文字の扱い
 
 畳み込みの対象はCSS Text 3が定める空白(space・tab・改行)だけです。

--- a/docs/src/supports/properties.md
+++ b/docs/src/supports/properties.md
@@ -54,6 +54,7 @@
 | `border-*-color` | ✅ | 初期値は`currentcolor` |
 | `border-radius` | ⚠️ | 1〜4値+`/`区切りの楕円構文に対応。パーセンテージ指定は非対応(`<length>`のみ)。4辺の太さ・スタイル・色が揃っていない場合は角丸を諦めて直線4辺へフォールバックする。`groove`/`ridge`/`inset`/`outset`との併用も同様にフォールバック |
 | `border-top-left-radius`ほか3隅 | ⚠️ | `<length>{1,2}`(水平/垂直半径)。制約は`border-radius`と同じ |
+| `border-start-start-radius`ほか3隅 | ⚠️ | 論理プロパティ。1つ目がblock方向、2つ目がinline方向を指す(`border-start-end-radius`=右上)。写像規則は[`margin-inline`](#ボックスモデル)と同じ |
 | `outline` | ✅ | `<width> \|\| <style> \|\| <color>`。border-boxの外側に描画し、レイアウトには影響しない |
 | `outline-width` / `outline-style` / `outline-color` | ⚠️ | `outline-style`は`border-style`と同じ値集合。UA依存の`auto`は非対応 |
 | `outline-offset` | ❌ | 常に0固定 |


### PR DESCRIPTION
## `&:hover` を索引から引く

`core/src/style/rule_index.rs` の `bucket_of()` が `Component::Is` の中を見ないため、`&` が絞り込みキーを担う形(`&:hover` / `&:focus` / `&[disabled]`)が全て `Bucket::Any` に落ちて全要素と照合されていた。

修正前後の比較

| CSS | main | このPR |
| - | -: | -: |
| `.cN:hover { }`(フラット) | 0.02s | 0.02s |
| `.cN { &:hover { } }` | 0.19s | 0.02s |

## SVG のメモリ改善

書き出しは `src` ごとに1回だけなので、振り直し済みチャンクを複製せず `take` で取り出す。
デコード結果のキャッシュが振り直し前の `VectorGraphic` を文書の最後まで持っていたので、`renumber_into_document` で取り出して解放する。

修正前後の比較

| 書き出し | main | このPR |
| - | -: | -: |
| バッチ | 101.1MB | 102.7MB |
| ストリーミング | 120.4MB | 76.5MB |

## trailerに `/ID` 書き出し

PDF/A が要求するので、Info辞書に書くのと同じメタデータ・作成日時・ページ数から16バイトのIDを作って書き出す。
