### PR TITLE
Generate anonymous table boxes so table content is not dropped without an explicit row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   table did not have, given zero width, and dropped from the output with no error or warning —
   a logo beside a label that appears on the following row, a common invoice-table shape. The
   count now falls out of the placement walk itself, so the two can no longer disagree.
+- Generate the anonymous table boxes that CSS 2.1 §17.2.1 calls for (#34). Content inside a
+  `display: table` was laid out only when every cell sat inside an explicit `display: table-row`
+  box; a stray `table-cell`, or a plain block child, was dropped from the output with no text,
+  no ink and no warning. Consecutive cells without a row now get an anonymous row (rule 2.1),
+  and consecutive children of a table or a row that are not cells get an anonymous cell
+  (rule 2.2). Whitespace between proper table children, and `<colgroup>` / `<col>`, still
+  generate nothing. `display: table` with `display: table-cell` and no row in between is a
+  common pre-flexbox column idiom, so a document using it lost whole columns silently.
 
 ### Added
 

--- a/core/src/layout/block.rs
+++ b/core/src/layout/block.rs
@@ -102,7 +102,9 @@ pub struct LaidOutTable {
 /// レイアウト済みのテーブル行1行分。
 #[derive(Debug, Clone)]
 pub struct LaidOutTableRow {
-    pub node: NodeId,
+    /// 元の`display: table-row`要素。無名行(CSSの無名ボックス生成規則で
+    /// 作られた行)は`None`。
+    pub node: Option<NodeId>,
     pub cells: Vec<LaidOutBox>,
     /// この行が属するセクション。`paginate`が`<thead>`の
     /// 行を各ページの先頭へ複製するために使う。

--- a/core/src/layout/box_tree.rs
+++ b/core/src/layout/box_tree.rs
@@ -178,7 +178,9 @@ pub enum TableSection {
 /// `display: table-row`要素(`<tr>`)1行分。
 #[derive(Debug, Clone)]
 pub struct TableRow {
-    pub node: NodeId,
+    /// 元の`display: table-row`要素。CSSの無名ボックス生成規則で作られた行は
+    /// 対応するDOMノードを持たないため`None`。
+    pub node: Option<NodeId>,
     pub cells: Vec<TableCell>,
     /// この行が属するセクション。ページ分割層が`<thead>`の行を各ページの
     /// 先頭に複製するために使う。
@@ -188,7 +190,8 @@ pub struct TableRow {
 /// `display: table-cell`要素(`<td>`/`<th>`)1セル分。
 #[derive(Debug, Clone)]
 pub struct TableCell {
-    pub node: NodeId,
+    /// 元の`display: table-cell`要素。無名セルは`None`。
+    pub node: Option<NodeId>,
     /// `colspan`属性の値(未指定または不正な値は1)。
     pub colspan: usize,
     /// `rowspan`属性の値(未指定または不正な値は1)。`rowspan="0"`(HTML5の
@@ -972,6 +975,51 @@ fn collect_table_rows(
     });
 }
 
+/// テーブル(またはその中の`<thead>`等の入れ物)の子が、テーブル構造の中で
+/// 何として扱われるか。
+enum TableChild {
+    Row,
+    Caption,
+    /// `<thead>`/`<tbody>`/`<tfoot>`。専用の`display`値を持たない透明な入れ物
+    /// なので、中の行をそのセクションとして集める。
+    Section(TableSection),
+    /// 行にもセクションにもならない子。無名の行・セルでくるむ対象
+    /// (CSS2.1 17.2.1 規則2.1)。
+    Content,
+    /// ボックスを生成しない(`display: none`・列指定・コメント等)。
+    Ignored,
+}
+
+fn table_child_kind(
+    dom: &Dom,
+    styles: &HashMap<NodeId, Rc<ComputedStyle>>,
+    node: NodeId,
+) -> TableChild {
+    if !matches!(dom.node(node).data, NodeData::Element { .. }) {
+        // テキストノードは内容として扱う(空白のみのものは、その並びが
+        // 空白しか無ければ`flush_anonymous_row`が捨てる)。コメント等は無視。
+        return match dom.node(node).data {
+            NodeData::Text { .. } => TableChild::Content,
+            _ => TableChild::Ignored,
+        };
+    }
+
+    match styles.get(&node).map(|s| s.display) {
+        Some(Display::TableRow) => TableChild::Row,
+        Some(Display::TableCaption) => TableChild::Caption,
+        Some(Display::None) | None => TableChild::Ignored,
+        _ => match element_local_name(dom, node).as_deref() {
+            Some("thead") => TableChild::Section(TableSection::Head),
+            Some("tfoot") => TableChild::Section(TableSection::Foot),
+            Some("tbody") => TableChild::Section(TableSection::Body),
+            // 列を表すボックスは描画されず、無名ボックスも生成しない
+            // (幅のヒントは`collect_column_widths`が別途読む)。
+            Some("colgroup") | Some("col") => TableChild::Ignored,
+            _ => TableChild::Content,
+        },
+    }
+}
+
 /// [`collect_table_rows`]の本体。`section`は「今いる入れ物」が示すセクション。
 fn collect_table_rows_in_section(
     dom: &Dom,
@@ -981,30 +1029,145 @@ fn collect_table_rows_in_section(
     out: &mut Vec<TableRow>,
     out_caption: &mut Option<NodeId>,
 ) {
+    // 行にならない子が連続する区間。区切りに達したところで無名の行にまとめる。
+    let mut pending: Vec<NodeId> = Vec::new();
+
     for child in dom.children(node) {
-        match styles.get(&child).map(|s| s.display) {
-            Some(Display::TableRow) => {
+        match table_child_kind(dom, styles, child) {
+            TableChild::Row => {
+                flush_anonymous_row(dom, styles, &mut pending, section, out);
                 out.push(build_table_row(dom, styles, child, section));
             }
-            Some(Display::TableCaption) => {
+            TableChild::Caption => {
+                flush_anonymous_row(dom, styles, &mut pending, section, out);
                 if out_caption.is_none() {
                     *out_caption = Some(child);
                 }
             }
-            Some(Display::Table) | Some(Display::None) | None => {}
-            _ => {
-                // `<thead>`/`<tfoot>`に入ったらそこから下の行のセクションが
-                // 決まる。入れ子の`<tbody>`等は現れない前提。
-                let child_section = match element_local_name(dom, child).as_deref() {
-                    Some("thead") => TableSection::Head,
-                    Some("tfoot") => TableSection::Foot,
-                    Some("tbody") => TableSection::Body,
-                    _ => section,
-                };
+            TableChild::Section(child_section) => {
+                flush_anonymous_row(dom, styles, &mut pending, section, out);
                 collect_table_rows_in_section(dom, styles, child, child_section, out, out_caption);
             }
+            TableChild::Content => pending.push(child),
+            TableChild::Ignored => {}
         }
     }
+
+    flush_anonymous_row(dom, styles, &mut pending, section, out);
+}
+
+/// 溜まっている「行にならない子」を1つの無名`table-row`にまとめて`out`へ積む
+/// (CSS2.1 17.2.1 規則2.1)。空白のみの並びは行を作らずに捨てる(規則1の
+/// 「無意味なボックスを取り除く」に相当)。
+fn flush_anonymous_row(
+    dom: &Dom,
+    styles: &HashMap<NodeId, Rc<ComputedStyle>>,
+    pending: &mut Vec<NodeId>,
+    section: TableSection,
+    out: &mut Vec<TableRow>,
+) {
+    if pending.is_empty() {
+        return;
+    }
+    let children = std::mem::take(pending);
+    if children
+        .iter()
+        .all(|&child| is_ignorable_whitespace(dom, child))
+    {
+        return;
+    }
+    let cells = build_row_cells(dom, styles, &children);
+    if cells.is_empty() {
+        return;
+    }
+    out.push(TableRow {
+        node: None,
+        cells,
+        section,
+    });
+}
+
+/// 空白のみのテキストノードか。テーブル構造の隙間(行やセルの間)にある
+/// 空白は、ボックスを生成しない。
+fn is_ignorable_whitespace(dom: &Dom, node: NodeId) -> bool {
+    match &dom.node(node).data {
+        NodeData::Text { contents } => white_space::is_collapsible_only(contents),
+        _ => false,
+    }
+}
+
+/// 行の子(`children`)からセル列を作る。`display: table-cell`はそのまま
+/// セルになり、そうでない子は連続するかたまりごとに無名のセルでくるむ
+/// (CSS2.1 17.2.1 規則2.2)。
+fn build_row_cells(
+    dom: &Dom,
+    styles: &HashMap<NodeId, Rc<ComputedStyle>>,
+    children: &[NodeId],
+) -> Vec<TableCell> {
+    let mut cells = Vec::new();
+    let mut pending: Vec<NodeId> = Vec::new();
+
+    for &child in children {
+        let display = styles.get(&child).map(|s| s.display);
+        if display == Some(Display::TableCell) {
+            flush_anonymous_cell(dom, styles, &mut pending, &mut cells);
+            cells.push(TableCell {
+                node: Some(child),
+                colspan: read_colspan(dom, child),
+                rowspan: read_rowspan(dom, child),
+                content: build_box_for_element(dom, styles, child)
+                    .unwrap_or_else(|| LayoutBox::for_node(child, BoxContent::Inline(Vec::new()))),
+            });
+            continue;
+        }
+        if display == Some(Display::None) || !generates_a_box(dom, child) {
+            continue;
+        }
+        pending.push(child);
+    }
+    flush_anonymous_cell(dom, styles, &mut pending, &mut cells);
+
+    cells
+}
+
+/// 要素以外(コメント等)や列の指定はボックスを生成しない。
+fn generates_a_box(dom: &Dom, node: NodeId) -> bool {
+    match &dom.node(node).data {
+        NodeData::Text { .. } => true,
+        NodeData::Element { .. } => !matches!(
+            element_local_name(dom, node).as_deref(),
+            Some("colgroup") | Some("col")
+        ),
+        _ => false,
+    }
+}
+
+/// 溜まっている「セルにならない子」を1つの無名`table-cell`にまとめる。
+/// 空白のみの並びはセルを作らずに捨てる。
+fn flush_anonymous_cell(
+    dom: &Dom,
+    styles: &HashMap<NodeId, Rc<ComputedStyle>>,
+    pending: &mut Vec<NodeId>,
+    cells: &mut Vec<TableCell>,
+) {
+    if pending.is_empty() {
+        return;
+    }
+    let children = std::mem::take(pending);
+    if children
+        .iter()
+        .all(|&child| is_ignorable_whitespace(dom, child))
+    {
+        return;
+    }
+    cells.push(TableCell {
+        node: None,
+        colspan: 1,
+        rowspan: 1,
+        content: LayoutBox::anonymous(BoxContent::Blocks(build_children_boxes(
+            dom, styles, &children, 1,
+        ))),
+    });
 }
 
 fn build_table_row(
@@ -1013,20 +1176,10 @@ fn build_table_row(
     row_node: NodeId,
     section: TableSection,
 ) -> TableRow {
-    let cells = dom
-        .children(row_node)
-        .filter(|&child| styles.get(&child).map(|s| s.display) == Some(Display::TableCell))
-        .map(|cell_node| TableCell {
-            node: cell_node,
-            colspan: read_colspan(dom, cell_node),
-            rowspan: read_rowspan(dom, cell_node),
-            content: build_box_for_element(dom, styles, cell_node)
-                .unwrap_or_else(|| LayoutBox::for_node(cell_node, BoxContent::Inline(Vec::new()))),
-        })
-        .collect();
+    let children: Vec<NodeId> = dom.children(row_node).collect();
     TableRow {
-        node: row_node,
-        cells,
+        node: Some(row_node),
+        cells: build_row_cells(dom, styles, &children),
         section,
     }
 }
@@ -1552,6 +1705,94 @@ mod tests {
             !text.contains("LEAK"),
             "hidden descendants must not contribute text, got {text:?}"
         );
+    }
+
+    #[test]
+    fn stray_table_cells_get_an_anonymous_row() {
+        // CSS2.1 17.2.1 規則2.1: `table`直下の連続する`table-cell`は1つの
+        // 無名`table-row`にまとまる。
+        let dom = html::parse(
+            br#"<div style="display: table">
+                <div style="display: table-cell">alpha</div>
+                <div style="display: table-cell">beta</div>
+            </div>"#,
+        );
+        let ua = user_agent_stylesheet();
+        let styles = compute_styles(&dom, &ua, &Stylesheet::default());
+        let tree = build_box_tree(&dom, &styles);
+
+        let table_node = find(&dom, dom.document(), "div").expect("table not found");
+        let table_box = find_box(&tree, table_node).expect("table box not found");
+        let BoxContent::Table(table) = &table_box.content else {
+            panic!("expected a table box");
+        };
+
+        assert_eq!(table.rows.len(), 1, "one anonymous row for both cells");
+        assert_eq!(table.rows[0].node, None, "the row has no DOM node");
+        assert_eq!(table.rows[0].cells.len(), 2);
+        assert!(
+            table.rows[0].cells.iter().all(|cell| cell.node.is_some()),
+            "the cells themselves are real elements"
+        );
+    }
+
+    #[test]
+    fn non_cell_children_get_an_anonymous_cell() {
+        // CSS2.1 17.2.1 規則2.2: セルでない子は、連続するかたまりごとに
+        // 1つの無名`table-cell`でくるまれる。
+        let dom = html::parse(
+            br#"<div style="display: table">
+                <div style="display: table-row">
+                    <div>alpha</div>
+                    <div>beta</div>
+                    <div style="display: table-cell">gamma</div>
+                </div>
+            </div>"#,
+        );
+        let ua = user_agent_stylesheet();
+        let styles = compute_styles(&dom, &ua, &Stylesheet::default());
+        let tree = build_box_tree(&dom, &styles);
+
+        let table_node = find(&dom, dom.document(), "div").expect("table not found");
+        let table_box = find_box(&tree, table_node).expect("table box not found");
+        let BoxContent::Table(table) = &table_box.content else {
+            panic!("expected a table box");
+        };
+
+        assert_eq!(table.rows.len(), 1);
+        let cells = &table.rows[0].cells;
+        assert_eq!(cells.len(), 2, "one anonymous cell + the explicit one");
+        assert_eq!(
+            cells[0].node, None,
+            "alpha and beta share an anonymous cell"
+        );
+        assert!(cells[1].node.is_some());
+        let BoxContent::Blocks(blocks) = &cells[0].content.content else {
+            panic!("expected block content in the anonymous cell");
+        };
+        assert_eq!(blocks.len(), 2, "both blocks live in that one cell");
+    }
+
+    #[test]
+    fn whitespace_between_table_children_creates_no_anonymous_row() {
+        let dom = html::parse(
+            br#"<table>
+                <tr><td>alpha</td></tr>
+                <tr><td>beta</td></tr>
+            </table>"#,
+        );
+        let ua = user_agent_stylesheet();
+        let styles = compute_styles(&dom, &ua, &Stylesheet::default());
+        let tree = build_box_tree(&dom, &styles);
+
+        let table_node = find(&dom, dom.document(), "table").expect("table not found");
+        let table_box = find_box(&tree, table_node).expect("table box not found");
+        let BoxContent::Table(table) = &table_box.content else {
+            panic!("expected a table box");
+        };
+
+        assert_eq!(table.rows.len(), 2, "only the two explicit rows");
+        assert!(table.rows.iter().all(|row| row.node.is_some()));
     }
 
     #[test]

--- a/core/src/layout/table.rs
+++ b/core/src/layout/table.rs
@@ -1297,7 +1297,7 @@ mod tests {
 
     fn grid_cell(colspan: usize, rowspan: usize) -> TableCell {
         TableCell {
-            node: NodeId(0),
+            node: Some(NodeId(0)),
             colspan,
             rowspan,
             content: LayoutBox::anonymous(BoxContent::Inline(Vec::new())),
@@ -1306,7 +1306,7 @@ mod tests {
 
     fn grid_row(cells: Vec<TableCell>) -> TableRow {
         TableRow {
-            node: NodeId(0),
+            node: Some(NodeId(0)),
             cells,
             section: super::super::box_tree::TableSection::Body,
         }

--- a/core/src/pdf/document.rs
+++ b/core/src/pdf/document.rs
@@ -2363,7 +2363,8 @@ fn render_row_background(
     settings: &PageSettings,
     alpha_gs_names: &[String],
 ) {
-    let Some(style) = styles.get(&row.node) else {
+    // 無名行(`node: None`)は背景を指定しようがないので何も描かない。
+    let Some(style) = row.node.and_then(|node| styles.get(&node)) else {
         return;
     };
     if style.background_color.alpha <= 0.0 || row.cells.is_empty() {

--- a/core/tests/table_anonymous_boxes.rs
+++ b/core/tests/table_anonymous_boxes.rs
@@ -1,0 +1,188 @@
+//! CSS2.1 17.2.1の無名テーブルボックス生成のE2Eテスト。
+//!
+//! `table_rowspan.rs`と同じ方針: 実際のパイプラインを通して回帰を検知する。
+//! 構造の検証は`layout_document`(ページ分割前)の結果に対して行う。
+
+use std::collections::HashMap;
+
+use sghtmltopdf_core::fonts::{Font, FontCollection};
+use sghtmltopdf_core::html;
+use sghtmltopdf_core::layout::{
+    build_box_tree, layout_document, paginate_document, LaidOutBox, LaidOutContent, PageSettings,
+};
+use sghtmltopdf_core::pdf::encode_pdf;
+use sghtmltopdf_core::style::{compute_styles, parse_stylesheet, user_agent_stylesheet};
+
+const FONT_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fonts/DejaVuSans.ttf");
+
+fn test_fonts() -> FontCollection {
+    FontCollection::new(vec![
+        Font::load(FONT_PATH).expect("should load bundled test font")
+    ])
+}
+
+fn layout(html_src: &str) -> LaidOutBox {
+    let dom = html::parse(html_src.as_bytes());
+    let ua = user_agent_stylesheet();
+    let author = parse_stylesheet("body { margin: 0; }");
+    let styles = compute_styles(&dom, &ua, &author);
+    let fonts = test_fonts();
+    let tree = build_box_tree(&dom, &styles);
+    layout_document(
+        &tree,
+        &styles,
+        &fonts,
+        PageSettings::default().content_width(),
+    )
+}
+
+/// 描画される行(テキストを持つ行ボックス)を、テキストとその位置つきで集める。
+fn collect_text_lines(b: &LaidOutBox, out: &mut Vec<(String, f32, f32)>) {
+    match &b.content {
+        LaidOutContent::Inline(lines) => {
+            for line in lines {
+                let text: String = line.runs.iter().map(|run| run.text.as_str()).collect();
+                if !text.trim().is_empty() {
+                    out.push((text, line.rect.x, line.rect.y));
+                }
+            }
+        }
+        LaidOutContent::Blocks(children) | LaidOutContent::Flex(children) => {
+            for child in children {
+                collect_text_lines(child, out);
+            }
+        }
+        LaidOutContent::Table(table) => {
+            if let Some(caption) = table.caption.as_deref() {
+                collect_text_lines(caption, out);
+            }
+            for cell in table.rows.iter().flat_map(|row| &row.cells) {
+                collect_text_lines(cell, out);
+            }
+        }
+        LaidOutContent::Grid(grid) => {
+            for item in grid.rows.iter().flat_map(|row| &row.items) {
+                collect_text_lines(item, out);
+            }
+        }
+        LaidOutContent::Image(_) => {}
+    }
+}
+
+fn texts(html_src: &str) -> Vec<String> {
+    let laid = layout(html_src);
+    let mut lines = Vec::new();
+    collect_text_lines(&laid, &mut lines);
+    lines.into_iter().map(|(text, _, _)| text).collect()
+}
+
+/// レイアウトからPDFまで通して、クラッシュせず1ページのPDFになることを確認する。
+fn renders_to_a_valid_pdf(html_src: &str) {
+    let dom = html::parse(html_src.as_bytes());
+    let ua = user_agent_stylesheet();
+    let author = parse_stylesheet("body { margin: 0; }");
+    let styles = compute_styles(&dom, &ua, &author);
+    let fonts = test_fonts();
+    let settings = PageSettings::default();
+    let pages = paginate_document(&dom, &styles, &fonts, &settings);
+    let bytes = encode_pdf(&pages, &styles, &HashMap::new(), &fonts, &settings);
+    assert!(bytes.starts_with(b"%PDF-"));
+}
+
+const CELLS_WITHOUT_A_ROW: &str = r#"<div style="display: table">
+    <div style="display: table-cell">alpha</div>
+    <div style="display: table-cell">beta</div>
+</div>"#;
+
+#[test]
+fn table_cells_without_a_row_get_an_anonymous_row() {
+    // CSS2.1 17.2.1 規則2.1。行の箱が無いと、セルごと出力から消えていた。
+    assert_eq!(texts(CELLS_WITHOUT_A_ROW), vec!["alpha", "beta"]);
+
+    let laid = layout(CELLS_WITHOUT_A_ROW);
+    let mut lines = Vec::new();
+    collect_text_lines(&laid, &mut lines);
+    let (_, alpha_x, alpha_y) = lines[0];
+    let (_, beta_x, beta_y) = lines[1];
+    assert!(
+        beta_x > alpha_x,
+        "the two cells should sit side by side: alpha at {alpha_x}, beta at {beta_x}"
+    );
+    assert!(
+        (alpha_y - beta_y).abs() < 0.5,
+        "both cells belong to the same anonymous row, so they share a baseline row"
+    );
+
+    renders_to_a_valid_pdf(CELLS_WITHOUT_A_ROW);
+}
+
+#[test]
+fn a_plain_block_inside_a_table_gets_an_anonymous_cell_and_row() {
+    let html_src = r#"<div style="display: table"><div>alpha</div></div>"#;
+    assert_eq!(texts(html_src), vec!["alpha"]);
+    renders_to_a_valid_pdf(html_src);
+}
+
+#[test]
+fn a_plain_block_inside_a_table_row_gets_an_anonymous_cell() {
+    // CSS2.1 17.2.1 規則2.2。
+    let html_src = r#"<div style="display: table">
+        <div style="display: table-row">
+            <div style="display: table-cell">alpha</div>
+            <div>beta</div>
+        </div>
+    </div>"#;
+    assert_eq!(texts(html_src), vec!["alpha", "beta"]);
+    renders_to_a_valid_pdf(html_src);
+}
+
+#[test]
+fn consecutive_non_cell_children_share_one_anonymous_cell() {
+    // 連続する「セルでない子」は1つの無名セルにまとまる(規則2.2)ため、
+    // 縦に積まれる。セルが分かれていれば横に並ぶ。
+    let html_src = r#"<div style="display: table">
+        <div style="display: table-row">
+            <div>alpha</div>
+            <div>beta</div>
+        </div>
+    </div>"#;
+    let laid = layout(html_src);
+    let mut lines = Vec::new();
+    collect_text_lines(&laid, &mut lines);
+    assert_eq!(lines.len(), 2);
+    let (_, alpha_x, alpha_y) = lines[0];
+    let (_, beta_x, beta_y) = lines[1];
+    assert!(
+        (alpha_x - beta_x).abs() < 0.5,
+        "both blocks belong to the same anonymous cell, so they share the left edge"
+    );
+    assert!(
+        beta_y > alpha_y,
+        "and stack vertically inside it: {alpha_y} then {beta_y}"
+    );
+}
+
+#[test]
+fn explicit_rows_and_real_table_elements_are_unchanged() {
+    let with_row = r#"<div style="display: table">
+        <div style="display: table-row">
+            <div style="display: table-cell">alpha</div>
+            <div style="display: table-cell">beta</div>
+        </div>
+    </div>"#;
+    assert_eq!(texts(with_row), vec!["alpha", "beta"]);
+    assert_eq!(
+        texts(r#"<table><tr><td>alpha</td><td>beta</td></tr></table>"#),
+        vec!["alpha", "beta"]
+    );
+}
+
+#[test]
+fn whitespace_and_column_elements_do_not_create_anonymous_boxes() {
+    // 行やセルの間の空白、`<colgroup>`/`<col>`は無名ボックスを作らない。
+    let html_src = r#"<table>
+        <colgroup><col style="width: 50px"><col></colgroup>
+        <tr><td>alpha</td><td>beta</td></tr>
+    </table>"#;
+    assert_eq!(texts(html_src), vec!["alpha", "beta"]);
+}

--- a/docs/po/en.po
+++ b/docs/po/en.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: sghtmltopdf\n"
-"POT-Creation-Date: 2026-08-30T16:06:58+09:00\n"
+"POT-Creation-Date: 2026-08-30T18:38:36+09:00\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -3065,9 +3065,9 @@ msgstr "Precompiled gems are distributed, so no Rust toolchain is needed."
 #: src/supports/properties.md:31 src/supports/properties.md:46
 #: src/supports/properties.md:65 src/supports/properties.md:86
 #: src/supports/properties.md:113 src/supports/properties.md:128
-#: src/supports/properties.md:146 src/supports/properties.md:155
-#: src/supports/properties.md:166 src/supports/properties.md:181
-#: src/supports/properties.md:216 src/supports/properties.md:235
+#: src/supports/properties.md:150 src/supports/properties.md:159
+#: src/supports/properties.md:170 src/supports/properties.md:185
+#: src/supports/properties.md:220 src/supports/properties.md:239
 #: src/supports/selectors.md:15 src/supports/selectors.md:28
 #: src/supports/selectors.md:47 src/supports/selectors.md:58
 #: src/supports/selectors.md:77 src/supports/selectors.md:90
@@ -3907,20 +3907,20 @@ msgstr "Display and visibility"
 #: src/supports/properties.md:20 src/supports/properties.md:31
 #: src/supports/properties.md:46 src/supports/properties.md:65
 #: src/supports/properties.md:86 src/supports/properties.md:113
-#: src/supports/properties.md:128 src/supports/properties.md:146
-#: src/supports/properties.md:155 src/supports/properties.md:166
-#: src/supports/properties.md:181 src/supports/properties.md:216
-#: src/supports/properties.md:235 src/supports/pagination.md:13
+#: src/supports/properties.md:128 src/supports/properties.md:150
+#: src/supports/properties.md:159 src/supports/properties.md:170
+#: src/supports/properties.md:185 src/supports/properties.md:220
+#: src/supports/properties.md:239 src/supports/pagination.md:13
 msgid "プロパティ"
 msgstr "Property"
 
 #: src/supports/properties.md:20 src/supports/properties.md:31
 #: src/supports/properties.md:46 src/supports/properties.md:65
 #: src/supports/properties.md:86 src/supports/properties.md:113
-#: src/supports/properties.md:128 src/supports/properties.md:146
-#: src/supports/properties.md:155 src/supports/properties.md:166
-#: src/supports/properties.md:181 src/supports/properties.md:216
-#: src/supports/properties.md:235 src/supports/selectors.md:15
+#: src/supports/properties.md:128 src/supports/properties.md:150
+#: src/supports/properties.md:159 src/supports/properties.md:170
+#: src/supports/properties.md:185 src/supports/properties.md:220
+#: src/supports/properties.md:239 src/supports/selectors.md:15
 #: src/supports/selectors.md:28 src/supports/selectors.md:47
 #: src/supports/selectors.md:77 src/supports/selectors.md:121
 #: src/migration/wkhtmltopdf-options.md:29
@@ -3959,10 +3959,10 @@ msgstr "`display`"
 #: src/supports/properties.md:115 src/supports/properties.md:117
 #: src/supports/properties.md:120 src/supports/properties.md:121
 #: src/supports/properties.md:131 src/supports/properties.md:133
-#: src/supports/properties.md:149 src/supports/properties.md:151
-#: src/supports/properties.md:157 src/supports/properties.md:168
-#: src/supports/properties.md:169 src/supports/properties.md:185
-#: src/supports/properties.md:190 src/supports/properties.md:192
+#: src/supports/properties.md:153 src/supports/properties.md:155
+#: src/supports/properties.md:161 src/supports/properties.md:172
+#: src/supports/properties.md:173 src/supports/properties.md:189
+#: src/supports/properties.md:194 src/supports/properties.md:196
 #: src/supports/selectors.md:38 src/supports/selectors.md:49
 #: src/supports/selectors.md:50 src/supports/selectors.md:79
 #: src/supports/selectors.md:81 src/supports/selectors.md:83
@@ -4127,18 +4127,18 @@ msgstr "`margin`"
 #: src/supports/properties.md:116 src/supports/properties.md:118
 #: src/supports/properties.md:119 src/supports/properties.md:130
 #: src/supports/properties.md:132 src/supports/properties.md:134
-#: src/supports/properties.md:135 src/supports/properties.md:148
-#: src/supports/properties.md:150 src/supports/properties.md:158
-#: src/supports/properties.md:159 src/supports/properties.md:170
-#: src/supports/properties.md:171 src/supports/properties.md:183
-#: src/supports/properties.md:184 src/supports/properties.md:186
-#: src/supports/properties.md:187 src/supports/properties.md:188
-#: src/supports/properties.md:189 src/supports/properties.md:191
-#: src/supports/properties.md:218 src/supports/properties.md:219
-#: src/supports/properties.md:220 src/supports/properties.md:221
+#: src/supports/properties.md:135 src/supports/properties.md:152
+#: src/supports/properties.md:154 src/supports/properties.md:162
+#: src/supports/properties.md:163 src/supports/properties.md:174
+#: src/supports/properties.md:175 src/supports/properties.md:187
+#: src/supports/properties.md:188 src/supports/properties.md:190
+#: src/supports/properties.md:191 src/supports/properties.md:192
+#: src/supports/properties.md:193 src/supports/properties.md:195
 #: src/supports/properties.md:222 src/supports/properties.md:223
 #: src/supports/properties.md:224 src/supports/properties.md:225
-#: src/supports/properties.md:237 src/supports/properties.md:238
+#: src/supports/properties.md:226 src/supports/properties.md:227
+#: src/supports/properties.md:228 src/supports/properties.md:229
+#: src/supports/properties.md:241 src/supports/properties.md:242
 #: src/supports/selectors.md:17 src/supports/selectors.md:18
 #: src/supports/selectors.md:19 src/supports/selectors.md:20
 #: src/supports/selectors.md:21 src/supports/selectors.md:22
@@ -4356,10 +4356,10 @@ msgid "`outline-offset`"
 msgstr "`outline-offset`"
 
 #: src/supports/properties.md:60 src/supports/properties.md:92
-#: src/supports/properties.md:122 src/supports/properties.md:160
-#: src/supports/properties.md:172 src/supports/properties.md:193
-#: src/supports/properties.md:194 src/supports/properties.md:226
-#: src/supports/properties.md:227 src/supports/properties.md:228
+#: src/supports/properties.md:122 src/supports/properties.md:164
+#: src/supports/properties.md:176 src/supports/properties.md:197
+#: src/supports/properties.md:198 src/supports/properties.md:230
+#: src/supports/properties.md:231 src/supports/properties.md:232
 #: src/supports/selectors.md:24 src/supports/selectors.md:51
 #: src/supports/selectors.md:52 src/supports/selectors.md:64
 #: src/supports/selectors.md:80 src/supports/selectors.md:85
@@ -4976,6 +4976,19 @@ msgstr ""
 
 #: src/supports/properties.md:140
 msgid ""
+"無名テーブルボックスの生成(CSS2.1 §17.2.1 規則2.1・2.2)に対応する。 "
+"`display: table`の直下に置かれた`display: table-cell`は無名の行にまとめられ、"
+"行やセルにならない子は無名のセルでくるまれる。 行を書かない`display: table` "
+"+ `display: table-cell`の段組みがそのまま動く。"
+msgstr ""
+"Anonymous table boxes are generated (CSS 2.1 §17.2.1, rules 2.1 and 2.2). A "
+"`display: table-cell` placed directly inside a `display: table` is gathered "
+"into an anonymous row, and a child that is neither a row nor a cell is "
+"wrapped in an anonymous cell. A `display: table` plus `display: table-cell` "
+"column layout written without any rows works as it is."
+
+#: src/supports/properties.md:144
+msgid ""
 "セルの`min-width`/`max-width`は列幅アルゴリズムに反映される。 `table-layout: "
 "auto`では列の自然幅をクランプする形で効くため、表を紙幅に収める比例縮尺の後は"
 "`min-width`が保証されない。 `table-layout: fixed`では1行目のセルの指定幅をク"
@@ -4988,24 +5001,24 @@ msgstr ""
 "width stated on the first row's cells, and a cell with `width: auto` and "
 "only a `min-width` uses that value as the column width."
 
-#: src/supports/properties.md:144
+#: src/supports/properties.md:148
 msgid "リスト"
 msgstr "Lists"
 
-#: src/supports/properties.md:148
+#: src/supports/properties.md:152
 msgid "`list-style`(ショートハンド)"
 msgstr "`list-style`, the shorthand"
 
-#: src/supports/properties.md:148
+#: src/supports/properties.md:152
 msgid "`type`/`position`/`image`を任意順・任意省略で受け付ける"
 msgstr ""
 "Accepts `type`, `position`, and `image` in any order with any part omitted"
 
-#: src/supports/properties.md:149
+#: src/supports/properties.md:153
 msgid "`list-style-type`"
 msgstr "`list-style-type`"
 
-#: src/supports/properties.md:149
+#: src/supports/properties.md:153
 msgid ""
 "`disc`/`circle`/`square`/`decimal`/`decimal-leading-zero`/`lower-roman`/"
 "`upper-roman`/`lower-alpha`(`lower-latin`)/`upper-alpha`(`upper-latin`)/"
@@ -5016,19 +5029,19 @@ msgstr ""
 "latin`), and `none`. `cjk-*`, `hiragana`, `katakana`, and the like are not "
 "supported. Inherited"
 
-#: src/supports/properties.md:150
+#: src/supports/properties.md:154
 msgid "`list-style-position`"
 msgstr "`list-style-position`"
 
-#: src/supports/properties.md:150
+#: src/supports/properties.md:154
 msgid "`outside`/`inside`。継承プロパティ"
 msgstr "`outside` and `inside`. Inherited"
 
-#: src/supports/properties.md:151
+#: src/supports/properties.md:155
 msgid "`list-style-image`"
 msgstr "`list-style-image`"
 
-#: src/supports/properties.md:151
+#: src/supports/properties.md:155
 msgid ""
 "`none \\| url(...)`をパースするが描画には使わない(常に`list-style-type`のテキ"
 "ストマーカーへフォールバック)"
@@ -5036,15 +5049,15 @@ msgstr ""
 "`none \\| url(...)` parses but is never drawn; it always falls back to the "
 "text marker from `list-style-type`"
 
-#: src/supports/properties.md:153
+#: src/supports/properties.md:157
 msgid "生成コンテンツ・カウンタ"
 msgstr "Generated content and counters"
 
-#: src/supports/properties.md:157
+#: src/supports/properties.md:161
 msgid "`content`"
 msgstr "`content`"
 
-#: src/supports/properties.md:157
+#: src/supports/properties.md:161
 msgid ""
 "`::before`/`::after`/`::first-letter`および`@page`のmargin box用。文字列リテ"
 "ラル・`attr()`・`counter()`/`counters()`・`open-quote`/`close-quote`/`no-"
@@ -5057,31 +5070,31 @@ msgstr ""
 "Inserting an image with `url()` is not supported. As a simplification, `::"
 "before` and `::after` are not generated on an element that has block children"
 
-#: src/supports/properties.md:158
+#: src/supports/properties.md:162
 msgid "`counter-reset`"
 msgstr "`counter-reset`"
 
-#: src/supports/properties.md:158
+#: src/supports/properties.md:162
 msgid "`none`または`name [<integer>]`の繰り返し"
 msgstr "`none`, or repeated `name [<integer>]`"
 
-#: src/supports/properties.md:159
+#: src/supports/properties.md:163
 msgid "`counter-increment`"
 msgstr "`counter-increment`"
 
-#: src/supports/properties.md:159
+#: src/supports/properties.md:163
 msgid "`none`または`name [<integer>]`の繰り返し(値省略時は1)"
 msgstr "`none`, or repeated `name [<integer>]`, the value being 1 when omitted"
 
-#: src/supports/properties.md:160
+#: src/supports/properties.md:164
 msgid "`counter-set`"
 msgstr "`counter-set`"
 
-#: src/supports/properties.md:160 src/supports/properties.md:228
+#: src/supports/properties.md:164 src/supports/properties.md:232
 msgid "未実装"
 msgstr "Not implemented"
 
-#: src/supports/properties.md:162
+#: src/supports/properties.md:166
 msgid ""
 "`counter(page)`/`counter(pages)`によるページ番号は`@page`のmargin box内で使え"
 "る(`counter(pages)`はストリーミングモードでは総ページ数が確定しないためエラー"
@@ -5091,15 +5104,15 @@ msgstr ""
 "the `@page` margin boxes. `counter(pages)` is an error in streaming mode, "
 "where the total page count is never settled."
 
-#: src/supports/properties.md:164
+#: src/supports/properties.md:168
 msgid "ページ分割(CSS Fragmentation)"
 msgstr "Page breaking (CSS Fragmentation)"
 
-#: src/supports/properties.md:168 src/supports/pagination.md:15
+#: src/supports/properties.md:172 src/supports/pagination.md:15
 msgid "`break-before` / `break-after`"
 msgstr "`break-before`, `break-after`"
 
-#: src/supports/properties.md:168
+#: src/supports/properties.md:172
 msgid ""
 "`auto`/`avoid`(`avoid-page`/`avoid-column`も同義)/`always`(`page`も同義)。"
 "`left`/`right`/`recto`/`verso`(見開き制御)、多段組み関連の値は非対応"
@@ -5108,41 +5121,41 @@ msgstr ""
 "`always` (`page` means the same). `left`, `right`, `recto`, and `verso`, "
 "which control spreads, and the multi-column values are not supported"
 
-#: src/supports/properties.md:169 src/supports/pagination.md:16
+#: src/supports/properties.md:173 src/supports/pagination.md:16
 msgid "`break-inside`"
 msgstr "`break-inside`"
 
-#: src/supports/properties.md:169
+#: src/supports/properties.md:173
 msgid "`auto`/`avoid`(`avoid-page`/`avoid-column`も同義)"
 msgstr "`auto` and `avoid` (`avoid-page` and `avoid-column` mean the same)"
 
-#: src/supports/properties.md:170
+#: src/supports/properties.md:174
 msgid "`page-break-before` / `page-break-after` / `page-break-inside`"
 msgstr "`page-break-before`, `page-break-after`, `page-break-inside`"
 
-#: src/supports/properties.md:170
+#: src/supports/properties.md:174
 msgid "上記`break-*`のエイリアス(wkhtmltopdf/wicked_pdf資産からの移行用)"
 msgstr ""
 "Aliases for the `break-*` properties above, for moving existing wkhtmltopdf "
 "and wicked_pdf work across"
 
-#: src/supports/properties.md:171
+#: src/supports/properties.md:175
 msgid "`orphans` / `widows`"
 msgstr "`orphans`, `widows`"
 
-#: src/supports/properties.md:171
+#: src/supports/properties.md:175
 msgid "1以上の整数。初期値2"
 msgstr "An integer of 1 or more; 2 by default"
 
-#: src/supports/properties.md:172
+#: src/supports/properties.md:176
 msgid "`page`(名前付きページ)"
 msgstr "`page`, named pages"
 
-#: src/supports/properties.md:172
+#: src/supports/properties.md:176
 msgid "`@page intro`のような名前付きページ自体が非対応"
 msgstr "Named pages themselves, such as `@page intro`, are not supported"
 
-#: src/supports/properties.md:174
+#: src/supports/properties.md:178
 msgid ""
 "HTML属性`data-page-break=\"before|after|avoid\"`によるシンタックスシュガーも"
 "利用できる。"
@@ -5150,11 +5163,11 @@ msgstr ""
 "The HTML attribute `data-page-break=\"before|after|avoid\"` is available as "
 "syntactic sugar."
 
-#: src/supports/properties.md:176
+#: src/supports/properties.md:180
 msgid "Flexbox"
 msgstr "Flexbox"
 
-#: src/supports/properties.md:178
+#: src/supports/properties.md:182
 msgid ""
 "`display: flex`のレイアウトは[taffy](https://github.com/DioxusLabs/taffy)へ委"
 "譲する。 flexコンテナはページ分割上アトミック(`display: table`と同じく途中で"
@@ -5164,27 +5177,27 @@ msgstr ""
 "DioxusLabs/taffy). A flex container is atomic as far as page breaking goes: "
 "like `display: table`, it is never split part way through."
 
-#: src/supports/properties.md:183
+#: src/supports/properties.md:187
 msgid "`flex-direction`"
 msgstr "`flex-direction`"
 
-#: src/supports/properties.md:183
+#: src/supports/properties.md:187
 msgid "`row`/`row-reverse`/`column`/`column-reverse`"
 msgstr "`row`, `row-reverse`, `column`, and `column-reverse`"
 
-#: src/supports/properties.md:184
+#: src/supports/properties.md:188
 msgid "`flex-wrap`"
 msgstr "`flex-wrap`"
 
-#: src/supports/properties.md:184
+#: src/supports/properties.md:188
 msgid "`nowrap`/`wrap`/`wrap-reverse`"
 msgstr "`nowrap`, `wrap`, and `wrap-reverse`"
 
-#: src/supports/properties.md:185
+#: src/supports/properties.md:189
 msgid "`justify-content`"
 msgstr "`justify-content`"
 
-#: src/supports/properties.md:185
+#: src/supports/properties.md:189
 msgid ""
 "`normal`(初期値)/`flex-start`(`start`)/`flex-end`(`end`)/`center`/`space-"
 "between`/`space-around`/`space-evenly`。`safe`/`unsafe`オーバーフローキーワー"
@@ -5194,21 +5207,21 @@ msgstr ""
 "`center`, `space-between`, `space-around`, and `space-evenly`. The `safe` "
 "and `unsafe` overflow keywords are not supported"
 
-#: src/supports/properties.md:186
+#: src/supports/properties.md:190
 msgid "`align-items`"
 msgstr "`align-items`"
 
-#: src/supports/properties.md:186
+#: src/supports/properties.md:190
 msgid "`flex-start`(`start`)/`flex-end`(`end`)/`center`/`baseline`/`stretch`"
 msgstr ""
 "`flex-start` (`start`), `flex-end` (`end`), `center`, `baseline`, and "
 "`stretch`"
 
-#: src/supports/properties.md:187
+#: src/supports/properties.md:191
 msgid "`align-content`"
 msgstr "`align-content`"
 
-#: src/supports/properties.md:187
+#: src/supports/properties.md:191
 msgid ""
 "`flex-start`(`start`)/`flex-end`(`end`)/`center`/`stretch`/`space-between`/"
 "`space-around`/`space-evenly`"
@@ -5216,41 +5229,41 @@ msgstr ""
 "`flex-start` (`start`), `flex-end` (`end`), `center`, `stretch`, `space-"
 "between`, `space-around`, and `space-evenly`"
 
-#: src/supports/properties.md:188
+#: src/supports/properties.md:192
 msgid "`align-self`"
 msgstr "`align-self`"
 
-#: src/supports/properties.md:188
+#: src/supports/properties.md:192
 msgid ""
 "`auto`/`flex-start`(`start`)/`flex-end`(`end`)/`center`/`baseline`/`stretch`"
 msgstr ""
 "`auto`, `flex-start` (`start`), `flex-end` (`end`), `center`, `baseline`, "
 "and `stretch`"
 
-#: src/supports/properties.md:189
+#: src/supports/properties.md:193
 msgid "`flex-grow` / `flex-shrink`"
 msgstr "`flex-grow`, `flex-shrink`"
 
-#: src/supports/properties.md:189
+#: src/supports/properties.md:193
 msgid "非負の`<number>`(負値は無効な宣言として無視)"
 msgstr ""
 "A non-negative `<number>`; a negative value makes the declaration invalid "
 "and it is ignored"
 
-#: src/supports/properties.md:190
+#: src/supports/properties.md:194
 msgid "`flex-basis`"
 msgstr "`flex-basis`"
 
-#: src/supports/properties.md:190
+#: src/supports/properties.md:194
 msgid "`auto`/`content`/`<length-percentage>`。`content`は`auto`と同一視"
 msgstr ""
 "`auto`, `content`, and `<length-percentage>`. `content` is treated as `auto`"
 
-#: src/supports/properties.md:191
+#: src/supports/properties.md:195
 msgid "`flex`(ショートハンド)"
 msgstr "`flex`, the shorthand"
 
-#: src/supports/properties.md:191
+#: src/supports/properties.md:195
 msgid ""
 "`none`および`<grow> [<shrink>] [<basis>]`。CSS仕様の既定値規則(`flex: 1`の"
 "basisは`0%`、`flex: <width>`のgrow/shrinkは1)を再現"
@@ -5259,53 +5272,53 @@ msgstr ""
 "rules are reproduced: the basis of `flex: 1` is `0%`, and the grow and "
 "shrink of `flex: <width>` are 1"
 
-#: src/supports/properties.md:192
+#: src/supports/properties.md:196
 msgid "`gap` / `row-gap` / `column-gap`"
 msgstr "`gap`, `row-gap`, `column-gap`"
 
-#: src/supports/properties.md:192
+#: src/supports/properties.md:196
 msgid "flexコンテナでのみ有効(多段組みの`column-gap`としては機能しない)"
 msgstr ""
 "In effect on flex containers only; it does not act as the multi-column "
 "`column-gap`"
 
-#: src/supports/properties.md:193
+#: src/supports/properties.md:197
 msgid "`order`"
 msgstr "`order`"
 
-#: src/supports/properties.md:193
+#: src/supports/properties.md:197
 msgid "taffy 0.12系が未対応のため"
 msgstr "The taffy 0.12 series does not support it"
 
-#: src/supports/properties.md:194
+#: src/supports/properties.md:198
 msgid "`place-content` / `place-items` / `place-self`(ショートハンド)"
 msgstr "`place-content`, `place-items`, `place-self`, the shorthands"
 
-#: src/supports/properties.md:194
+#: src/supports/properties.md:198
 msgid "未実装。個別のロングハンドを使う"
 msgstr "Not implemented. Use the individual longhands"
 
-#: src/supports/properties.md:195 src/supports/properties.md:224
+#: src/supports/properties.md:199 src/supports/properties.md:228
 msgid "`justify-items` / `justify-self`"
 msgstr "`justify-items`, `justify-self`"
 
-#: src/supports/properties.md:195 src/migration/wicked-pdf.md:72
+#: src/supports/properties.md:199 src/migration/wicked-pdf.md:72
 #: src/migration/wicked-pdf.md:73 src/migration/wicked-pdf.md:74
 #: src/migration/wicked-pdf.md:75 src/migration/wicked-pdf.md:76
 #: src/migration/wicked-pdf.md:77
 msgid "—"
 msgstr "—"
 
-#: src/supports/properties.md:195
+#: src/supports/properties.md:199
 msgid "flexアイテムには適用されない(下記)"
 msgstr "They do not apply to flex items; see below"
 
-#: src/supports/properties.md:197
+#: src/supports/properties.md:201
 msgid "`justify-items`/`justify-self`がflexで効かないのは仕様"
 msgstr ""
 "`justify-items` and `justify-self` having no effect in flex is by design"
 
-#: src/supports/properties.md:199
+#: src/supports/properties.md:203
 msgid ""
 "CSS Box Alignmentでは`justify-items`/`justify-self`はGrid・ブロックレイアウト"
 "用のプロパティで、flexアイテムには適用されない(主軸方向のアイテム個別の配置は"
@@ -5320,7 +5333,7 @@ msgstr ""
 "which layout is delegated, only the Grid algorithm looks at them; the "
 "flexbox algorithm never does."
 
-#: src/supports/properties.md:203
+#: src/supports/properties.md:207
 msgid ""
 "したがってこのエンジンでパースに対応しても見た目は変わらないため、意図的に実"
 "装していない。 flexで特定のアイテムだけを寄せたい場合は`margin: auto`を使う"
@@ -5330,21 +5343,21 @@ msgstr ""
 "deliberately left unimplemented. To push a particular flex item to one side, "
 "use `margin: auto`, which is supported:"
 
-#: src/supports/properties.md:207
+#: src/supports/properties.md:211
 msgid "/* justify-self: end 相当(主軸の終端へ) */"
 msgstr ""
 "/* the equivalent of justify-self: end, pushing to the end of the main axis "
 "*/"
 
-#: src/supports/properties.md:208
+#: src/supports/properties.md:212
 msgid "/* justify-self: center 相当 */"
 msgstr "/* the equivalent of justify-self: center */"
 
-#: src/supports/properties.md:211
+#: src/supports/properties.md:215
 msgid "Grid"
 msgstr "Grid"
 
-#: src/supports/properties.md:213
+#: src/supports/properties.md:217
 msgid ""
 "`display: grid`のレイアウトはFlexboxと同じくtaffyへ委譲する。 Flexboxと違い、"
 "1ページに収まらないグリッドは行単位でページ分割される(テーブルと同じ方針。複"
@@ -5355,11 +5368,11 @@ msgstr ""
 "same approach as tables; no break is taken at a boundary crossed by an item "
 "that spans several rows."
 
-#: src/supports/properties.md:218
+#: src/supports/properties.md:222
 msgid "`grid-template-columns` / `grid-template-rows`"
 msgstr "`grid-template-columns`, `grid-template-rows`"
 
-#: src/supports/properties.md:218
+#: src/supports/properties.md:222
 msgid ""
 "`none`/`<length>`/`<percentage>`/`fr`/`auto`/`min-content`/`max-content`/"
 "`minmax()`/`fit-content()`/`repeat(<整数>\\|auto-fill\\|auto-fit)`/"
@@ -5369,11 +5382,11 @@ msgstr ""
 "content`, `minmax()`, `fit-content()`, `repeat(<integer>\\|auto-fill\\|auto-"
 "fit)`, and `[name]` for line names. `calc()` is not supported in a track size"
 
-#: src/supports/properties.md:219
+#: src/supports/properties.md:223
 msgid "`grid-template-areas`"
 msgstr "`grid-template-areas`"
 
-#: src/supports/properties.md:219
+#: src/supports/properties.md:223
 msgid ""
 "文字列マトリクス。列数の不一致・非矩形のエリアは不正な値として宣言ごと無視す"
 "る(仕様通り)。`.`は名前なしセル"
@@ -5382,43 +5395,43 @@ msgstr ""
 "makes the value invalid and the whole declaration is ignored, as the "
 "specification says. A `.` is an unnamed cell"
 
-#: src/supports/properties.md:220
+#: src/supports/properties.md:224
 msgid "`grid-auto-columns` / `grid-auto-rows`"
 msgstr "`grid-auto-columns`, `grid-auto-rows`"
 
-#: src/supports/properties.md:220
+#: src/supports/properties.md:224
 msgid "`<track-size>+`"
 msgstr "`<track-size>+`"
 
-#: src/supports/properties.md:221
+#: src/supports/properties.md:225
 msgid "`grid-auto-flow`"
 msgstr "`grid-auto-flow`"
 
-#: src/supports/properties.md:221
+#: src/supports/properties.md:225
 msgid "`row`/`column`/`dense`(併記可)"
 msgstr "`row`, `column`, and `dense`, which may be combined"
 
-#: src/supports/properties.md:222
+#: src/supports/properties.md:226
 msgid "`grid-row-start` / `-end` / `grid-column-start` / `-end`"
 msgstr "`grid-row-start`, `-end`, `grid-column-start`, `-end`"
 
-#: src/supports/properties.md:222
+#: src/supports/properties.md:226
 msgid ""
 "`auto`/`<integer>`/`span <integer>`/`<custom-ident>`/`span <custom-ident>`"
 msgstr ""
 "`auto`, `<integer>`, `span <integer>`, `<custom-ident>`, and `span <custom-"
 "ident>`"
 
-#: src/supports/properties.md:223
+#: src/supports/properties.md:227
 msgid "`grid-row` / `grid-column` / `grid-area`"
 msgstr "`grid-row`, `grid-column`, `grid-area`"
 
-#: src/supports/properties.md:223
+#: src/supports/properties.md:227
 msgid ""
 "`/`区切りのショートハンド。`grid-area: <name>`で名前付きエリアを指定できる"
 msgstr "The shorthands, separated by `/`. `grid-area: <name>` names an area"
 
-#: src/supports/properties.md:224
+#: src/supports/properties.md:228
 msgid ""
 "Gridでのみ意味を持つ(flexアイテムには適用されない、[上記](#justify-"
 "itemsjustify-selfがflexで効かないのは仕様))"
@@ -5426,20 +5439,20 @@ msgstr ""
 "Meaningful in Grid only; they do not apply to flex items, as [noted above]"
 "(#justify-items-and-justify-self-having-no-effect-in-flex-is-by-design)"
 
-#: src/supports/properties.md:225
+#: src/supports/properties.md:229
 msgid ""
 "`align-items` / `align-self` / `justify-content` / `align-content` / `gap`"
 msgstr "`align-items`, `align-self`, `justify-content`, `align-content`, `gap`"
 
-#: src/supports/properties.md:225
+#: src/supports/properties.md:229
 msgid "Flexboxと共有(値の範囲は[Flexbox](#flexbox)節を参照)"
 msgstr "Ranges"
 
-#: src/supports/properties.md:226
+#: src/supports/properties.md:230
 msgid "`grid` / `grid-template`(ショートハンド)"
 msgstr "`grid`, `grid-template`, the shorthands"
 
-#: src/supports/properties.md:226
+#: src/supports/properties.md:230
 msgid ""
 "個別のロングハンドを使う。トラック定義とエリア定義を1つの構文へ詰め込む複雑な"
 "文法のため非対応"
@@ -5447,19 +5460,19 @@ msgstr ""
 "Use the individual longhands. These pack track and area definitions into one "
 "syntax, and that grammar is too involved to support"
 
-#: src/supports/properties.md:227
+#: src/supports/properties.md:231
 msgid "`display: inline-grid`"
 msgstr "`display: inline-grid`"
 
-#: src/supports/properties.md:227
+#: src/supports/properties.md:231
 msgid "`inline-flex`と同じ理由で非対応"
 msgstr "Not supported, for the same reason as `inline-flex`"
 
-#: src/supports/properties.md:228
+#: src/supports/properties.md:232
 msgid "subgrid / masonry"
 msgstr "subgrid, masonry"
 
-#: src/supports/properties.md:230
+#: src/supports/properties.md:234
 msgid ""
 "`auto`トラックだけで構成したグリッドにコンテナ幅の指定がある場合、余った幅は"
 "`auto`トラックへ配分されますが、その配分比率はCSSの規定(`auto`トラックへ均等)"
@@ -5470,29 +5483,29 @@ msgstr ""
 "proportion CSS prescribes (an equal share to each `auto` track). Use `fr` or "
 "a length if the column widths need to be exact."
 
-#: src/supports/properties.md:233
+#: src/supports/properties.md:237
 msgid "置換要素(画像)"
 msgstr "Replaced elements: images"
 
-#: src/supports/properties.md:237
+#: src/supports/properties.md:241
 msgid "`object-fit`"
 msgstr "`object-fit`"
 
-#: src/supports/properties.md:237
+#: src/supports/properties.md:241
 msgid "`fill`/`contain`/`cover`/`none`/`scale-down`。`<img>`にのみ意味を持つ"
 msgstr ""
 "`fill`, `contain`, `cover`, `none`, and `scale-down`. Meaningful on `<img>` "
 "only"
 
-#: src/supports/properties.md:238
+#: src/supports/properties.md:242
 msgid "`object-position`"
 msgstr "`object-position`"
 
-#: src/supports/properties.md:238
+#: src/supports/properties.md:242
 msgid "`background-position`と同じ値文法。初期値`50% 50%`"
 msgstr "The same syntax as `background-position`. `50% 50%` by default"
 
-#: src/supports/properties.md:240
+#: src/supports/properties.md:244
 msgid ""
 "`<img>`はインライン配置・`width`/`height`属性/CSSによるサイズ指定に対応。 対"
 "応フォーマットはPNG/JPEG/WebP。 CSSで`width`/`height`の片方だけを指定した場合"
@@ -5503,11 +5516,11 @@ msgstr ""
 "When CSS gives only one of `width` and `height`, the other is derived from "
 "the intrinsic aspect ratio (see [`aspect-ratio`](#box-model))."
 
-#: src/supports/properties.md:244
+#: src/supports/properties.md:248
 msgid "非対応プロパティ一覧"
 msgstr "List of unsupported properties"
 
-#: src/supports/properties.md:246
+#: src/supports/properties.md:250
 msgid ""
 "以下は宣言ごと無視される(パースエラー)。 実装が無いだけで、意図的に永久除外と"
 "決めたものだけではない。 カテゴリ表の`❌`行も参照。"
@@ -5516,7 +5529,7 @@ msgstr ""
 "are simply unimplemented, not all deliberately ruled out forever. See the "
 "`❌` rows in the tables above as well."
 
-#: src/supports/properties.md:250
+#: src/supports/properties.md:254
 msgid ""
 "ショートハンド: `font`/`place-content`/`place-items`/`place-self`/`text-"
 "decoration`の色・線種部分"
@@ -5524,7 +5537,7 @@ msgstr ""
 "Shorthands: `font`, `place-content`, `place-items`, `place-self`, and the "
 "colour and line-style parts of `text-decoration`"
 
-#: src/supports/properties.md:251
+#: src/supports/properties.md:255
 msgid ""
 "論理プロパティのうち寸法系: `inline-size`/`block-size`/`min-inline-size`/"
 "`max-block-size`等(`margin`/`padding`/`inset`/`border`の論理プロパティは対応"
@@ -5534,7 +5547,7 @@ msgstr ""
 "size`, `max-block-size` and so on (the `margin`, `padding`, `inset` and "
 "`border` logical properties are supported)"
 
-#: src/supports/properties.md:252
+#: src/supports/properties.md:256
 msgid ""
 "書字方向: `direction`/`unicode-bidi`/`writing-mode`/`text-orientation`/`text-"
 "combine-upright`"
@@ -5542,7 +5555,7 @@ msgstr ""
 "Writing direction: `direction`, `unicode-bidi`, `writing-mode`, `text-"
 "orientation`, `text-combine-upright`"
 
-#: src/supports/properties.md:253
+#: src/supports/properties.md:257
 msgid ""
 "テキスト詳細: `text-decoration-color`/`-style`/`-thickness`/`text-underline-"
 "offset`/`text-emphasis-skip`/`tab-size`/`ruby-*`/`text-justify`/`line-break`"
@@ -5551,7 +5564,7 @@ msgstr ""
 "underline-offset`, `text-emphasis-skip`, `tab-size`, `ruby-*`, `text-"
 "justify`, `line-break`"
 
-#: src/supports/properties.md:254
+#: src/supports/properties.md:258
 msgid ""
 "フォント詳細: `font-variant`/`font-stretch`/`font-feature-settings`/`font-"
 "variation-settings`/`font-kerning`/`font-display`"
@@ -5559,7 +5572,7 @@ msgstr ""
 "Font details: `font-variant`, `font-stretch`, `font-feature-settings`, `font-"
 "variation-settings`, `font-kerning`, `font-display`"
 
-#: src/supports/properties.md:255
+#: src/supports/properties.md:259
 msgid ""
 "多段組み: `columns`/`column-count`/`column-width`/`column-rule`/`column-"
 "span`/`column-fill`"
@@ -5567,7 +5580,7 @@ msgstr ""
 "Multi-column: `columns`, `column-count`, `column-width`, `column-rule`, "
 "`column-span`, `column-fill`"
 
-#: src/supports/properties.md:256
+#: src/supports/properties.md:260
 msgid ""
 "視覚効果: `filter`/`backdrop-filter`/`mix-blend-mode`/`background-blend-"
 "mode`/`clip`/`clip-path`/`mask`/`isolation`"
@@ -5575,7 +5588,7 @@ msgstr ""
 "Visual effects: `filter`, `backdrop-filter`, `mix-blend-mode`, `background-"
 "blend-mode`, `clip`, `clip-path`, `mask`, `isolation`"
 
-#: src/supports/properties.md:257
+#: src/supports/properties.md:261
 msgid ""
 "3D/アニメーション: `perspective`/`transform-style`/`backface-visibility`/"
 "`translate`/`rotate`/`scale`(個別プロパティ版)/`transition-*`/`animation-*`/"
@@ -5585,7 +5598,7 @@ msgstr ""
 "the individual `translate`, `rotate`, and `scale` properties, `transition-"
 "*`, `animation-*`, `will-change`"
 
-#: src/supports/properties.md:258
+#: src/supports/properties.md:262
 msgid ""
 "枠線・背景の拡張: `border-image-*`/`background-clip`/`background-origin`/"
 "`outline-offset`"
@@ -5593,7 +5606,7 @@ msgstr ""
 "Border and background extensions: `border-image-*`, `background-clip`, "
 "`background-origin`, `outline-offset`"
 
-#: src/supports/properties.md:259
+#: src/supports/properties.md:263
 msgid ""
 "オーバーフロー: `overflow-x`/`overflow-y`/`resize`/`scroll-*`/`overscroll-"
 "behavior`"
@@ -5601,7 +5614,7 @@ msgstr ""
 "Overflow: `overflow-x`, `overflow-y`, `resize`, `scroll-*`, `overscroll-"
 "behavior`"
 
-#: src/supports/properties.md:260
+#: src/supports/properties.md:264
 msgid ""
 "UI/対話: `cursor`/`pointer-events`/`user-select`/`caret-color`/`accent-"
 "color`/`appearance`"
@@ -5609,7 +5622,7 @@ msgstr ""
 "UI and interaction: `cursor`, `pointer-events`, `user-select`, `caret-"
 "color`, `accent-color`, `appearance`"
 
-#: src/supports/properties.md:261
+#: src/supports/properties.md:265
 msgid ""
 "その他: `all`/`content-visibility`/`counter-set`/`page`(名前付きページ)/"
 "`speak`等の音声メディア系/`zoom`"

--- a/docs/po/messages.pot
+++ b/docs/po/messages.pot
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: sghtmltopdf\n"
-"POT-Creation-Date: 2026-08-30T16:06:58+09:00\n"
+"POT-Creation-Date: 2026-08-30T18:38:36+09:00\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -2452,9 +2452,9 @@ msgstr ""
 #: src/supports/properties.md:31 src/supports/properties.md:46
 #: src/supports/properties.md:65 src/supports/properties.md:86
 #: src/supports/properties.md:113 src/supports/properties.md:128
-#: src/supports/properties.md:146 src/supports/properties.md:155
-#: src/supports/properties.md:166 src/supports/properties.md:181
-#: src/supports/properties.md:216 src/supports/properties.md:235
+#: src/supports/properties.md:150 src/supports/properties.md:159
+#: src/supports/properties.md:170 src/supports/properties.md:185
+#: src/supports/properties.md:220 src/supports/properties.md:239
 #: src/supports/selectors.md:15 src/supports/selectors.md:28
 #: src/supports/selectors.md:47 src/supports/selectors.md:58
 #: src/supports/selectors.md:77 src/supports/selectors.md:90
@@ -3129,20 +3129,20 @@ msgstr ""
 #: src/supports/properties.md:20 src/supports/properties.md:31
 #: src/supports/properties.md:46 src/supports/properties.md:65
 #: src/supports/properties.md:86 src/supports/properties.md:113
-#: src/supports/properties.md:128 src/supports/properties.md:146
-#: src/supports/properties.md:155 src/supports/properties.md:166
-#: src/supports/properties.md:181 src/supports/properties.md:216
-#: src/supports/properties.md:235 src/supports/pagination.md:13
+#: src/supports/properties.md:128 src/supports/properties.md:150
+#: src/supports/properties.md:159 src/supports/properties.md:170
+#: src/supports/properties.md:185 src/supports/properties.md:220
+#: src/supports/properties.md:239 src/supports/pagination.md:13
 msgid "プロパティ"
 msgstr ""
 
 #: src/supports/properties.md:20 src/supports/properties.md:31
 #: src/supports/properties.md:46 src/supports/properties.md:65
 #: src/supports/properties.md:86 src/supports/properties.md:113
-#: src/supports/properties.md:128 src/supports/properties.md:146
-#: src/supports/properties.md:155 src/supports/properties.md:166
-#: src/supports/properties.md:181 src/supports/properties.md:216
-#: src/supports/properties.md:235 src/supports/selectors.md:15
+#: src/supports/properties.md:128 src/supports/properties.md:150
+#: src/supports/properties.md:159 src/supports/properties.md:170
+#: src/supports/properties.md:185 src/supports/properties.md:220
+#: src/supports/properties.md:239 src/supports/selectors.md:15
 #: src/supports/selectors.md:28 src/supports/selectors.md:47
 #: src/supports/selectors.md:77 src/supports/selectors.md:121
 #: src/migration/wkhtmltopdf-options.md:29
@@ -3181,10 +3181,10 @@ msgstr ""
 #: src/supports/properties.md:115 src/supports/properties.md:117
 #: src/supports/properties.md:120 src/supports/properties.md:121
 #: src/supports/properties.md:131 src/supports/properties.md:133
-#: src/supports/properties.md:149 src/supports/properties.md:151
-#: src/supports/properties.md:157 src/supports/properties.md:168
-#: src/supports/properties.md:169 src/supports/properties.md:185
-#: src/supports/properties.md:190 src/supports/properties.md:192
+#: src/supports/properties.md:153 src/supports/properties.md:155
+#: src/supports/properties.md:161 src/supports/properties.md:172
+#: src/supports/properties.md:173 src/supports/properties.md:189
+#: src/supports/properties.md:194 src/supports/properties.md:196
 #: src/supports/selectors.md:38 src/supports/selectors.md:49
 #: src/supports/selectors.md:50 src/supports/selectors.md:79
 #: src/supports/selectors.md:81 src/supports/selectors.md:83
@@ -3302,18 +3302,18 @@ msgstr ""
 #: src/supports/properties.md:116 src/supports/properties.md:118
 #: src/supports/properties.md:119 src/supports/properties.md:130
 #: src/supports/properties.md:132 src/supports/properties.md:134
-#: src/supports/properties.md:135 src/supports/properties.md:148
-#: src/supports/properties.md:150 src/supports/properties.md:158
-#: src/supports/properties.md:159 src/supports/properties.md:170
-#: src/supports/properties.md:171 src/supports/properties.md:183
-#: src/supports/properties.md:184 src/supports/properties.md:186
-#: src/supports/properties.md:187 src/supports/properties.md:188
-#: src/supports/properties.md:189 src/supports/properties.md:191
-#: src/supports/properties.md:218 src/supports/properties.md:219
-#: src/supports/properties.md:220 src/supports/properties.md:221
+#: src/supports/properties.md:135 src/supports/properties.md:152
+#: src/supports/properties.md:154 src/supports/properties.md:162
+#: src/supports/properties.md:163 src/supports/properties.md:174
+#: src/supports/properties.md:175 src/supports/properties.md:187
+#: src/supports/properties.md:188 src/supports/properties.md:190
+#: src/supports/properties.md:191 src/supports/properties.md:192
+#: src/supports/properties.md:193 src/supports/properties.md:195
 #: src/supports/properties.md:222 src/supports/properties.md:223
 #: src/supports/properties.md:224 src/supports/properties.md:225
-#: src/supports/properties.md:237 src/supports/properties.md:238
+#: src/supports/properties.md:226 src/supports/properties.md:227
+#: src/supports/properties.md:228 src/supports/properties.md:229
+#: src/supports/properties.md:241 src/supports/properties.md:242
 #: src/supports/selectors.md:17 src/supports/selectors.md:18
 #: src/supports/selectors.md:19 src/supports/selectors.md:20
 #: src/supports/selectors.md:21 src/supports/selectors.md:22
@@ -3483,10 +3483,10 @@ msgid "`outline-offset`"
 msgstr ""
 
 #: src/supports/properties.md:60 src/supports/properties.md:92
-#: src/supports/properties.md:122 src/supports/properties.md:160
-#: src/supports/properties.md:172 src/supports/properties.md:193
-#: src/supports/properties.md:194 src/supports/properties.md:226
-#: src/supports/properties.md:227 src/supports/properties.md:228
+#: src/supports/properties.md:122 src/supports/properties.md:164
+#: src/supports/properties.md:176 src/supports/properties.md:197
+#: src/supports/properties.md:198 src/supports/properties.md:230
+#: src/supports/properties.md:231 src/supports/properties.md:232
 #: src/supports/selectors.md:24 src/supports/selectors.md:51
 #: src/supports/selectors.md:52 src/supports/selectors.md:64
 #: src/supports/selectors.md:80 src/supports/selectors.md:85
@@ -3663,7 +3663,8 @@ msgid "`line-height`"
 msgstr ""
 
 #: src/supports/properties.md:94
-msgid "`normal`/`<number>`/`<length>`/`<percentage>`"
+msgid ""
+"`normal`/`<number>`/`<length>`/`<percentage>`。`normal`はフォント自身の推奨行送り(アセント+ディセント+行間)から求めるため、フォントによって値が変わる"
 msgstr ""
 
 #: src/supports/properties.md:95
@@ -3939,272 +3940,279 @@ msgstr ""
 
 #: src/supports/properties.md:140
 msgid ""
+"無名テーブルボックスの生成(CSS2.1 §17.2.1 規則2.1・2.2)に対応する。 `display: "
+"table`の直下に置かれた`display: table-cell`は無名の行にまとめられ、行やセルにならない子は無名のセルでくるまれる。 "
+"行を書かない`display: table` + `display: table-cell`の段組みがそのまま動く。"
+msgstr ""
+
+#: src/supports/properties.md:144
+msgid ""
 "セルの`min-width`/`max-width`は列幅アルゴリズムに反映される。 `table-layout: "
 "auto`では列の自然幅をクランプする形で効くため、表を紙幅に収める比例縮尺の後は`min-width`が保証されない。 `table-layout: "
 "fixed`では1行目のセルの指定幅をクランプし、`width: auto`かつ`min-width`のみの指定はその値を列幅として使う。"
 msgstr ""
 
-#: src/supports/properties.md:144
+#: src/supports/properties.md:148
 msgid "リスト"
 msgstr ""
 
-#: src/supports/properties.md:148
+#: src/supports/properties.md:152
 msgid "`list-style`(ショートハンド)"
 msgstr ""
 
-#: src/supports/properties.md:148
+#: src/supports/properties.md:152
 msgid "`type`/`position`/`image`を任意順・任意省略で受け付ける"
 msgstr ""
 
-#: src/supports/properties.md:149
+#: src/supports/properties.md:153
 msgid "`list-style-type`"
 msgstr ""
 
-#: src/supports/properties.md:149
+#: src/supports/properties.md:153
 msgid ""
 "`disc`/`circle`/`square`/`decimal`/`decimal-leading-zero`/`lower-roman`/`upper-roman`/`lower-alpha`(`lower-latin`)/`upper-alpha`(`upper-latin`)/`none`。`cjk-*`/`hiragana`/`katakana`等は非対応。継承プロパティ"
 msgstr ""
 
-#: src/supports/properties.md:150
+#: src/supports/properties.md:154
 msgid "`list-style-position`"
 msgstr ""
 
-#: src/supports/properties.md:150
+#: src/supports/properties.md:154
 msgid "`outside`/`inside`。継承プロパティ"
 msgstr ""
 
-#: src/supports/properties.md:151
+#: src/supports/properties.md:155
 msgid "`list-style-image`"
 msgstr ""
 
-#: src/supports/properties.md:151
+#: src/supports/properties.md:155
 msgid "`none \\| url(...)`をパースするが描画には使わない(常に`list-style-type`のテキストマーカーへフォールバック)"
 msgstr ""
 
-#: src/supports/properties.md:153
+#: src/supports/properties.md:157
 msgid "生成コンテンツ・カウンタ"
 msgstr ""
 
-#: src/supports/properties.md:157
+#: src/supports/properties.md:161
 msgid "`content`"
 msgstr ""
 
-#: src/supports/properties.md:157
+#: src/supports/properties.md:161
 msgid ""
 "`::before`/`::after`/`::first-letter`および`@page`のmargin "
 "box用。文字列リテラル・`attr()`・`counter()`/`counters()`・`open-quote`/`close-quote`/`no-open-quote`/`no-close-quote`の連結に対応。`url()`による画像挿入は非対応。ブロック子を持つ要素の`::before`/`::after`は生成されない(簡略化)"
 msgstr ""
 
-#: src/supports/properties.md:158
+#: src/supports/properties.md:162
 msgid "`counter-reset`"
 msgstr ""
 
-#: src/supports/properties.md:158
+#: src/supports/properties.md:162
 msgid "`none`または`name [<integer>]`の繰り返し"
 msgstr ""
 
-#: src/supports/properties.md:159
+#: src/supports/properties.md:163
 msgid "`counter-increment`"
 msgstr ""
 
-#: src/supports/properties.md:159
+#: src/supports/properties.md:163
 msgid "`none`または`name [<integer>]`の繰り返し(値省略時は1)"
 msgstr ""
 
-#: src/supports/properties.md:160
+#: src/supports/properties.md:164
 msgid "`counter-set`"
 msgstr ""
 
-#: src/supports/properties.md:160 src/supports/properties.md:228
+#: src/supports/properties.md:164 src/supports/properties.md:232
 msgid "未実装"
 msgstr ""
 
-#: src/supports/properties.md:162
+#: src/supports/properties.md:166
 msgid ""
 "`counter(page)`/`counter(pages)`によるページ番号は`@page`のmargin "
 "box内で使える(`counter(pages)`はストリーミングモードでは総ページ数が確定しないためエラーになる)。"
 msgstr ""
 
-#: src/supports/properties.md:164
+#: src/supports/properties.md:168
 msgid "ページ分割(CSS Fragmentation)"
 msgstr ""
 
-#: src/supports/properties.md:168 src/supports/pagination.md:15
+#: src/supports/properties.md:172 src/supports/pagination.md:15
 msgid "`break-before` / `break-after`"
 msgstr ""
 
-#: src/supports/properties.md:168
+#: src/supports/properties.md:172
 msgid ""
 "`auto`/`avoid`(`avoid-page`/`avoid-column`も同義)/`always`(`page`も同義)。`left`/`right`/`recto`/`verso`(見開き制御)、多段組み関連の値は非対応"
 msgstr ""
 
-#: src/supports/properties.md:169 src/supports/pagination.md:16
+#: src/supports/properties.md:173 src/supports/pagination.md:16
 msgid "`break-inside`"
 msgstr ""
 
-#: src/supports/properties.md:169
+#: src/supports/properties.md:173
 msgid "`auto`/`avoid`(`avoid-page`/`avoid-column`も同義)"
 msgstr ""
 
-#: src/supports/properties.md:170
+#: src/supports/properties.md:174
 msgid "`page-break-before` / `page-break-after` / `page-break-inside`"
 msgstr ""
 
-#: src/supports/properties.md:170
+#: src/supports/properties.md:174
 msgid "上記`break-*`のエイリアス(wkhtmltopdf/wicked_pdf資産からの移行用)"
 msgstr ""
 
-#: src/supports/properties.md:171
+#: src/supports/properties.md:175
 msgid "`orphans` / `widows`"
 msgstr ""
 
-#: src/supports/properties.md:171
+#: src/supports/properties.md:175
 msgid "1以上の整数。初期値2"
 msgstr ""
 
-#: src/supports/properties.md:172
+#: src/supports/properties.md:176
 msgid "`page`(名前付きページ)"
 msgstr ""
 
-#: src/supports/properties.md:172
+#: src/supports/properties.md:176
 msgid "`@page intro`のような名前付きページ自体が非対応"
 msgstr ""
 
-#: src/supports/properties.md:174
+#: src/supports/properties.md:178
 msgid "HTML属性`data-page-break=\"before|after|avoid\"`によるシンタックスシュガーも利用できる。"
 msgstr ""
 
-#: src/supports/properties.md:176
+#: src/supports/properties.md:180
 msgid "Flexbox"
 msgstr ""
 
-#: src/supports/properties.md:178
+#: src/supports/properties.md:182
 msgid ""
 "`display: flex`のレイアウトは[taffy](https://github.com/DioxusLabs/taffy)へ委譲する。 "
 "flexコンテナはページ分割上アトミック(`display: table`と同じく途中で分割されない)。"
 msgstr ""
 
-#: src/supports/properties.md:183
+#: src/supports/properties.md:187
 msgid "`flex-direction`"
 msgstr ""
 
-#: src/supports/properties.md:183
+#: src/supports/properties.md:187
 msgid "`row`/`row-reverse`/`column`/`column-reverse`"
 msgstr ""
 
-#: src/supports/properties.md:184
+#: src/supports/properties.md:188
 msgid "`flex-wrap`"
 msgstr ""
 
-#: src/supports/properties.md:184
+#: src/supports/properties.md:188
 msgid "`nowrap`/`wrap`/`wrap-reverse`"
 msgstr ""
 
-#: src/supports/properties.md:185
+#: src/supports/properties.md:189
 msgid "`justify-content`"
 msgstr ""
 
-#: src/supports/properties.md:185
+#: src/supports/properties.md:189
 msgid ""
 "`normal`(初期値)/`flex-start`(`start`)/`flex-end`(`end`)/`center`/`space-between`/`space-around`/`space-evenly`。`safe`/`unsafe`オーバーフローキーワードは非対応"
 msgstr ""
 
-#: src/supports/properties.md:186
+#: src/supports/properties.md:190
 msgid "`align-items`"
 msgstr ""
 
-#: src/supports/properties.md:186
+#: src/supports/properties.md:190
 msgid "`flex-start`(`start`)/`flex-end`(`end`)/`center`/`baseline`/`stretch`"
 msgstr ""
 
-#: src/supports/properties.md:187
+#: src/supports/properties.md:191
 msgid "`align-content`"
 msgstr ""
 
-#: src/supports/properties.md:187
+#: src/supports/properties.md:191
 msgid ""
 "`flex-start`(`start`)/`flex-end`(`end`)/`center`/`stretch`/`space-between`/`space-around`/`space-evenly`"
 msgstr ""
 
-#: src/supports/properties.md:188
+#: src/supports/properties.md:192
 msgid "`align-self`"
 msgstr ""
 
-#: src/supports/properties.md:188
+#: src/supports/properties.md:192
 msgid ""
 "`auto`/`flex-start`(`start`)/`flex-end`(`end`)/`center`/`baseline`/`stretch`"
 msgstr ""
 
-#: src/supports/properties.md:189
+#: src/supports/properties.md:193
 msgid "`flex-grow` / `flex-shrink`"
 msgstr ""
 
-#: src/supports/properties.md:189
+#: src/supports/properties.md:193
 msgid "非負の`<number>`(負値は無効な宣言として無視)"
 msgstr ""
 
-#: src/supports/properties.md:190
+#: src/supports/properties.md:194
 msgid "`flex-basis`"
 msgstr ""
 
-#: src/supports/properties.md:190
+#: src/supports/properties.md:194
 msgid "`auto`/`content`/`<length-percentage>`。`content`は`auto`と同一視"
 msgstr ""
 
-#: src/supports/properties.md:191
+#: src/supports/properties.md:195
 msgid "`flex`(ショートハンド)"
 msgstr ""
 
-#: src/supports/properties.md:191
+#: src/supports/properties.md:195
 msgid ""
 "`none`および`<grow> [<shrink>] [<basis>]`。CSS仕様の既定値規則(`flex: "
 "1`のbasisは`0%`、`flex: <width>`のgrow/shrinkは1)を再現"
 msgstr ""
 
-#: src/supports/properties.md:192
+#: src/supports/properties.md:196
 msgid "`gap` / `row-gap` / `column-gap`"
 msgstr ""
 
-#: src/supports/properties.md:192
+#: src/supports/properties.md:196
 msgid "flexコンテナでのみ有効(多段組みの`column-gap`としては機能しない)"
 msgstr ""
 
-#: src/supports/properties.md:193
+#: src/supports/properties.md:197
 msgid "`order`"
 msgstr ""
 
-#: src/supports/properties.md:193
+#: src/supports/properties.md:197
 msgid "taffy 0.12系が未対応のため"
 msgstr ""
 
-#: src/supports/properties.md:194
+#: src/supports/properties.md:198
 msgid "`place-content` / `place-items` / `place-self`(ショートハンド)"
 msgstr ""
 
-#: src/supports/properties.md:194
+#: src/supports/properties.md:198
 msgid "未実装。個別のロングハンドを使う"
 msgstr ""
 
-#: src/supports/properties.md:195 src/supports/properties.md:224
+#: src/supports/properties.md:199 src/supports/properties.md:228
 msgid "`justify-items` / `justify-self`"
 msgstr ""
 
-#: src/supports/properties.md:195 src/migration/wicked-pdf.md:72
+#: src/supports/properties.md:199 src/migration/wicked-pdf.md:72
 #: src/migration/wicked-pdf.md:73 src/migration/wicked-pdf.md:74
 #: src/migration/wicked-pdf.md:75 src/migration/wicked-pdf.md:76
 #: src/migration/wicked-pdf.md:77
 msgid "—"
 msgstr ""
 
-#: src/supports/properties.md:195
+#: src/supports/properties.md:199
 msgid "flexアイテムには適用されない(下記)"
 msgstr ""
 
-#: src/supports/properties.md:197
+#: src/supports/properties.md:201
 msgid "`justify-items`/`justify-self`がflexで効かないのは仕様"
 msgstr ""
 
-#: src/supports/properties.md:199
+#: src/supports/properties.md:203
 msgid ""
 "CSS Box "
 "Alignmentでは`justify-items`/`justify-self`はGrid・ブロックレイアウト用のプロパティで、flexアイテムには適用されない(主軸方向のアイテム個別の配置は`justify-content`と`margin: "
@@ -4212,220 +4220,220 @@ msgid ""
 "レイアウトを委譲しているtaffyでも、これらを参照するのはGridのアルゴリズムだけで、flexboxのアルゴリズムは一切参照しない。"
 msgstr ""
 
-#: src/supports/properties.md:203
+#: src/supports/properties.md:207
 msgid ""
 "したがってこのエンジンでパースに対応しても見た目は変わらないため、意図的に実装していない。 flexで特定のアイテムだけを寄せたい場合は`margin: "
 "auto`を使う(こちらは対応済み):"
 msgstr ""
 
-#: src/supports/properties.md:207
+#: src/supports/properties.md:211
 msgid "/* justify-self: end 相当(主軸の終端へ) */"
 msgstr ""
 
-#: src/supports/properties.md:208
+#: src/supports/properties.md:212
 msgid "/* justify-self: center 相当 */"
 msgstr ""
 
-#: src/supports/properties.md:211
+#: src/supports/properties.md:215
 msgid "Grid"
 msgstr ""
 
-#: src/supports/properties.md:213
+#: src/supports/properties.md:217
 msgid ""
 "`display: grid`のレイアウトはFlexboxと同じくtaffyへ委譲する。 "
 "Flexboxと違い、1ページに収まらないグリッドは行単位でページ分割される(テーブルと同じ方針。複数行にまたがるアイテムがある境界では分割しない)。"
 msgstr ""
 
-#: src/supports/properties.md:218
+#: src/supports/properties.md:222
 msgid "`grid-template-columns` / `grid-template-rows`"
 msgstr ""
 
-#: src/supports/properties.md:218
+#: src/supports/properties.md:222
 msgid ""
 "`none`/`<length>`/`<percentage>`/`fr`/`auto`/`min-content`/`max-content`/`minmax()`/`fit-content()`/`repeat(<整数>\\|auto-fill\\|auto-fit)`/`[name]`(ライン名)。トラックサイズに`calc()`は非対応"
 msgstr ""
 
-#: src/supports/properties.md:219
+#: src/supports/properties.md:223
 msgid "`grid-template-areas`"
 msgstr ""
 
-#: src/supports/properties.md:219
+#: src/supports/properties.md:223
 msgid "文字列マトリクス。列数の不一致・非矩形のエリアは不正な値として宣言ごと無視する(仕様通り)。`.`は名前なしセル"
 msgstr ""
 
-#: src/supports/properties.md:220
+#: src/supports/properties.md:224
 msgid "`grid-auto-columns` / `grid-auto-rows`"
 msgstr ""
 
-#: src/supports/properties.md:220
+#: src/supports/properties.md:224
 msgid "`<track-size>+`"
 msgstr ""
 
-#: src/supports/properties.md:221
+#: src/supports/properties.md:225
 msgid "`grid-auto-flow`"
 msgstr ""
 
-#: src/supports/properties.md:221
+#: src/supports/properties.md:225
 msgid "`row`/`column`/`dense`(併記可)"
 msgstr ""
 
-#: src/supports/properties.md:222
+#: src/supports/properties.md:226
 msgid "`grid-row-start` / `-end` / `grid-column-start` / `-end`"
 msgstr ""
 
-#: src/supports/properties.md:222
+#: src/supports/properties.md:226
 msgid ""
 "`auto`/`<integer>`/`span <integer>`/`<custom-ident>`/`span <custom-ident>`"
 msgstr ""
 
-#: src/supports/properties.md:223
+#: src/supports/properties.md:227
 msgid "`grid-row` / `grid-column` / `grid-area`"
 msgstr ""
 
-#: src/supports/properties.md:223
+#: src/supports/properties.md:227
 msgid "`/`区切りのショートハンド。`grid-area: <name>`で名前付きエリアを指定できる"
 msgstr ""
 
-#: src/supports/properties.md:224
+#: src/supports/properties.md:228
 msgid ""
 "Gridでのみ意味を持つ(flexアイテムには適用されない、[上記](#justify-itemsjustify-selfがflexで効かないのは仕様))"
 msgstr ""
 
-#: src/supports/properties.md:225
+#: src/supports/properties.md:229
 msgid ""
 "`align-items` / `align-self` / `justify-content` / `align-content` / `gap`"
 msgstr ""
 
-#: src/supports/properties.md:225
+#: src/supports/properties.md:229
 msgid "Flexboxと共有(値の範囲は[Flexbox](#flexbox)節を参照)"
 msgstr ""
 
-#: src/supports/properties.md:226
+#: src/supports/properties.md:230
 msgid "`grid` / `grid-template`(ショートハンド)"
 msgstr ""
 
-#: src/supports/properties.md:226
+#: src/supports/properties.md:230
 msgid "個別のロングハンドを使う。トラック定義とエリア定義を1つの構文へ詰め込む複雑な文法のため非対応"
 msgstr ""
 
-#: src/supports/properties.md:227
+#: src/supports/properties.md:231
 msgid "`display: inline-grid`"
 msgstr ""
 
-#: src/supports/properties.md:227
+#: src/supports/properties.md:231
 msgid "`inline-flex`と同じ理由で非対応"
 msgstr ""
 
-#: src/supports/properties.md:228
+#: src/supports/properties.md:232
 msgid "subgrid / masonry"
 msgstr ""
 
-#: src/supports/properties.md:230
+#: src/supports/properties.md:234
 msgid ""
 "`auto`トラックだけで構成したグリッドにコンテナ幅の指定がある場合、余った幅は`auto`トラックへ配分されますが、その配分比率はCSSの規定(`auto`トラックへ均等)と一致しません。 "
 "列幅を厳密に決めたい場合は`fr`か長さで指定してください。"
 msgstr ""
 
-#: src/supports/properties.md:233
+#: src/supports/properties.md:237
 msgid "置換要素(画像)"
 msgstr ""
 
-#: src/supports/properties.md:237
+#: src/supports/properties.md:241
 msgid "`object-fit`"
 msgstr ""
 
-#: src/supports/properties.md:237
+#: src/supports/properties.md:241
 msgid "`fill`/`contain`/`cover`/`none`/`scale-down`。`<img>`にのみ意味を持つ"
 msgstr ""
 
-#: src/supports/properties.md:238
+#: src/supports/properties.md:242
 msgid "`object-position`"
 msgstr ""
 
-#: src/supports/properties.md:238
+#: src/supports/properties.md:242
 msgid "`background-position`と同じ値文法。初期値`50% 50%`"
 msgstr ""
 
-#: src/supports/properties.md:240
+#: src/supports/properties.md:244
 msgid ""
 "`<img>`はインライン配置・`width`/`height`属性/CSSによるサイズ指定に対応。 対応フォーマットはPNG/JPEG/WebP。 "
 "CSSで`width`/`height`の片方だけを指定した場合は内在アスペクト比でもう一方を導出する([`aspect-ratio`](#ボックスモデル)、)。"
 msgstr ""
 
-#: src/supports/properties.md:244
+#: src/supports/properties.md:248
 msgid "非対応プロパティ一覧"
 msgstr ""
 
-#: src/supports/properties.md:246
+#: src/supports/properties.md:250
 msgid "以下は宣言ごと無視される(パースエラー)。 実装が無いだけで、意図的に永久除外と決めたものだけではない。 カテゴリ表の`❌`行も参照。"
 msgstr ""
 
-#: src/supports/properties.md:250
+#: src/supports/properties.md:254
 msgid ""
 "ショートハンド: "
 "`font`/`place-content`/`place-items`/`place-self`/`text-decoration`の色・線種部分"
 msgstr ""
 
-#: src/supports/properties.md:251
+#: src/supports/properties.md:255
 msgid ""
 "論理プロパティのうち寸法系: "
 "`inline-size`/`block-size`/`min-inline-size`/`max-block-size`等(`margin`/`padding`/`inset`/`border`の論理プロパティは対応済み)"
 msgstr ""
 
-#: src/supports/properties.md:252
+#: src/supports/properties.md:256
 msgid ""
 "書字方向: "
 "`direction`/`unicode-bidi`/`writing-mode`/`text-orientation`/`text-combine-upright`"
 msgstr ""
 
-#: src/supports/properties.md:253
+#: src/supports/properties.md:257
 msgid ""
 "テキスト詳細: "
 "`text-decoration-color`/`-style`/`-thickness`/`text-underline-offset`/`text-emphasis-skip`/`tab-size`/`ruby-*`/`text-justify`/`line-break`"
 msgstr ""
 
-#: src/supports/properties.md:254
+#: src/supports/properties.md:258
 msgid ""
 "フォント詳細: "
 "`font-variant`/`font-stretch`/`font-feature-settings`/`font-variation-settings`/`font-kerning`/`font-display`"
 msgstr ""
 
-#: src/supports/properties.md:255
+#: src/supports/properties.md:259
 msgid ""
 "多段組み: "
 "`columns`/`column-count`/`column-width`/`column-rule`/`column-span`/`column-fill`"
 msgstr ""
 
-#: src/supports/properties.md:256
+#: src/supports/properties.md:260
 msgid ""
 "視覚効果: "
 "`filter`/`backdrop-filter`/`mix-blend-mode`/`background-blend-mode`/`clip`/`clip-path`/`mask`/`isolation`"
 msgstr ""
 
-#: src/supports/properties.md:257
+#: src/supports/properties.md:261
 msgid ""
 "3D/アニメーション: "
 "`perspective`/`transform-style`/`backface-visibility`/`translate`/`rotate`/`scale`(個別プロパティ版)/`transition-*`/`animation-*`/`will-change`"
 msgstr ""
 
-#: src/supports/properties.md:258
+#: src/supports/properties.md:262
 msgid ""
 "枠線・背景の拡張: "
 "`border-image-*`/`background-clip`/`background-origin`/`outline-offset`"
 msgstr ""
 
-#: src/supports/properties.md:259
+#: src/supports/properties.md:263
 msgid ""
 "オーバーフロー: `overflow-x`/`overflow-y`/`resize`/`scroll-*`/`overscroll-behavior`"
 msgstr ""
 
-#: src/supports/properties.md:260
+#: src/supports/properties.md:264
 msgid ""
 "UI/対話: "
 "`cursor`/`pointer-events`/`user-select`/`caret-color`/`accent-color`/`appearance`"
 msgstr ""
 
-#: src/supports/properties.md:261
+#: src/supports/properties.md:265
 msgid ""
 "その他: "
 "`all`/`content-visibility`/`counter-set`/`page`(名前付きページ)/`speak`等の音声メディア系/`zoom`"

--- a/docs/src/supports/properties.md
+++ b/docs/src/supports/properties.md
@@ -137,6 +137,10 @@
 `<colgroup>`/`<col>`の`width`属性・CSS`width`による列幅指定、`rowspan`/`colspan`、`<thead>`のページまたぎ繰り返しに対応。
 `rowspan="0"`は1として扱う。
 
+無名テーブルボックスの生成(CSS2.1 §17.2.1 規則2.1・2.2)に対応する。
+`display: table`の直下に置かれた`display: table-cell`は無名の行にまとめられ、行やセルにならない子は無名のセルでくるまれる。
+行を書かない`display: table` + `display: table-cell`の段組みがそのまま動く。
+
 セルの`min-width`/`max-width`は列幅アルゴリズムに反映される。
 `table-layout: auto`では列の自然幅をクランプする形で効くため、表を紙幅に収める比例縮尺の後は`min-width`が保証されない。
 `table-layout: fixed`では1行目のセルの指定幅をクランプし、`width: auto`かつ`min-width`のみの指定はその値を列幅として使う。


### PR DESCRIPTION
Fixes https://github.com/waka/sghtmltopdf/issues/34 .

Content inside a `display: table` was laid out only when every cell sat inside an explicit `display: table-row` box. A stray `table-cell`, or a plain block child, was dropped from the output entirely no text, no ink, no warning.

### Cause

`collect_table_rows_in_section` matched a child's `display` and, for anything that was not a row or a caption, recursed into it looking for rows.
That recursion exists so that `<thead>`, `<tbody>` and `<tfoot>` are traversed transparently, but it was applied to every other child too.
A `table-cell` or a `<div>` contains no `table-row`, so the walk found nothing and the whole subtree disappeared. `build_table_row` had the matching gap.

In CSS 2.1 §17.2.1 rules 2.1 and 2.2, generate an anonymous `table-row` around consecutive cells, and an anonymous `table-cell` around consecutive non-cell children.

### Fixed

- `core/tests/table_anonymous_boxes.rs` (new): the four cases from the report, plus consecutive non-cell children sharing one anonymous cell, plus whitespace and `<colgroup>` / `<col>` not producing spurious boxes.
- Unit tests in `box_tree.rs` for the resulting structure: the anonymous row and cell carry `node: None`, both blocks land in a single anonymous cell, and whitespace between rows creates no extra row.                                                                                                                                                                                                    
                                                                                                                                                                                                                  
Verified end to end by rendering the reported markup through the CLI: two text-drawing operations at x = 104 and x = 426.97, side by side. Before, the page had none.

