### PR TITLE
Derive line-height: normal from the font's own metrics instead of a fixed 1.2em

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   program but not lifted into the dictionary. Strict PDF tooling (e.g. HexaPDF,
   veraPDF) rejects the file without them, which blocks PDF/A-3 validation and
   therefore Factur-X / ZUGFeRD hybrid e-invoice embedding.
+- Keep the outside marker on a list item that is split across pages (#31). An item that did
+  not fit in what was left of a page kept its marker gutter but lost the marker itself, so an
+  ordered list that paginated silently skipped numbers (7., 14. and 21. in the reported
+  document); the numbers were missing from the text layer too, not merely clipped. Pagination
+  moves the marker onto the item's first fragment, but fragments were only produced for a
+  container that actually paints a background or border. A plain `li` paints neither, so the
+  marker was taken off the container with nowhere to put it back. On a decorated item the
+  marker survived but carried its pre-pagination coordinates, which placed it at a position
+  belonging to another page; that is corrected as well.
+- Count a table's columns with the occupancy of `rowspan` taken into account (#32). The column
+  count was the largest per-row sum of `colspan`, while cell placement skips the columns still
+  held by a `rowspan` from an earlier row. When the first row held nothing but a `rowspan="2"`
+  cell, both rows summed to one column, so the second row's cell was placed in a column the
+  table did not have, given zero width, and dropped from the output with no error or warning —
+  a logo beside a label that appears on the following row, a common invoice-table shape. The
+  count now falls out of the placement walk itself, so the two can no longer disagree.
 
 ### Added
 
@@ -87,6 +103,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - An inline `<svg>` in the HTML now warns once per document instead of silently rendering
   nothing. It is still not drawn — only `<img>` and `background-image` references are — but
   saying "SVG is supported" and then dropping inline SVG without a word was misleading.
+- `line-height: normal` is now the font's own recommended line spacing (ascent + descent +
+  line gap), as CSS defines it, rather than a fixed 1.2em (#33). The fixed ratio only worked
+  for fonts whose content area fits inside it: DejaVu Sans needs 1.164em and Liberation Sans
+  1.150em, but Noto Sans CJK needs 1.448em, and CJK fonts around 1.4em are common. Where the
+  ratio was too small the half-leading went negative and the glyphs spilled out of their line
+  box, so the last line of a block overlapped whatever came next — a table cell's
+  `border-bottom` drawn through the text, for instance. The overflow scales with `font-size`,
+  which is why it appeared when a larger font followed a smaller one and stayed invisible in
+  the other order.
+
+  Line spacing therefore changes in any document that leaves `line-height` unset. Latin text
+  tightens slightly (1.2em to 1.164em with DejaVu Sans); Japanese text loosens by roughly a
+  fifth (1.2em to 1.448em with Noto Sans CJK), so some documents will gain pages. A document
+  that sets `line-height` explicitly, as a number or a length, is unaffected and its output is
+  unchanged byte for byte. An explicit value smaller than the font's content area still
+  overflows its line box, exactly as it does in a browser; that is the specified behaviour and
+  is deliberately left alone.
 
 ### Known limitations
 

--- a/core/src/fonts/font.rs
+++ b/core/src/fonts/font.rs
@@ -117,6 +117,9 @@ struct Metrics {
     units_per_em: u16,
     ascender: i16,
     descender: i16,
+    /// 行間(`hhea`の`lineGap`。`OS/2`がUSE_TYPO_METRICSを立てていれば
+    /// `sTypoLineGap`)。`line-height: normal`の算出に使う。
+    line_gap: i16,
     capital_height: Option<i16>,
     x_height: Option<i16>,
     subscript_y_offset: Option<i16>,
@@ -161,6 +164,7 @@ impl Metrics {
             units_per_em: m.units_per_em,
             ascender: m.ascent as i16,
             descender: m.descent as i16,
+            line_gap: m.leading as i16,
             capital_height: m.cap_height.map(|v| v as i16),
             x_height: m.x_height.map(|v| v as i16),
             subscript_y_offset: os2.as_ref().map(|t| t.y_subscript_y_offset()),
@@ -315,6 +319,22 @@ impl Font {
 
     pub fn descender(&self) -> i16 {
         self.metrics.descender
+    }
+
+    /// `line-height: normal`の使用値(px)。
+    ///
+    /// CSSの`normal`は「フォントが推奨する行送り」で、その実体は
+    /// アセント+ディセント+行間(`lineGap`)。固定倍率(1.2em等)で近似すると、
+    /// アセント+ディセントがそれを超えるフォント(CJKのフォントは1.4em前後の
+    /// ものが珍しくない)でグリフが行ボックスからはみ出し、隣接する行や
+    /// 枠線と重なる。
+    pub fn normal_line_height(&self, font_size: f32) -> f32 {
+        let units_per_em = self.units_per_em() as f32;
+        if units_per_em <= 0.0 {
+            return 0.0;
+        }
+        let content = self.ascender() as f32 - self.descender() as f32;
+        (content + self.metrics.line_gap as f32) / units_per_em * font_size
     }
 
     pub fn capital_height(&self) -> Option<i16> {
@@ -546,6 +566,44 @@ mod tests {
             "with no extra leading, the baseline offset should equal the ascent: {offset} vs {ascent}"
         );
         assert!(offset > 0.0 && offset < line_height);
+    }
+
+    #[test]
+    fn normal_line_height_is_the_fonts_own_content_area_plus_line_gap() {
+        let font = Font::load(TEST_FONT_PATH).expect("should load bundled test font");
+        let units_per_em = font.units_per_em() as f32;
+        let expected = (font.ascender() as f32 - font.descender() as f32) / units_per_em * 16.0;
+
+        // DejaVu Sansは`lineGap`が0なので、アセント+ディセントがそのまま
+        // `normal`の行送りになる。
+        let normal = font.normal_line_height(16.0);
+        assert!(
+            (normal - expected).abs() < 0.01,
+            "normal line height should be ascent + descent (+ line gap): {normal} vs {expected}"
+        );
+    }
+
+    #[test]
+    fn normal_line_height_always_covers_the_glyphs_content_area() {
+        // `normal`が「アセント+ディセント」を下回るフォントがあると、
+        // 半行送りが負になってグリフが行ボックスからはみ出す。
+        let paths = [
+            TEST_FONT_PATH,
+            concat!(
+                env!("CARGO_MANIFEST_DIR"),
+                "/tests/fonts/NotoSansCJK-Regular.ttc"
+            ),
+        ];
+        for path in paths {
+            let font = Font::load(path).expect("should load test font");
+            let units_per_em = font.units_per_em() as f32;
+            let content = (font.ascender() as f32 - font.descender() as f32) / units_per_em * 16.0;
+            assert!(
+                font.normal_line_height(16.0) >= content - 0.01,
+                "{path}: normal line height {} must not be shorter than the content area {content}",
+                font.normal_line_height(16.0)
+            );
+        }
     }
 }
 

--- a/core/src/layout/inline.rs
+++ b/core/src/layout/inline.rs
@@ -3,7 +3,7 @@
 use std::collections::{HashMap, VecDeque};
 use std::rc::Rc;
 
-use crate::fonts::{measure_text, shape_text, FontCollection, ShapedGlyph};
+use crate::fonts::{measure_text, shape_text, Font, FontCollection, ShapedGlyph};
 use crate::html::NodeId;
 use crate::style::{
     BoxSizing, ComputedStyle, ComputedTextShadow, EmphasisPosition, EmphasisStyle, FontStyle,
@@ -70,8 +70,8 @@ pub struct TextRun {
     /// 行ボックス(`LineBox::rect`)の左端からの相対x座標。
     pub x_offset: f32,
     pub width: f32,
-    /// このランの計算済み行高さ(px)。`line-height: normal`は`font_size*1.2`の
-    /// 近似、`<number>`はこのランの`font_size`で乗算済み。
+    /// このランの計算済み行高さ(px)。`line-height: normal`はこのランのフォントの
+    /// メトリクス由来、`<number>`はこのランの`font_size`で乗算済み。
     pub line_height: f32,
     /// `letter-spacing`の解決済みpx。PDF描画層(`pdf::document::render_line`)
     /// が`Tc`(character spacing)としてそのまま
@@ -367,7 +367,7 @@ pub(crate) fn layout_inline_content(
                 // (`white-space: nowrap`でも効く)。
                 let break_height = span_styles
                     .get(style_index)
-                    .map(resolve_line_height)
+                    .map(|style| empty_line_height(style, fonts))
                     .unwrap_or(0.0);
                 if current_runs.is_empty() && current_atomics.is_empty() {
                     // 行に何も無い状態での強制改行(連続する`<br>`や段落先頭の
@@ -442,8 +442,8 @@ pub(crate) fn layout_inline_content(
             let starting_new_line = current_runs.is_empty() && current_atomics.is_empty();
 
             if starting_new_line {
-                // 新しい行の先頭: floatに応じた帯を、このchunkのフォントサイズ
-                // から近似した行高さ(`line_height_for`と同じ*1.2)で問い合わせる
+                // 新しい行の先頭: floatに応じた帯を、このchunkの先頭ランの
+                // 行高さ(`line_height_for`と同じ計算値)で問い合わせる
                 // (既知の簡略化: 行内でフォントサイズが極端に混在する場合は
                 // 帯判定がわずかに不正確になり得るが、帳票用途では稀)。
                 let hint = line_height_hint_for_chunk(&chunk);
@@ -1314,15 +1314,41 @@ fn resolve_length_percentage(lp: LengthPercentage, basis: f32) -> f32 {
     }
 }
 
+/// `line-height: normal`をフォントメトリクスから求められない場合
+/// (コレクションが空でフォントを1つも選べない)の倍率。実際に使われるのは
+/// フォントを持たないテスト用の経路くらいで、通常の文書では
+/// [`Font::normal_line_height`]が使われる。
+const NORMAL_LINE_HEIGHT_FALLBACK: f32 = 1.2;
+
 /// `line-height`の計算値からこの要素自身の`font_size`を使ってpx値を求める
 /// (`Number`/`Normal`は使用側=ここでその要素のfont-sizeを使って乗算する)。
-fn resolve_line_height(style: &ComputedStyle) -> f32 {
+///
+/// `normal`はフォントごとに異なる(アセント+ディセント+行間)ため、そのランで
+/// 実際に使うフォントを渡す必要がある。`font`が`None`なら固定倍率で近似する。
+fn resolve_line_height(style: &ComputedStyle, font: Option<&Font>) -> f32 {
     let font_size = style.font_size.0;
     match style.line_height {
-        LineHeight::Normal => font_size * 1.2,
+        LineHeight::Normal => match font {
+            Some(font) => font.normal_line_height(font_size),
+            None => font_size * NORMAL_LINE_HEIGHT_FALLBACK,
+        },
         LineHeight::Number(n) => n * font_size,
         LineHeight::Length(px) => px,
     }
+}
+
+/// `style`の`font-family`に対する「最初に使えるフォント」(CSSのfirst available
+/// font)。テキストを持たない行(`<br>`だけの行や`white-space: pre`の空行)でも
+/// `line-height: normal`を解決できるように、半角スペースを代表文字として選ぶ。
+fn first_available_font<'a>(style: &ComputedStyle, fonts: &'a FontCollection) -> Option<&'a Font> {
+    fonts
+        .select_for_char(&style.font_family, style.font_weight, style.font_style, ' ')
+        .and_then(|index| fonts.get(index))
+}
+
+/// テキストを持たない行の高さ(`line-height`の使用値)。
+fn empty_line_height(style: &ComputedStyle, fonts: &FontCollection) -> f32 {
+    resolve_line_height(style, first_available_font(style, fonts))
 }
 
 /// `white-space: pre`用のレイアウト。改行文字(`\n`)で明示的に行を分割し、
@@ -1358,7 +1384,7 @@ fn layout_pre_content(
             .first()
             .and_then(|sc| span_styles.get(sc.style_index))
             .or_else(|| span_styles.first())
-            .map(resolve_line_height)
+            .map(|style| empty_line_height(style, fonts))
             .unwrap_or(0.0);
         let (mut line_left, _) = line_band(float_ctx, cursor_y, hint, origin_x, available_width);
         // `text-indent`は最初の物理行のみに適用する(CSS2.1 §16.1)。
@@ -1425,7 +1451,7 @@ pub(super) fn shape_run(
     let needs_synthetic_bold = style.font_weight == FontWeight::Bold && !fonts.is_bold(font_index);
     let needs_synthetic_italic =
         style.font_style == FontStyle::Italic && !fonts.is_italic(font_index);
-    let mut line_height = resolve_line_height(style);
+    let mut line_height = resolve_line_height(style, Some(font));
     // `letter-spacing`はグリフ数分だけ幅に加算する(行末にも均等加算する
     // 既知の簡略化)。PDF描画層は`run.letter_spacing`を`Tc`として使う
     // ため、ここでの幅計算とレンダリング結果が一致する。
@@ -1837,6 +1863,15 @@ mod tests {
         FontCollection::new(vec![Font::load(DEJAVU_PATH).unwrap()])
     }
 
+    /// 既定スタイル(`line-height: normal`)での1行の高さ。`normal`はフォントの
+    /// メトリクス由来なので、テスト用フォントから求める。
+    fn default_line_height(fonts: &FontCollection) -> f32 {
+        fonts
+            .get(0)
+            .expect("テスト用フォントは必ず1本ある")
+            .normal_line_height(ComputedStyle::default().font_size.0)
+    }
+
     fn dejavu_regular_and_bold() -> FontCollection {
         FontCollection::new(vec![
             Font::load(DEJAVU_PATH).unwrap(),
@@ -1917,10 +1952,7 @@ mod tests {
         assert_eq!(lines[0].rect.x, 10.0);
         assert_eq!(lines[0].rect.y, 20.0);
         assert!(lines[0].rect.width > 0.0);
-        assert_eq!(
-            lines[0].rect.height,
-            ComputedStyle::default().font_size.0 * 1.2
-        );
+        assert_eq!(lines[0].rect.height, default_line_height(&fonts));
         // 同じ体裁で連続するので1ランにまとまり、単語間の空白も復元される。
         assert_eq!(lines[0].runs.len(), 1);
         assert_eq!(lines[0].runs[0].text, "hello world");
@@ -1975,7 +2007,7 @@ mod tests {
         let wrapped = layout_inline_content(&spans, &styles, &fonts, 60.0, 0.0, 0.0, None);
         assert!(wrapped.len() > 1);
 
-        let line_height = ComputedStyle::default().font_size.0 * 1.2;
+        let line_height = default_line_height(&fonts);
         assert_eq!(wrapped[1].rect.y, wrapped[0].rect.y + line_height);
     }
 
@@ -2009,7 +2041,7 @@ mod tests {
 
         let fonts = dejavu_only();
         let (_, spans, styles) = spans_for("hello world foo bar baz", "");
-        let line_height = ComputedStyle::default().font_size.0 * 1.2;
+        let line_height = default_line_height(&fonts);
 
         // floatの高さは1行分だけ: 1行目はfloatの右に押し込まれ、2行目以降は
         // floatの下に出るため元の幅・左端に戻るはず。
@@ -2330,7 +2362,7 @@ mod tests {
             lines[1].rect.width > 60.0,
             "the second physical line should not wrap despite overflowing"
         );
-        let line_height = ComputedStyle::default().font_size.0 * 1.2;
+        let line_height = default_line_height(&fonts);
         assert_eq!(lines[1].rect.y, lines[0].rect.y + line_height);
     }
 

--- a/core/tests/cli.rs
+++ b/core/tests/cli.rs
@@ -1065,12 +1065,15 @@ fn header_and_footer_lines_are_drawn() {
 
 #[test]
 fn header_spacing_increases_the_top_margin() {
+    // 1ページの残り高さの差がページ数の差として現れるだけの分量と余白を使う
+    // (行送りはフォントのメトリクス由来なので、境界ぎりぎりの分量にすると
+    // フォントを変えただけでページ数が並んでしまう)。
     let html = format!(
         "<html><body>{}</body></html>",
-        "<p style=\"margin:0\">line</p>".repeat(40)
+        "<p style=\"margin:0\">line</p>".repeat(90)
     );
     let normal = run_cli_with(&html, &[], "spacing-none");
-    let spaced = run_cli_with(&html, &["--header-spacing", "40"], "spacing-40");
+    let spaced = run_cli_with(&html, &["--header-spacing", "100"], "spacing-100");
     assert!(
         count_occurrences(&spaced, b"/MediaBox") > count_occurrences(&normal, b"/MediaBox"),
         "a larger top margin should need more pages"

--- a/core/tests/fixtures/sample.html
+++ b/core/tests/fixtures/sample.html
@@ -43,6 +43,16 @@
   <p class="item">Line item 28: Widget BB - quantity 8 - unit price 7.70</p>
   <p class="item">Line item 29: Widget CC - quantity 1 - unit price 150.00</p>
   <p class="item">Line item 30: Widget DD - quantity 4 - unit price 22.22</p>
+  <p class="item">Line item 31: Widget AAA - quantity 5 - unit price 46.50</p>
+  <p class="item">Line item 32: Widget BBB - quantity 6 - unit price 48.00</p>
+  <p class="item">Line item 33: Widget CCC - quantity 7 - unit price 49.50</p>
+  <p class="item">Line item 34: Widget DDD - quantity 8 - unit price 51.00</p>
+  <p class="item">Line item 35: Widget EEE - quantity 9 - unit price 52.50</p>
+  <p class="item">Line item 36: Widget FFF - quantity 1 - unit price 54.00</p>
+  <p class="item">Line item 37: Widget GGG - quantity 2 - unit price 55.50</p>
+  <p class="item">Line item 38: Widget HHH - quantity 3 - unit price 57.00</p>
+  <p class="item">Line item 39: Widget III - quantity 4 - unit price 58.50</p>
+  <p class="item">Line item 40: Widget JJJ - quantity 5 - unit price 60.00</p>
   <p>End of report. Thank you for reviewing this sample document.</p>
 </body>
 </html>

--- a/core/tests/typography.rs
+++ b/core/tests/typography.rs
@@ -18,6 +18,12 @@ use sghtmltopdf_core::pdf::encode_pdf;
 use sghtmltopdf_core::style::{compute_styles, parse_stylesheet, user_agent_stylesheet};
 
 const FONT_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fonts/DejaVuSans.ttf");
+/// アセント+ディセントが1.2emを超えるフォント(1.448em)。`line-height: normal`を
+/// 固定倍率で近似していると、このフォントでグリフが行ボックスからはみ出す。
+const TALL_METRICS_FONT_PATH: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/tests/fonts/NotoSansCJK-Regular.ttc"
+);
 
 fn test_fonts() -> FontCollection {
     FontCollection::new(vec![
@@ -393,4 +399,119 @@ line   two</pre>
     assert_eq!(page_count, 1);
     assert!(bytes.starts_with(b"%PDF-"));
     assert!(count_occurrences(&decompressed_stream_bytes(&bytes), b" Tc\n") > 0);
+}
+
+/// `fonts`でレイアウトした結果から、`tag`の最初のボックスを返す。
+fn layout_with(html_src: &str, css: &str, fonts: &FontCollection) -> (Dom, LaidOutBox) {
+    let dom = html::parse(html_src.as_bytes());
+    let ua = user_agent_stylesheet();
+    let author = parse_stylesheet(css);
+    let styles = compute_styles(&dom, &ua, &author);
+    let tree = build_box_tree(&dom, &styles);
+    let laid = layout_document(
+        &tree,
+        &styles,
+        fonts,
+        PageSettings::default().content_width(),
+    );
+    (dom, laid)
+}
+
+/// `b`以下の全ての行を集める。
+fn collect_lines(b: &LaidOutBox, out: &mut Vec<sghtmltopdf_core::layout::LineBox>) {
+    match &b.content {
+        LaidOutContent::Inline(lines) => out.extend(lines.iter().cloned()),
+        LaidOutContent::Blocks(children) | LaidOutContent::Flex(children) => {
+            for child in children {
+                collect_lines(child, out);
+            }
+        }
+        LaidOutContent::Table(table) => {
+            for cell in table.rows.iter().flat_map(|row| &row.cells) {
+                collect_lines(cell, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+#[test]
+fn line_height_normal_fits_the_glyphs_of_a_font_taller_than_1_2em() {
+    // `line-height: normal`をfont-size*1.2で近似していると、アセント+
+    // ディセントが1.2emを超えるフォントでグリフが行ボックスからはみ出し、
+    // 積み重ねたブロックの最後の行が親の下端(セルのborder-bottom等)と重なる。
+    // はみ出し量はfont-sizeに比例するため、font-sizeが増えていく並びで
+    // 顕著になる。
+    let fonts = FontCollection::new(vec![
+        Font::load(TALL_METRICS_FONT_PATH).expect("should load the CJK test font")
+    ]);
+    let html_src = r#"<table><tr><td>
+        <div class="small">Label</div>
+        <div class="large">Value</div>
+    </td></tr></table>"#;
+    let css = "body { margin: 0; } td { padding: 0; } \
+               .small { font-size: 9px; } .large { font-size: 11px; }";
+
+    let (_, laid) = layout_with(html_src, css, &fonts);
+    let mut lines = Vec::new();
+    collect_lines(&laid, &mut lines);
+    assert_eq!(lines.len(), 2, "expected one line per div");
+
+    for line in &lines {
+        let descent = line
+            .runs
+            .iter()
+            .map(|run| run.descent)
+            .fold(0.0f32, f32::max);
+        let glyph_bottom = line.baseline + descent;
+        assert!(
+            glyph_bottom <= line.rect.height + 0.01,
+            "glyphs must fit inside their line box: bottom={glyph_bottom} height={}",
+            line.rect.height
+        );
+        let ascent = line
+            .runs
+            .iter()
+            .map(|run| run.ascent)
+            .fold(0.0f32, f32::max);
+        assert!(
+            line.baseline >= ascent - 0.01,
+            "the baseline must leave room for the ascent: baseline={} ascent={ascent}",
+            line.baseline
+        );
+    }
+}
+
+#[test]
+fn line_height_normal_follows_the_fonts_own_metrics() {
+    // `normal`はフォントごとに異なる。メトリクスの大きいフォントのほうが
+    // 同じfont-sizeでも行が高くなる。
+    let html_src = r#"<p>x</p>"#;
+    let css = "body { margin: 0; } p { margin: 0; font-size: 10px; }";
+
+    let dejavu = FontCollection::new(vec![Font::load(FONT_PATH).unwrap()]);
+    let tall = FontCollection::new(vec![Font::load(TALL_METRICS_FONT_PATH).unwrap()]);
+
+    let mut heights = Vec::new();
+    for fonts in [&dejavu, &tall] {
+        let (dom, laid) = layout_with(html_src, css, fonts);
+        let p = find_tag(&dom, dom.document(), "p").expect("p not found");
+        let p_box = find_laid_out(&laid, p).expect("p box not found");
+        let LaidOutContent::Inline(lines) = &p_box.content else {
+            panic!("expected inline content");
+        };
+        let font = fonts.get(0).unwrap();
+        assert!(
+            (lines[0].rect.height - font.normal_line_height(10.0)).abs() < 0.01,
+            "the line height should be the font's own normal line height: {} vs {}",
+            lines[0].rect.height,
+            font.normal_line_height(10.0)
+        );
+        heights.push(lines[0].rect.height);
+    }
+
+    assert!(
+        heights[1] > heights[0],
+        "the font with taller metrics should produce a taller line: {heights:?}"
+    );
 }

--- a/docs/po/en.po
+++ b/docs/po/en.po
@@ -4595,8 +4595,13 @@ msgid "`line-height`"
 msgstr "`line-height`"
 
 #: src/supports/properties.md:94
-msgid "`normal`/`<number>`/`<length>`/`<percentage>`"
-msgstr "`normal`, `<number>`, `<length>`, and `<percentage>`"
+msgid ""
+"`normal`/`<number>`/`<length>`/`<percentage>`。`normal`はフォント自身の推奨行"
+"送り(アセント+ディセント+行間)から求めるため、フォントによって値が変わる"
+msgstr ""
+"`normal`, `<number>`, `<length>`, and `<percentage>`. `normal` is derived "
+"from the font's own recommended line spacing (ascent + descent + line gap), "
+"so its value depends on the font"
 
 #: src/supports/properties.md:95
 msgid "`text-align`"

--- a/docs/src/supports/properties.md
+++ b/docs/src/supports/properties.md
@@ -91,7 +91,7 @@
 | `font-style` | ⚠️ | `normal`/`italic`/`oblique`(`oblique`は`italic`と同一視、傾斜角の指定は不可)。イタリック字形が無い場合はテキスト行列のせん断による疑似イタリック |
 | `font`(ショートハンド) | ❌ | 個別のロングハンドを使う |
 | `color` | ✅ | 継承プロパティ。指定できる色の記法は[セレクタ・値・at-rule](selectors.md#色)を参照 |
-| `line-height` | ✅ | `normal`/`<number>`/`<length>`/`<percentage>` |
+| `line-height` | ✅ | `normal`/`<number>`/`<length>`/`<percentage>`。`normal`はフォント自身の推奨行送り(アセント+ディセント+行間)から求めるため、フォントによって値が変わる |
 | `text-align` | ⚠️ | `left`/`right`/`center`/`justify`。`justify`は最終行以外の単語間で余白を配分する。`start`/`end`は非対応(`direction`自体が非対応のため) |
 | `text-indent` | ⚠️ | `<length>`/`<percentage>`。`hanging`/`each-line`は非対応 |
 | `text-transform` | ⚠️ | `none`/`uppercase`/`lowercase`/`capitalize`(語頭のみ変換)。`full-width`/`full-size-kana`は非対応 |


### PR DESCRIPTION
Fixes https://github.com/waka/sghtmltopdf/issues/33 .

When a table cell stacks two block elements and the second one has a larger `font-size`, the following border is drawn through the larger text instead of below it.
The cell's height is computed from the smaller font alone that is not what happens.
The cell height is correct (10.8 + 13.2 = 24.0 for 9px + 11px).
What is wrong is the height of the line boxes inside it.

### Cause

CSS defines normal as the font's own recommended line spacing, which is ascent + descent + lineGap.
Fixed ratio only happens to work for fonts whose content area fits inside it.
Plenty of fonts do not: DejaVu Sans is 1.164em and Liberation Sans 1.150em, but Noto Sans CJK is 1.448em, and CJK fonts around 1.4em are common.

### Fixed

- Metrics now keeps line_gap (skrifa's m.leading, which follows the OS/2 USE_TYPO_METRICS bit the same way ascent/descent already do), and Font::normal_line_height(font_size) returns (ascender - descender + line_gap) / upem * font_size. 
- resolve_line_height(style) became resolve_line_height(style, Option<&Font>). normal is resolved from the font, falling back to a fixed ratio only when no font can be selected at all (an empty collection).
- Lines with no text needed a font too, so first_available_font (CSS's first available font, looked up with a space as the representative character) and empty_line_height were added and used for <br>-only lines and blank white-space: pre lines.
- shape_run already has the resolved font and just passes it through. Lines that mix fonts through fallback keep working unchanged, since the line height is already the max over the runs.