### PR TITLE
Fix three pagination bugs that put content in the wrong place

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Keep the spacing that margin collapsing produced when a document is split across pages.
+  The pagination rebuilt each page by stacking margin boxes at a running cursor, which
+  reopened every margin the layout had collapsed: adjacent siblings were pushed apart by
+  the smaller of the two margins (paragraphs 50.6px apart instead of 34.7px with the
+  default stylesheet), and a `margin-top` hoisted out of a first child was added once per
+  ancestor, so the top of the first page was pushed down by a multiple of it (85.8px
+  instead of 21.4px for `<h1>` under `<html><body>`). Boxes are now placed at the offsets
+  the layout gave them, so a document that spans several pages has the same geometry as
+  the same content on a single page, and pages hold as much as they should.
+- Start a `display: grid` or `display: table` on the next page when its first row does not
+  fit in what is left of the current one. The row-splitting rule only broke once a fragment
+  already held a row, so the first row was laid down at the bottom of the page whatever the
+  space left and was cut off by the page edge, where blocks and flex containers move on.
+- Place the row bands of a `display: grid` container the same way as everything else when
+  its subtree is moved vertically. `shift_box_y_in_place` and `shift_content_vertical`
+  added the delta to `LaidOutGridRow`'s `top`/`bottom` while subtracting it from every
+  other coordinate, so a paginated grid under collapsing margins started its second page
+  above the top of the page and lost the rows there.
 - Paint the rows of a `display: grid` container on the pages it was split across (#18).
   The pagination allocated the right number of pages and moved each row band into page
   coordinates, but shifted the items inside the band the opposite way, so every page after

--- a/core/src/layout/block.rs
+++ b/core/src/layout/block.rs
@@ -1609,8 +1609,10 @@ pub(super) fn shift_box_y_in_place(b: &mut LaidOutBox, delta: f32) {
         }
         LaidOutContent::Grid(grid) => {
             for row in grid.rows.iter_mut() {
-                row.top += delta;
-                row.bottom += delta;
+                // 行帯の上端/下端はアイテムと同じ座標空間にあるので、
+                // `shift_rect_y`と同じ「`delta`を引く」向きで動かす。
+                row.top -= delta;
+                row.bottom -= delta;
                 for item in row.items.iter_mut() {
                     shift_box_y_in_place(item, delta);
                 }
@@ -1661,8 +1663,8 @@ pub(super) fn shift_content_vertical(b: &LaidOutBox, delta: f32) -> LaidOutBox {
         }
         LaidOutContent::Grid(grid) => {
             for row in grid.rows.iter_mut() {
-                row.top += delta;
-                row.bottom += delta;
+                row.top -= delta;
+                row.bottom -= delta;
                 for item in row.items.iter_mut() {
                     *item = shift_box_y(item, delta);
                 }

--- a/core/src/layout/paginate.rs
+++ b/core/src/layout/paginate.rs
@@ -569,7 +569,10 @@ fn place_box(
                     )
                 },
                 |child: &LaidOutBox| child.is_float,
-                margin_box_top,
+                |child: &LaidOutBox| {
+                    let top = margin_box_top(child);
+                    (top, top + child.layout.margin_box_height())
+                },
                 |child, ph, ps, c| {
                     place_box(child, ph, ps, c);
                 },
@@ -607,7 +610,7 @@ fn place_box(
                 move |i, _line| (forced_breaks[i], false),
                 // 行にfloatの概念は無い。
                 |_line: &LineBox| false,
-                |_line: &LineBox| 0.0,
+                |line: &LineBox| (line.rect.y, line.rect.y + line.rect.height),
                 |line, ph, ps, c| {
                     place_line(line, ph, ps, c);
                 },
@@ -634,7 +637,7 @@ fn place_box(
                 // the behaviour hard to predict.
                 |_i, _band: &FlexBand| (false, false),
                 |_band: &FlexBand| false,
-                |band: &FlexBand| band.top,
+                |band: &FlexBand| (band.top, band.bottom),
                 |band, ph, ps, c| {
                     place_flex_band(band, ph, ps, c);
                 },
@@ -834,24 +837,21 @@ fn place_split<T>(
     cursor: &mut f32,
     break_hints: impl Fn(usize, &T) -> (bool, bool),
     is_float: impl Fn(&T) -> bool,
-    item_margin_box_top: impl Fn(&T) -> f32,
+    item_extent: impl Fn(&T) -> (f32, f32),
     place_one: impl Fn(&mut T, f32, &mut PaginationState<'_>, &mut f32),
 ) {
     let top_extra = container.top_extra();
-    let bottom_extra = container.layout.padding.bottom
-        + container.layout.border.bottom
-        + container.layout.margin.bottom;
 
     // 最初のフラグメントの前に、コンテナ自身の上マージン/枠線/パディング分の
     // スペースを確保する(この余白がページの残りを超える極端なケースの調整は
     // 行わない
     *cursor += top_extra;
 
-    // 絶対Y座標(`b.layout.content.y`)→ページ内相対Y座標(`*cursor`)への
+    // 絶対Y座標(レイアウト時の座標)→ページ内相対Y座標(`*cursor`)への
     // 変換係数。コンテナの最初の子(通常フロー)の絶対Y位置は、コンテナ自身の
     // content領域の絶対Y位置(`b.layout.content.y`)に一致するため、これを
-    // 初期値として使える。非float項目を配置するたびに更新する(改ページで
-    // `*cursor`がリセットされても追従できるようにするため)。
+    // 初期値として使える。項目を1つ置くたびに、実際に置かれた位置から引き直す
+    // (改ページで`*cursor`がリセットされても追従できるようにするため)。
     let mut shift_reference = container.layout.content.y - *cursor;
 
     // `b`が実際に背景色・枠線を描画しないなら、そもそも装飾フラグメントを
@@ -903,6 +903,9 @@ fn place_split<T>(
     };
 
     let item_count = items.len();
+    // 強制改ページ直後は、`shift_reference`が前のページのものになっている。
+    // 次に置く項目はそのページの先頭へ来るので、係数を引き直してから使う。
+    let mut forced_page_start = false;
     for (i, item) in items.iter_mut().enumerate() {
         let (breaks_before, breaks_after) = break_hints(i, item);
         // 現在のページに実際の内容が何もなければ(祖先のマージン分だけ`cursor`が
@@ -910,6 +913,7 @@ fn place_split<T>(
         // 作るだけなので何もしない。
         if breaks_before && current_page_has_content(state) {
             force_new_page(state, cursor, &mut current_page, &mut segments);
+            forced_page_start = true;
         }
 
         if is_float(item) {
@@ -918,12 +922,23 @@ fn place_split<T>(
             // `place_one`(=`place_box`)内部の
             // `shift = margin_box_top -*cursor`計算が周囲の通常フローと同じ
             // 平行移動になり、正しいページ内相対位置に配置される。
-            let mut local_cursor = item_margin_box_top(item) - shift_reference;
+            let mut local_cursor = item_extent(item).0 - shift_reference;
             place_one(item, page_height, state, &mut local_cursor);
         } else {
-            let cursor_before_item = *cursor;
+            // レイアウト時の絶対座標をそのままページ内へ写す。マージンボックスの
+            // 高さを積み上げる方式だと、マージン相殺で重なっている margin box を
+            // 別々に数えてしまい、相殺したはずの分だけ間隔が開く(親へ持ち上げた
+            // 上マージンは階層の数だけ足され、兄弟間の相殺は2つとも足される)。
+            if forced_page_start {
+                shift_reference = item_extent(item).0 - *cursor;
+                forced_page_start = false;
+            }
+            // ページ先頭より上へ出る位置は描画できないので0で止める。
+            *cursor = (item_extent(item).0 - shift_reference).max(0.0);
             place_one(item, page_height, state, cursor);
-            shift_reference = item_margin_box_top(item) - cursor_before_item;
+            // `place_one`の中で改ページされることがあるため、実際に置かれた
+            // 結果(下端のページ内座標)から係数を引き直す。
+            shift_reference = item_extent(item).1 - *cursor;
 
             let now_page = state.current_index();
             if now_page != current_page {
@@ -945,11 +960,21 @@ fn place_split<T>(
         // 空ページを作らないため)。
         if breaks_after && i + 1 < item_count {
             force_new_page(state, cursor, &mut current_page, &mut segments);
+            forced_page_start = true;
         }
     }
 
-    // 呼び出し元(兄弟要素)のため、下マージン/枠線/パディング分もカーソルへ加算する。
-    *cursor += bottom_extra;
+    // 呼び出し元(兄弟要素)のために、コンテナ自身の下端(margin box)を
+    // ページ内座標へ写して返す。`padding-bottom`等を足すだけだと、最後の子と
+    // 相殺した`margin-bottom`を二重に数えたり、内容より大きい明示`height`を
+    // 落としたりする。中身がはみ出している場合に兄弟と重ならないよう、
+    // 最後に置いた項目の下端より上には戻さない。
+    let container_bottom = container.layout.content.y
+        + container.layout.content.height
+        + container.layout.padding.bottom
+        + container.layout.border.bottom
+        + container.layout.margin.bottom;
+    *cursor = (container_bottom - shift_reference).max(*cursor);
 
     if !needs_fragments {
         return;
@@ -1164,6 +1189,16 @@ fn place_grid(
         if pending.is_empty() {
             fragment_top = *cursor;
             shift = row.top - *cursor;
+
+            // 断片の最初の行がページの残りに収まらないなら、はみ出させずに
+            // 次ページの先頭から始める(この判定を省くと、ページ下端に置かれた
+            // 行の下半分が欠ける)。まっさらなページにも収まらない巨大な行は
+            // そのまま置く(前進しなくなるのを避けるため)。
+            if row.bottom - shift > page_height && current_page_has_content(state) {
+                new_page(state, cursor);
+                fragment_top = *cursor;
+                shift = row.top - *cursor;
+            }
         }
 
         // 直前の行帯からまたいでいるアイテムがあると、その境界では切れない。
@@ -1270,12 +1305,6 @@ struct FlexBand {
     items: Vec<LaidOutBox>,
     top: f32,
     bottom: f32,
-    /// Vertical distance from the bottom of the previous band (0.0 for the
-    /// first one). `gap`/`row-gap`, and any space `justify-content` left
-    /// between the bands, belong to no item's margin box, so `place_split`,
-    /// which packs each item at the cursor, would drop it. [`place_flex_band`]
-    /// adds it back, the way [`place_grid`] keeps the gaps between its rows.
-    gap_before: f32,
 }
 
 /// Tolerance (px) used when deciding where a band ends. The coordinates taffy
@@ -1305,21 +1334,11 @@ fn group_flex_items_into_bands(mut items: Vec<LaidOutBox>) -> Vec<FlexBand> {
                 band.items.push(item);
                 band.bottom = band.bottom.max(bottom);
             }
-            _ => {
-                // The space taffy left between this band and the previous one
-                // (`gap`, or `justify-content`); negative overlap cannot happen
-                // here, since an item that overlapped would have joined the band.
-                let gap_before = bands
-                    .last()
-                    .map(|previous| (top - previous.bottom).max(0.0))
-                    .unwrap_or(0.0);
-                bands.push(FlexBand {
-                    items: vec![item],
-                    top,
-                    bottom,
-                    gap_before,
-                })
-            }
+            _ => bands.push(FlexBand {
+                items: vec![item],
+                top,
+                bottom,
+            }),
         }
     }
     bands
@@ -1339,13 +1358,6 @@ fn place_flex_band(
     state: &mut PaginationState<'_>,
     cursor: &mut f32,
 ) {
-    // Reopen the space that separates this band from the previous one, so a
-    // split container keeps the spacing an unsplit one has. At the very top of a
-    // page there is no previous band to separate from, so the gap is dropped
-    // (`place_grid` drops the row gap at a page boundary the same way).
-    if *cursor > 0.0 {
-        *cursor += band.gap_before;
-    }
     if let [item] = band.items.as_mut_slice() {
         place_box(item, page_height, state, cursor);
         return;
@@ -1430,6 +1442,15 @@ fn place_table(
             let (top, s) = start_new_fragment(cursor, row_top, extra_above);
             fragment_top = top;
             shift = s;
+
+            // グリッドと同じく、最初の行がページの残りに収まらないなら
+            // 次ページの先頭から始める(captionの高さも含めて判定する)。
+            if row_bottom - shift > page_height && current_page_has_content(state) {
+                new_page(state, cursor);
+                let (top, s) = start_new_fragment(cursor, row_top, extra_above);
+                fragment_top = top;
+                shift = s;
+            }
         }
 
         // この行を今のページに置くと溢れるなら、ここまでの断片を確定して改ページ。

--- a/core/tests/fragmentation.rs
+++ b/core/tests/fragmentation.rs
@@ -263,3 +263,94 @@ fn widows_forces_lines_forward_end_to_end() {
         "the paragraph should still split across exactly two pages"
     );
 }
+
+/// ページ内の各テキスト行を(文字列, ページ内y)で、文書順に返す。
+fn text_lines_on_page(page: &sghtmltopdf_core::layout::Page) -> Vec<(String, f32)> {
+    fn walk(b: &LaidOutBox, out: &mut Vec<(String, f32)>) {
+        match &b.content {
+            LaidOutContent::Blocks(children) | LaidOutContent::Flex(children) => {
+                for child in children {
+                    walk(child, out);
+                }
+            }
+            LaidOutContent::Grid(grid) => {
+                for item in grid.rows.iter().flat_map(|row| &row.items) {
+                    walk(item, out);
+                }
+            }
+            LaidOutContent::Inline(lines) => {
+                for line in lines {
+                    let text: String = line.runs.iter().map(|run| run.text.as_str()).collect();
+                    if !text.trim().is_empty() {
+                        out.push((text, line.rect.y));
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    let mut out = Vec::new();
+    for b in &page.boxes {
+        walk(b, &mut out);
+    }
+    out
+}
+
+fn paginate(html_src: &str, css: &str) -> Vec<sghtmltopdf_core::layout::Page> {
+    let dom = html::parse(html_src.as_bytes());
+    let styles = compute_styles(&dom, &user_agent_stylesheet(), &parse_stylesheet(css));
+    paginate_document(&dom, &styles, &test_fonts(), &PageSettings::default())
+}
+
+#[test]
+fn collapsed_margins_between_siblings_survive_pagination() {
+    // 隣接する兄弟の`margin-bottom`/`margin-top`は相殺するので、高さ30px・
+    // 上下マージン20pxの段落は50px間隔で並ぶ。ページ分割がmargin boxの高さを
+    // 積み上げて配置していると、相殺したはずの20pxが復活して70px間隔になり、
+    // 1ページに収まる同じ文書と見た目が変わってしまう。
+    let paragraphs: String = (0..40).map(|i| format!("<p>p{i}</p>")).collect();
+    let pages = paginate(
+        &paragraphs,
+        "* { margin: 0; padding: 0 } p { margin: 20px 0; height: 30px }",
+    );
+
+    assert!(pages.len() > 1, "40段落は1ページに収まらない");
+    for (page_index, page) in pages.iter().enumerate() {
+        let lines = text_lines_on_page(page);
+        assert!(!lines.is_empty(), "ページ{page_index}が空");
+        for pair in lines.windows(2) {
+            let (above, above_y) = &pair[0];
+            let (below, below_y) = &pair[1];
+            assert!(
+                (below_y - above_y - 50.0).abs() < 0.01,
+                "ページ{page_index}の{above}と{below}の間隔が{}(期待値は高さ30px+相殺後のマージン20px)",
+                below_y - above_y
+            );
+        }
+    }
+    assert!(
+        (text_lines_on_page(&pages[0])[0].1 - 20.0).abs() < 0.01,
+        "先頭段落の上マージン20pxは1回だけ効く: {:?}",
+        text_lines_on_page(&pages[0])[0]
+    );
+}
+
+#[test]
+fn a_hoisted_top_margin_is_counted_once_whatever_the_nesting_depth() {
+    // 親に上境界が無いとき、最初の子の`margin-top`は親の外へ持ち上げられ、
+    // 相殺後の値が祖先すべての`margin.top`に入る。ページ分割が各階層で自分の
+    // `margin-top`を足していくと、同じ40pxを階層の数だけ足してしまい、
+    // 1ページ目の先頭が下へずれる(このHTMLでは40pxではなく200pxになっていた)。
+    let paragraphs: String = (0..60).map(|i| format!("<p>p{i}</p>")).collect();
+    let pages = paginate(
+        &format!(r#"<div class="wrap"><div class="inner">{paragraphs}</div></div>"#),
+        "* { margin: 0; padding: 0 } .inner { margin-top: 40px } p { height: 20px }",
+    );
+
+    assert!(pages.len() > 1, "60段落は1ページに収まらない");
+    let first = &text_lines_on_page(&pages[0])[0];
+    assert!(
+        (first.1 - 40.0).abs() < 0.01,
+        "先頭段落は持ち上げられた40pxのぶんだけ下がる: {first:?}"
+    );
+}

--- a/core/tests/grid.rs
+++ b/core/tests/grid.rs
@@ -545,3 +545,84 @@ fn grid_items_on_later_pages_are_placed_within_the_page() {
         "every paragraph appears exactly once, in order"
     );
 }
+
+#[test]
+fn a_paginated_grid_under_collapsing_margins_stays_inside_its_pages() {
+    // 行帯(`LaidOutGridRow`の`top`/`bottom`)だけが`shift_box_y_in_place`で
+    // アイテムと逆向きに動いていたため、マージン相殺で子がシフトされる構造の
+    // 中にあるグリッドは、2ページ目以降がページ上端より上(負のy)に置かれて
+    // 欠けていた。
+    let cells: String = (0..40).map(|i| format!("<div>g{i}</div>")).collect();
+    let html =
+        format!(r#"<div class="wrap"><div class="inner"><div class="g">{cells}</div></div></div>"#);
+    let css = "* { margin: 0; padding: 0 } \
+               .wrap { margin-top: 20px } \
+               .inner { margin-top: 40px } \
+               .g { display: grid; grid-template-columns: 1fr 1fr } \
+               .g > div { height: 60px }";
+    let dom = html::parse(html.as_bytes());
+    let styles = compute_styles(&dom, &user_agent_stylesheet(), &parse_stylesheet(css));
+    let settings = PageSettings::default();
+    let page_height = settings.content_height();
+    let pages = paginate_document(&dom, &styles, &test_fonts(), &settings);
+
+    assert!(pages.len() > 1, "20行×60pxは1ページに収まらない");
+    for (page_index, page) in pages.iter().enumerate() {
+        let lines = text_lines_on_page(page);
+        assert!(!lines.is_empty(), "ページ{page_index}が空");
+        for (text, y, height) in &lines {
+            assert!(
+                *y >= -0.01 && y + height <= page_height + 0.01,
+                "{text:?}がページ{page_index}の外に出ている: y={y} height={height}"
+            );
+        }
+        let first_y = lines[0].1;
+        let expected = if page_index == 0 { 40.0 } else { 0.0 };
+        assert!(
+            (first_y - expected).abs() < 0.01,
+            "ページ{page_index}の先頭行はy={expected}のはず(相殺後の上マージンは1ページ目にだけ効く): y={first_y}"
+        );
+    }
+}
+
+#[test]
+fn a_grid_row_that_does_not_fit_the_rest_of_the_page_starts_on_the_next_page() {
+    // 行帯の分割判定は「この断片に既に1行以上ある」ことを条件にしていたため、
+    // グリッドの最初の行帯だけは、ページの残り高さに収まらなくてもその場に
+    // 置かれ、ページ下端からはみ出して欠けていた(blockとflexは次ページへ送る)。
+    let settings = PageSettings::default();
+    let filler_height = settings.content_height() - 30.0;
+    let html = r#"<div class="filler"></div><div class="g"><div>ga</div><div>gb</div><div>gc</div><div>gd</div></div>"#;
+    let css = format!(
+        "* {{ margin: 0; padding: 0 }} .filler {{ height: {filler_height}px }} \
+         .g {{ display: grid; grid-template-columns: 1fr 1fr }} .g > div {{ height: 40px }}"
+    );
+    let dom = html::parse(html.as_bytes());
+    let styles = compute_styles(&dom, &user_agent_stylesheet(), &parse_stylesheet(&css));
+    let page_height = settings.content_height();
+    let pages = paginate_document(&dom, &styles, &test_fonts(), &settings);
+
+    assert_eq!(pages.len(), 2, "グリッドは2ページ目へ送られる");
+    assert!(
+        text_lines_on_page(&pages[0]).is_empty(),
+        "1ページ目には残り30pxしかないので、40pxの行帯は置けない: {:?}",
+        text_lines_on_page(&pages[0])
+    );
+    let second = text_lines_on_page(&pages[1]);
+    assert_eq!(
+        second.len(),
+        4,
+        "2行帯4アイテムが2ページ目に載る: {second:?}"
+    );
+    for (text, y, height) in &second {
+        assert!(
+            *y >= -0.01 && y + height <= page_height + 0.01,
+            "{text:?}がページからはみ出している: y={y} height={height}"
+        );
+    }
+    assert!(
+        (second[0].1 - 0.0).abs() < 0.01,
+        "2ページ目の先頭はページ上端から始まる: {:?}",
+        second[0]
+    );
+}

--- a/core/tests/table_pagination.rs
+++ b/core/tests/table_pagination.rs
@@ -313,3 +313,84 @@ fn a_document_with_a_repeated_header_encodes_to_a_valid_pdf() {
     assert!(bytes.starts_with(b"%PDF-"));
     assert!(bytes.windows(5).any(|w| w == b"%%EOF"));
 }
+
+/// ページ内の各ボックス(テーブルのセルまで含む)が、ページの上下に収まって
+/// いるかを確かめる。収まっていないものを`(ページ番号, 上端, 下端)`で返す。
+fn boxes_outside_pages(pages: &[sghtmltopdf_core::layout::Page]) -> Vec<(usize, f32, f32)> {
+    fn walk(
+        page_index: usize,
+        b: &sghtmltopdf_core::layout::LaidOutBox,
+        page_height: f32,
+        out: &mut Vec<(usize, f32, f32)>,
+    ) {
+        let top = b.layout.content.y - b.layout.padding.top - b.layout.border.top;
+        let bottom =
+            top + b.layout.content.height + b.layout.padding.bottom + b.layout.border.bottom;
+        if top < -0.01 || bottom > page_height + 0.01 {
+            out.push((page_index, top, bottom));
+        }
+        match &b.content {
+            LaidOutContent::Blocks(children) | LaidOutContent::Flex(children) => {
+                for child in children {
+                    walk(page_index, child, page_height, out);
+                }
+            }
+            LaidOutContent::Table(table) => {
+                for cell in table.rows.iter().flat_map(|row| &row.cells) {
+                    walk(page_index, cell, page_height, out);
+                }
+            }
+            _ => {}
+        }
+    }
+    let page_height = PageSettings::default().content_height();
+    let mut out = Vec::new();
+    for (i, page) in pages.iter().enumerate() {
+        for b in &page.boxes {
+            walk(i, b, page_height, &mut out);
+        }
+    }
+    out
+}
+
+#[test]
+fn a_table_whose_first_row_does_not_fit_starts_on_the_next_page() {
+    // 分割判定は「この断片に既に1行以上ある」ことを条件にしていたため、
+    // テーブルの最初の行だけは、ページの残り高さに収まらなくてもその場に
+    // 置かれ、ページ下端からはみ出して欠けていた。
+    let settings = PageSettings::default();
+    let filler_height = settings.content_height() - 30.0;
+    let html_src = r#"<div class="filler"></div><table><tr><td>first</td></tr><tr><td>second</td></tr></table>"#;
+    let css = format!(
+        "* {{ margin: 0; padding: 0 }} .filler {{ height: {filler_height}px }} td {{ height: 40px }}"
+    );
+    let dom = html::parse(html_src.as_bytes());
+    let styles = compute_styles(&dom, &user_agent_stylesheet(), &parse_stylesheet(&css));
+    let pages = paginate_document(&dom, &styles, &test_fonts(), &settings);
+
+    assert_eq!(pages.len(), 2, "テーブルは2ページ目へ送られる");
+    assert_eq!(
+        rows_on_page(&pages[0]),
+        0,
+        "1ページ目には残り30pxしかないので、40pxの行は置けない"
+    );
+    assert_eq!(rows_on_page(&pages[1]), 2);
+    assert!(
+        boxes_outside_pages(&pages).is_empty(),
+        "ページからはみ出したボックスがある: {:?}",
+        boxes_outside_pages(&pages)
+    );
+}
+
+fn rows_on_page(page: &sghtmltopdf_core::layout::Page) -> usize {
+    fn count(b: &sghtmltopdf_core::layout::LaidOutBox) -> usize {
+        match &b.content {
+            LaidOutContent::Table(table) => table.rows.len(),
+            LaidOutContent::Blocks(children) | LaidOutContent::Flex(children) => {
+                children.iter().map(count).sum()
+            }
+            _ => 0,
+        }
+    }
+    page.boxes.iter().map(count).sum()
+}


### PR DESCRIPTION
## Cause

- When the page was split and each page was rearranged, the height of the margin box was being stacked up and the cursor was being moved, so all the margins that had been offset by the layout were being reopened.
- With `shift_box_y_in_place`/`shift_content_vertical`, only the grid row was moving in the opposite direction to `row.top += delta`. In a structure where children are shifted due to margin collapsing, the grid that divides pages was placed above the top edge of the page from the second page onwards, and was missing.

## Fixed

- Collapse of adjacent siblings: Since both margins are counted separately, the default UA style results in a paragraph spacing of 50.6px instead of 34.7px.
- Top margin lifted to parent: The collapsed value is added to the margin.top of all ancestors, so it is added for each level of hierarchy. For example, the first line of `<html><body><h1>` is 85.8px instead of 21.4px.
- The grid/table splitting condition was "this fragment already has one or more rows," so only the first row of the fragment was placed where it was, even if it didn't fit within the remaining page height, and was cut off at the bottom of the page (block and flex would move to the next page). If the current page has content, start from the beginning of the next page.

