### PR TITLE
Count table columns from the rowspan-aware grid walk instead of per-row colspan sums

### DIFF
--- a/core/src/layout/table.rs
+++ b/core/src/layout/table.rs
@@ -88,12 +88,11 @@ pub(super) fn layout_table(
     };
     let rows_start_y = rows_block_start + v_spacing;
 
-    let column_count = table
-        .rows
-        .iter()
-        .map(|row| row.cells.iter().map(|cell| cell.colspan).sum::<usize>())
-        .max()
-        .unwrap_or(0);
+    // rowspan/colspanのoccupancyを考慮したグリッド配置。以降の列幅・行の
+    // 高さ・セル配置は全てこのグリッド経由で計算する。列数はこの配置の結果
+    // として決まる(行ごとのcolspan合計の最大値では、rowspanで埋まった列を
+    // 飛ばした先に置かれるセルを数え落とす)。
+    let (grid, column_count) = build_table_grid(&table.rows);
 
     if column_count == 0 {
         let (caption, total_height) = match laid_caption {
@@ -115,12 +114,6 @@ pub(super) fn layout_table(
     // `h_spacing`を差し引いたもの。
     let available_column_width =
         (containing_width - h_spacing * (column_count + 1) as f32).max(0.0);
-
-    // rowspan/colspanのoccupancyを考慮したグリッド配置。以降の列幅・行の
-    // 高さ・セル配置は全てこのグリッド経由で計算する。rowspanが全て1の場合、
-    // `col += cell.colspan`による単純な列
-    // カーソル走査と完全に同一の結果になる。
-    let grid = build_table_grid(&table.rows, column_count);
 
     // `<colgroup>`/`<col>`由来の列幅ヒントを、この時点で使用幅(px)へ
     // 解決する。列数を超える分は捨て、足りない分は指定なしとして扱う。
@@ -403,24 +396,33 @@ struct GridCell<'a> {
 }
 
 /// `rows`から、rowspan/colspanのoccupancy(rowspanで埋まっている列を後続行が
-/// スキップする)を考慮したグリッド配置を求める。戻り値は行ごとの`GridCell`
-/// 一覧(外側の`Vec`が行、内側がその行に属するセル)。rowspanが全て1の場合、列
-/// カーソルを`col += cell.colspan`で単純に進める走査と完全に同一の結果を
-/// 返すため、既存の(rowspanを使わない)テストへの後方互換性が保たれる。
-fn build_table_grid(rows: &[TableRow], column_count: usize) -> Vec<Vec<GridCell<'_>>> {
+/// スキップする)を考慮したグリッド配置と、その結果決まる列数を求める。戻り値の
+/// グリッドは行ごとの`GridCell`一覧(外側の`Vec`が行、内側がその行に属する
+/// セル)。rowspanが全て1の場合、列カーソルを`col += cell.colspan`で単純に
+/// 進める走査と完全に同一の結果を返すため、既存の(rowspanを使わない)テストへの
+/// 後方互換性が保たれる。
+///
+/// 列数を呼び出し元から受け取らずここで数えるのは、rowspanで埋まった列を飛ばす
+/// 配置と列数の数え方が食い違うと、行き場を失ったセルが黙って消えるため
+/// (「1行目がrowspanセル1つだけ、2行目が残りの列を埋める」形が典型)。
+fn build_table_grid(rows: &[TableRow]) -> (Vec<Vec<GridCell<'_>>>, usize) {
     // occupied[col]: その列を占有しているrowspanの残り行数(0なら空き)。
-    let mut occupied = vec![0usize; column_count];
+    // 配置先が既知の列数を超えたらその都度伸ばし、最終的な長さが列数になる。
+    let mut occupied: Vec<usize> = Vec::new();
     let mut grid = Vec::with_capacity(rows.len());
 
     for (row_index, row) in rows.iter().enumerate() {
         let mut row_cells = Vec::with_capacity(row.cells.len());
         let mut col = 0usize;
         for cell in &row.cells {
-            while col < column_count && occupied[col] > 0 {
+            while col < occupied.len() && occupied[col] > 0 {
                 col += 1;
             }
             let col_start = col;
-            let col_end = (col_start + cell.colspan).min(column_count);
+            let col_end = col_start + cell.colspan;
+            if occupied.len() < col_end {
+                occupied.resize(col_end, 0);
+            }
             for slot in &mut occupied[col_start..col_end] {
                 *slot = cell.rowspan;
             }
@@ -440,7 +442,8 @@ fn build_table_grid(rows: &[TableRow], column_count: usize) -> Vec<Vec<GridCell<
         }
     }
 
-    grid
+    let column_count = occupied.len();
+    (grid, column_count)
 }
 
 /// `table-layout: fixed`用の列幅決定(CSS2.1 §17.5.2.1の簡略版)。
@@ -1322,7 +1325,8 @@ mod tests {
             grid_row(vec![grid_cell(2, 1), grid_cell(1, 1)]),
             grid_row(vec![grid_cell(1, 1), grid_cell(1, 1), grid_cell(1, 1)]),
         ];
-        let grid = build_table_grid(&rows, 3);
+        let (grid, column_count) = build_table_grid(&rows);
+        assert_eq!(column_count, 3);
         assert_eq!(
             grid_spans(&grid),
             vec![vec![(0, 2), (2, 3)], vec![(0, 1), (1, 2), (2, 3)]]
@@ -1340,7 +1344,8 @@ mod tests {
             grid_row(vec![grid_cell(1, 1)]),
             grid_row(vec![grid_cell(1, 1), grid_cell(1, 1)]),
         ];
-        let grid = build_table_grid(&rows, 2);
+        let (grid, column_count) = build_table_grid(&rows);
+        assert_eq!(column_count, 2);
         assert_eq!(
             grid_spans(&grid),
             vec![vec![(0, 1), (1, 2)], vec![(1, 2)], vec![(0, 1), (1, 2)]]
@@ -1355,8 +1360,25 @@ mod tests {
             grid_row(vec![grid_cell(2, 2), grid_cell(1, 1)]),
             grid_row(vec![grid_cell(1, 1)]),
         ];
-        let grid = build_table_grid(&rows, 3);
+        let (grid, column_count) = build_table_grid(&rows);
+        assert_eq!(column_count, 3);
         assert_eq!(grid_spans(&grid), vec![vec![(0, 2), (2, 3)], vec![(2, 3)]]);
+    }
+
+    #[test]
+    fn build_table_grid_counts_a_column_that_only_exists_after_a_rowspan_is_skipped() {
+        // 行0はrowspan=2のセル1つだけ。行0のcolspan合計は1だが、行1のセルは
+        // col0がまだ埋まっているためcol1へ回るので、テーブルの列数は2になる。
+        let rows = vec![
+            grid_row(vec![grid_cell(1, 2)]),
+            grid_row(vec![grid_cell(1, 1)]),
+        ];
+        let (grid, column_count) = build_table_grid(&rows);
+        assert_eq!(
+            column_count, 2,
+            "the column opened up next to the rowspan cell must be counted"
+        );
+        assert_eq!(grid_spans(&grid), vec![vec![(0, 1)], vec![(1, 2)]]);
     }
 
     #[test]

--- a/core/tests/table_rowspan.rs
+++ b/core/tests/table_rowspan.rs
@@ -149,3 +149,52 @@ fn table_without_rowspan_behaves_as_before_end_to_end() {
         "cells without rowspan should still sit side by side with no gap"
     );
 }
+
+#[test]
+fn a_row_whose_only_cell_has_a_rowspan_still_opens_a_column_for_the_next_row() {
+    // 1行目がrowspan=2のセル1つだけの場合、テーブルの列数は「行ごとのcolspan
+    // 合計の最大値」では1にしかならず、2行目のセルは行き場を失って消えていた。
+    let html_src = r#"<table style="width: 400px;">
+        <tr><td rowspan="2" style="width: 150px;">Logo</td></tr>
+        <tr><td>Second row text</td></tr>
+    </table>"#;
+    let css = "body { margin: 0; }";
+
+    let (dom, laid) = layout(html_src, css);
+    let mut tds = Vec::new();
+    find_all_tags(&dom, dom.document(), "td", &mut tds);
+    assert_eq!(tds.len(), 2);
+
+    let logo = find_laid_out(&laid, tds[0]).expect("rowspan cell not found");
+    let second = find_laid_out(&laid, tds[1]).expect("second row cell not found");
+
+    // 2行目のセルはrowspanが占有するcol0を避けてcol1へ回るため、"Logo"の
+    // 右隣に、幅を持った状態で置かれるはず。
+    let logo_box = logo.layout.border_box();
+    let logo_right = logo_box.x + logo_box.width;
+    assert!(
+        second.layout.border_box().x >= logo_right,
+        "the second row's cell should sit in the column next to the rowspan cell \
+         (x={}, rowspan cell right edge={logo_right})",
+        second.layout.border_box().x
+    );
+    assert!(
+        second.layout.content.width > 0.0,
+        "the second row's cell should get a share of the table width, got {}",
+        second.layout.content.width
+    );
+    // テキストが行として実際にレイアウトされていること(幅0の列に潰れると
+    // 行そのものが失われる)。
+    let LaidOutContent::Inline(lines) = &second.content else {
+        panic!("expected inline content in the second row's cell");
+    };
+    let text: String = lines
+        .iter()
+        .flat_map(|line| line.runs.iter())
+        .map(|run| run.text.as_str())
+        .collect();
+    assert!(
+        text.contains("Second"),
+        "the second row's text should survive layout, got {text:?}"
+    );
+}


### PR DESCRIPTION
Fixes https://github.com/waka/sghtmltopdf/issues/32 .

When a table's first row contains only a single `rowspan="2"` cell and the second row supplies the cell for the remaining column, the second row's content is not rendered at all.
It silently disappears instead of being placed in the column the rowspan leaves open.

### Cause

`core/src/layout/table.rs` had two different notions of how many columns a table has, and they disagreed.                                                                                                                                                                                                      

- The column count was the maximum per-row sum of `colspan`, which ignores rowspan occupancy.
- Cell placement (`build_table_grid`) skips columns still occupied by a rowspan from an earlier row and puts the cell in the next free one.

### FIxed

The column count is now a result of the placement walk rather than a separate calculation, so the two can no longer drift apart.

- `build_table_grid(rows, column_count) -> Vec<Vec<GridCell>>` became `build_table_grid(rows) -> (Vec<Vec<GridCell>>, usize)`. Its `occupied` vector grows as cells are placed instead of being pre-sized, and its final length is the column count.
- `layout_table` no longer counts columns itself; the call was moved above the `column_count == 0` early return and its result is used for both the grid and the width calculations.
- The `.min(column_count)` clamp on `col_end` is gone. A cell pushed rightward by a rowspan now extends the table's column count, which is what the HTML table model asks for.
