### PR TITLE
Fix to missing outside ::marker on the first li of an ol

### DIFF
--- a/core/src/layout/paginate.rs
+++ b/core/src/layout/paginate.rs
@@ -830,7 +830,11 @@ fn place_split<T>(
     // (`<html>`/`<body>`や大半のラッパー`<div>`)がこの高速経路を通ることで、
     // ストリーミング時のflush頻度が大きく改善される。
     let needs_decoration = container.has_visible_decoration;
-    if needs_decoration {
+    // outsideのマーカー(`list-style-position: outside`)は先頭フラグメントに
+    // 載せて描画するため、装飾が無くてもフラグメント生成は必要になる。これを
+    // 省くと、ページをまたいで分割された`li`のマーカーが落ちてしまう。
+    let needs_fragments = needs_decoration || container.marker.is_some();
+    if needs_fragments {
         // このコンテナが最初に触れる絶対ページインデックスを記録する
         state.enter_split();
     }
@@ -841,7 +845,7 @@ fn place_split<T>(
     }
 
     let mut current_page = state.current_index();
-    let mut segments: Vec<Segment> = if needs_decoration {
+    let mut segments: Vec<Segment> = if needs_fragments {
         vec![Segment {
             page_index: current_page,
             start_index: state.get(current_page).boxes.len(),
@@ -859,7 +863,7 @@ fn place_split<T>(
                           segments: &mut Vec<Segment>| {
         new_page(state, cursor);
         *current_page = state.current_index();
-        if needs_decoration {
+        if needs_fragments {
             segments.push(Segment {
                 page_index: *current_page,
                 start_index: 0,
@@ -894,7 +898,7 @@ fn place_split<T>(
             if now_page != current_page {
                 // 新しいページへ進んだ。今回作られたページは、この`b`の内容以外が
                 // 割り込む余地がないため、先頭(index 0)から始まる。
-                if needs_decoration {
+                if needs_fragments {
                     for p in (current_page + 1)..=now_page {
                         segments.push(Segment {
                             page_index: p,
@@ -916,7 +920,7 @@ fn place_split<T>(
     // 呼び出し元(兄弟要素)のため、下マージン/枠線/パディング分もカーソルへ加算する。
     *cursor += bottom_extra;
 
-    if !needs_decoration {
+    if !needs_fragments {
         return;
     }
 
@@ -930,38 +934,49 @@ fn place_split<T>(
     let fragments: Vec<(usize, usize, LaidOutBox)> = valid
         .iter()
         .enumerate()
-        .map(|(i, seg)| {
+        .filter_map(|(i, seg)| {
             let is_first = i == 0;
             let is_last = i == valid.len() - 1;
+            // 装飾を持たないコンテナはマーカーを載せる先頭フラグメントだけが
+            // 必要で、後続フラグメントは何も描画しない空の箱にしかならない。
+            if !needs_decoration && !is_first {
+                return None;
+            }
             let end_index = state.get(seg.page_index).boxes.len();
             let (top, bottom) =
                 extent_of(&state.get(seg.page_index).boxes[seg.start_index..end_index]);
             let layout = fragment_layout(&container.layout, top, bottom, is_first, is_last);
+            // マーカーは`b`の先頭フラグメントにのみ残す(このボックスが
+            // 複数ページにまたがって分割される場合、後続フラグメントで
+            // 重複して描画されるのを避ける)。マーカーの座標はレイアウト時の
+            // 絶対座標のままなので、フラグメントのページ内相対座標へ移す
+            // (コンテナのcontent上端からの相対位置を保つ)。
+            let marker = if is_first {
+                container.marker.take().map(|mut marker| {
+                    marker.rect.y -= container.layout.content.y - layout.content.y;
+                    marker
+                })
+            } else {
+                None
+            };
             let decoration = LaidOutBox {
                 node: container.node,
                 layout,
                 // 装飾専用フラグメントはこれ以上分割対象にならないため、
                 // fragmentationヒントは意味を持たない(初期値のまま)。
                 fragmentation: FragmentationHints::default(),
-                // `b`自身が装飾を持つ場合のみここに来るため`true`。この
-                // ボックス自体は`Blocks(Vec::new())`で子を持たず、再度
-                // `place_split`に渡されることもない。
-                has_visible_decoration: true,
+                // このボックス自体は`Blocks(Vec::new())`で子を持たず、再度
+                // `place_split`に渡されることもない。マーカーのためだけに
+                // 作られたフラグメントは背景・枠線を描画しない。
+                has_visible_decoration: needs_decoration,
                 // 装飾フラグメント自体はfloatではない(`b`自身がfloatでも、この
                 // 断片は通常フローの一部として`place_split`の残りのループに
                 // 混在するため`false`にしておく必要がある)。
                 is_float: false,
                 content: LaidOutContent::Blocks(Vec::new()),
-                // マーカーは`b`の先頭フラグメントにのみ残す(このボックスが
-                // 複数ページにまたがって分割される場合、後続フラグメントで
-                // 重複して描画されるのを避ける)。
-                marker: if is_first {
-                    container.marker.take()
-                } else {
-                    None
-                },
+                marker,
             };
-            (seg.page_index, seg.start_index, decoration)
+            Some((seg.page_index, seg.start_index, decoration))
         })
         .collect();
 

--- a/core/tests/list_style.rs
+++ b/core/tests/list_style.rs
@@ -12,7 +12,8 @@ use std::collections::HashMap;
 use sghtmltopdf_core::fonts::{Font, FontCollection};
 use sghtmltopdf_core::html::{self, Dom, NodeData, NodeId};
 use sghtmltopdf_core::layout::{
-    build_box_tree, layout_document, paginate_document, LaidOutBox, LaidOutContent, PageSettings,
+    build_box_tree, layout_document, paginate_document, LaidOutBox, LaidOutContent, Page,
+    PageSettings,
 };
 use sghtmltopdf_core::pdf::encode_pdf;
 use sghtmltopdf_core::style::{compute_styles, parse_stylesheet, user_agent_stylesheet};
@@ -255,4 +256,105 @@ fn list_style_shorthand_applies_type_position_and_falls_back_from_image() {
     };
     let run_texts: Vec<&str> = lines[0].runs.iter().map(|r| r.text.as_str()).collect();
     assert_eq!(run_texts, vec!["▪", "x"]);
+}
+
+/// ページ分割まで実行する共通ヘルパー。
+fn paginate(html_src: &str, css: &str) -> Vec<Page> {
+    let dom = html::parse(html_src.as_bytes());
+    let ua = user_agent_stylesheet();
+    let author = parse_stylesheet(css);
+    let styles = compute_styles(&dom, &ua, &author);
+    let fonts = test_fonts();
+    paginate_document(&dom, &styles, &fonts, &PageSettings::default())
+}
+
+/// `pages`に配置されたボックスを再帰的に辿り、outsideマーカーのテキストと
+/// そのページ内相対Y座標を、ページ番号(0始まり)つきで集める。
+fn collect_markers(pages: &[Page]) -> Vec<(usize, String, f32)> {
+    fn walk(b: &LaidOutBox, page_index: usize, out: &mut Vec<(usize, String, f32)>) {
+        if let Some(marker) = &b.marker {
+            let text: String = marker.runs.iter().map(|r| r.text.as_str()).collect();
+            out.push((page_index, text, marker.rect.y));
+        }
+        match &b.content {
+            LaidOutContent::Blocks(children) => {
+                for child in children {
+                    walk(child, page_index, out);
+                }
+            }
+            LaidOutContent::Inline(lines) => {
+                for line in lines {
+                    for atomic in &line.atomics {
+                        walk(&atomic.content, page_index, out);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let mut out = Vec::new();
+    for (page_index, page) in pages.iter().enumerate() {
+        for b in &page.boxes {
+            walk(b, page_index, &mut out);
+        }
+    }
+    out
+}
+
+/// 1ページに収まらない長さの`li`を24個並べたリストを`css`つきでページ分割し、
+/// 「すべての`li`が順番どおりにマーカーを1つずつ保っている」「マーカーが
+/// 自分の載るページの中に収まっている」ことを確認する。
+fn assert_split_list_keeps_every_marker(css: &str) {
+    let words = "Word ".repeat(80);
+    let items: String = (0..24).map(|_| format!("<li>{words}</li>")).collect();
+    let pages = paginate(&format!("<ol>{items}</ol>"), css);
+    assert!(
+        pages.len() > 1,
+        "the fixture should span multiple pages, got {}",
+        pages.len()
+    );
+
+    let markers = collect_markers(&pages);
+    let texts: Vec<&str> = markers.iter().map(|(_, text, _)| text.as_str()).collect();
+    let expected: Vec<String> = (1..=24).map(|n| format!("{n}.")).collect();
+    assert_eq!(
+        texts,
+        expected.iter().map(String::as_str).collect::<Vec<_>>(),
+        "every list item should keep its marker exactly once, in order"
+    );
+
+    // 分割された`li`のマーカーは、その`li`が始まるページに載っていること
+    // (ページをまたいだ結果、座標が別ページのものへずれていないこと)。
+    let content_height = PageSettings::default().content_height();
+    for (page_index, text, y) in &markers {
+        assert!(
+            *y >= 0.0 && *y <= content_height,
+            "marker {text} on page {page_index} sits outside the page (y={y})"
+        );
+    }
+
+    // 少なくとも1つのマーカーは2ページ目以降に載っているはず(先頭ページに
+    // 全部載っているなら分割経路を通っていない)。
+    assert!(
+        markers.iter().any(|(page_index, _, _)| *page_index > 0),
+        "the fixture should place some markers on later pages"
+    );
+}
+
+#[test]
+fn outside_marker_survives_when_a_list_item_is_split_across_pages() {
+    // ページをまたいで分割される`li`は`place_split`経路を通る。装飾
+    // (背景・枠線)を持たない`li`でもマーカーが先頭フラグメントに残ることを
+    // 確認する。
+    assert_split_list_keeps_every_marker("body { margin: 0; } ol, li { margin: 0; }");
+}
+
+#[test]
+fn outside_marker_of_a_split_list_item_with_a_background_stays_on_its_own_page() {
+    // 装飾を持つ`li`は分割時に装飾フラグメントが作られる。マーカーの座標が
+    // レイアウト時の絶対Yのまま残っていると、別ページの位置へずれてしまう。
+    assert_split_list_keeps_every_marker(
+        "body { margin: 0; } ol, li { margin: 0; } li { background: #eee; }",
+    );
 }


### PR DESCRIPTION
Fixes https://github.com/waka/sghtmltopdf/issues/31 .                                                                                                                                                           
                                                                                                                                                                                                                  
When an ordered list paginates, the first list item that starts on a new page keeps its outside-marker gutter but does not paint the marker (`9.`, `1.`, etc.). 
This PR fixes that, and also a latent coordinate bug on the same path that misplaced the marker of a decorated list item.

### Cause

`place_split` takes the marker off the container (`SplitContainer::take_from`) so that it can be re-attached to the first fragment.
But fragment generation is gated on `needs_decoration` (whether the container actually paints a background or border), and a plain `li` returns early at `if !needs_decoration { return; }`.

The marker had been taken with nowhere to be put back, so it was silently dropped.

### Fixed

- Added `needs_fragments = needs_decoration || container.marker.is_some()` and gated segment tracking and `enter_split`/`exit_split` on it, so a container that carries a marker still produces its first fragment even without decoration.
- When the container has no decoration, only the first fragment is built; the following ones would be empty boxes that paint nothing. The fragment's `has_visible_decoration` now carries `needs_decoration` instead of a hardcoded `true`, so a marker-only fragment draws no background or border.
- The marker is translated into the fragment's page-relative coordinates with `marker.rect.y -= container.layout.content.y - layout.content.y`, keeping its offset from the container's content top. This also follows the item when orphans/widows push it wholesale onto the next page.