### PR TITLE
Fixed url() bug in sghtmltopdf_stylesheet_link_tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   also stops mapping a source that is already a URL onto a same-named file under `public/`,
   and no longer gives up on a `public/`-only file in a Propshaft app, where `asset_path`
   raises `MissingAssetError` rather than returning a path.
+- `sghtmltopdf_stylesheet_link_tag` now points the `url()`s of the CSS it inlines at files
+  the engine can read, instead of copying the file verbatim (#45). The asset pipeline
+  rewrites every `url()` through `asset_path` while precompiling, so a `@font-face` source
+  became a digested `/assets/…` path, or an absolute `https://…` URL once `asset_host` was
+  set; rendering never goes through the HTTP server, so neither could be fetched and the
+  family fell back to the engine default rather than to the next `font-family` — silently,
+  since a `@font-face` that cannot be loaded only warns. Each reference is now mapped back
+  onto its file — the path part of an absolute URL, a site-root-relative path under
+  `public/` or the pipeline load path, a relative one against the stylesheet's own
+  directory as CSS says it means — and written the way `sghtmltopdf_image_tag` writes an
+  image: relative to `base_url`, the absolute path when it sits elsewhere the engine may
+  read, a `data:` URI when it may not. A reference that names no file of the application,
+  such as a font served by a CDN, is left alone. `@import` is spliced in rather than left
+  for the engine, which resolves every `url()` against the document's base whatever
+  stylesheet it came from, so the same problem would reappear one level down.
 - `position: relative` now moves the content of the element together with its background
   and border (#29). The offset was applied to the box's own rectangle after its lines and
   child boxes had been placed, so text, images, nested blocks and list markers were left

--- a/README.md
+++ b/README.md
@@ -119,6 +119,9 @@ That is enough for a precompiled production app; in development the digested `/a
 <%= sghtmltopdf_image_tag "logo.png" %>
 ```
 
+`sghtmltopdf_stylesheet_link_tag` does not copy the CSS verbatim: it points every `url()` at a file the engine can read and splices in every `@import`.
+The asset pipeline rewrites `url()` through `asset_path` while precompiling, which turns a `@font-face` source into a digested `/assets/…` path, or into an absolute URL once `asset_host` is set — neither can be fetched while rendering, and a `@font-face` that fails to load falls back to the engine default rather than to the next `font-family`.
+
 To send pages as soon as their layout is final, pass a block and use `ActionController::Live` this also makes `Rack::Timeout` and `Thread#kill` effective at chunk boundaries:
 
 ```ruby

--- a/bindings/ruby/README.md
+++ b/bindings/ruby/README.md
@@ -76,6 +76,9 @@ That is enough for a precompiled production app; in development the digested `/a
 <%= sghtmltopdf_image_tag "logo.png" %>
 ```
 
+`sghtmltopdf_stylesheet_link_tag` does not copy the CSS verbatim: it points every `url()` at a file the engine can read and splices in every `@import`.
+The asset pipeline rewrites `url()` through `asset_path` while precompiling, which turns a `@font-face` source into a digested `/assets/…` path, or into an absolute URL once `asset_host` is set — neither can be fetched while rendering, and a `@font-face` that fails to load falls back to the engine default rather than to the next `font-family`.
+
 A file `allow_path` does not cover is embedded as a `data:` URI instead, so that it cannot silently vanish from the PDF; pass `inline: true` to embed unconditionally.
 
 ### Streaming the response

--- a/bindings/ruby/lib/sghtmltopdf/view_helpers.rb
+++ b/bindings/ruby/lib/sghtmltopdf/view_helpers.rb
@@ -42,10 +42,14 @@ module Sghtmltopdf
 
     # Expands the CSS itself into a `<style>`. Takes several sources; any that
     # cannot be found are skipped silently (rendering still goes ahead).
+    #
+    # The file is not copied verbatim: its `url()`s are pointed at files the
+    # engine can read and its `@import`s are spliced in, see
+    # [#inline_stylesheet].
     def sghtmltopdf_stylesheet_link_tag(*sources)
       css = sources.flatten.filter_map do |source|
         path = sghtmltopdf_asset_path(with_extension(source, ".css"))
-        File.read(path) if path
+        inline_stylesheet(path) if path
       end
       return "".html_safe if css.empty?
 
@@ -88,6 +92,164 @@ module Sghtmltopdf
     end
 
     private
+
+    # `path` read as CSS, with every `url()` pointed at a file the engine can
+    # read and every `@import` spliced in.
+    #
+    # Both have to happen here because the engine keeps one base for the whole
+    # document: every CSS source is concatenated before it is parsed, so a
+    # `url()` is resolved against the HTML's `base_url` whatever stylesheet it
+    # came from. Only this side knows where each file sits on disk, so each
+    # one's references are resolved against its own directory before its text
+    # is spliced into the next.
+    #
+    # What has to be undone is mostly the asset pipeline's own work: it
+    # rewrites every `url()` through `asset_path` while precompiling, which
+    # yields a digested `/assets/…` path, or an absolute URL once `asset_host`
+    # is set. Rendering never goes through the HTTP server, so neither can be
+    # fetched.
+    #
+    # `chain` holds the files already being expanded, innermost last.
+    def inline_stylesheet(path, chain = [])
+      css = File.read(path)
+      dir = File.dirname(path)
+      chain += [real_path(path)].compact
+      comments = comment_ranges(css)
+      out = +""
+      cursor = 0
+      while (import = IMPORT_STATEMENT.match(css, cursor))
+        commented = comments.any? { |range| range.cover?(import.begin(0)) }
+        expanded = imported_stylesheet(import[:href], dir, chain) unless commented
+        out << rewrite_css_urls(css[cursor...import.begin(0)].to_s, dir)
+        cursor = import.end(0)
+        out << (expanded || import[0])
+      end
+      out << rewrite_css_urls(css[cursor..].to_s, dir)
+    end
+
+    # The expanded content of an `@import` target, or `nil` to leave the
+    # statement as it is, which hands it to the engine untouched. That happens
+    # when it names no asset of this application, when the nesting is too deep,
+    # and when it points back at a file already being expanded.
+    #
+    # Media conditions on the statement are dropped. The engine replaces the
+    # whole statement with the imported text too, so nothing changes by doing
+    # it here.
+    def imported_stylesheet(href, dir, chain)
+      return nil if chain.length >= MAX_IMPORT_DEPTH
+
+      target = css_url_target(unquote(href), dir)
+      return nil if target.nil?
+
+      real = real_path(target)
+      return nil if real.nil? || chain.include?(real)
+
+      inline_stylesheet(target, chain)
+    end
+
+    # Byte ranges of the `/* … */` comments in `css`. A commented-out `@import`
+    # must not be spliced in.
+    def comment_ranges(css)
+      css.enum_for(:scan, CSS_COMMENT).map { Regexp.last_match.begin(0)...Regexp.last_match.end(0) }
+    end
+
+    # Every `url()` in `css` pointed at something the engine can read: a path
+    # when it may read the file there, a `data:` URI when it may not.
+    #
+    # A reference that names no file of this application is left alone, which
+    # covers `data:` URIs, bare fragments, and genuinely remote resources such
+    # as a font served by a CDN.
+    def rewrite_css_urls(css, dir)
+      css.gsub(CSS_URL) do
+        match = Regexp.last_match
+        target = css_url_target(unquote(match[:href]), dir)
+        target ? css_url(engine_readable_src(target) || data_uri(target)) : match[0]
+      end
+    end
+
+    # The local file a CSS reference names, or `nil` when it names none.
+    def css_url_target(ref, dir)
+      path = ref.split(/[?#]/, 2).first.to_s
+      return nil if path.empty? || path.match?(/\Adata:/i)
+
+      if path.match?(%r{\A(?:[a-z][a-z0-9+.\-]*:|//)}i)
+        # Only an http(s) or protocol-relative URL can be one of ours. The host
+        # is not compared against `asset_host`: it may be a callable or carry a
+        # `%d` wildcard, so there is no general way to recognise it. Finding the
+        # path on disk is the test instead, and what that finds is the very file
+        # the reference names.
+        return nil unless path.match?(%r{\A(?:https?:)?//}i)
+
+        path = path.sub(%r{\A(?:https?:)?//[^/]*}i, "")
+        return nil if path.empty?
+      end
+
+      path.start_with?("/") ? from_site_root(path) : from_stylesheet_dir(path, dir)
+    end
+
+    # A site-root-relative reference (`/assets/pdf-<digest>.css`) mapped onto a
+    # file. `relative_url_root` comes off first: the pipeline writes it in front
+    # of every URL, but it is a mount point, not a directory under `public/`.
+    def from_site_root(path)
+      root = ::Rails.application.config.try(:relative_url_root).to_s
+      path = path.delete_prefix(root) unless root.empty?
+      candidate = File.join(::Rails.public_path.to_s, path)
+      return candidate if File.file?(candidate)
+
+      # Nothing is precompiled in development, so the load path is asked as
+      # well. The mount point is not part of a logical path either.
+      logical = path.delete_prefix("/")
+      prefix = ::Rails.application.config.try(:assets)&.prefix.to_s.delete_prefix("/")
+      from_asset_pipeline(logical) ||
+        (prefix.empty? ? nil : from_asset_pipeline(logical.delete_prefix("#{prefix}/")))
+    end
+
+    # A reference relative to the stylesheet that wrote it, which is what CSS
+    # says it means and what the pipeline assumed while compiling the file.
+    #
+    # The load path is tried too. An uncompiled stylesheet sitting at the root
+    # of its own load path names assets by logical path, which is spelled the
+    # same way but is looked up across every root.
+    def from_stylesheet_dir(path, dir)
+      candidate = File.expand_path(path, dir)
+      return candidate if File.file?(candidate)
+
+      from_asset_pipeline(path.delete_prefix("./"))
+    end
+
+    # A `url()` whose argument is always quoted, so that a path holding a space
+    # or a parenthesis survives.
+    def css_url(value)
+      %(url("#{value.gsub(/["\\]/) { |char| "\\#{char}" }}"))
+    end
+
+    def unquote(value)
+      value = value.to_s.strip
+      quoted = value.match(/\A(["'])(.*)\1\z/m)
+      quoted ? quoted[2] : value
+    end
+
+    # Matches the engine's own cap (`core/src/style/import.rs`). Past it the
+    # statement is left in place and the engine decides what to do with it.
+    MAX_IMPORT_DEPTH = 16
+    private_constant :MAX_IMPORT_DEPTH
+
+    # `@import` up to its terminating `;`, in both the `url()` and the bare
+    # string form. Media conditions are matched so they are consumed, not kept.
+    IMPORT_STATEMENT = /
+      @import \s+
+      (?: url\( \s* (?<href> "[^"]*" | '[^']*' | [^)"'\s]* ) \s* \)
+        | (?<href> "[^"]*" | '[^']*' ) )
+      [^;]* ;
+    /xi
+    private_constant :IMPORT_STATEMENT
+
+    # A `url()` token. The lookbehind keeps identifiers ending in "url" out.
+    CSS_URL = /(?<![\w-])url\( \s* (?<href> "[^"]*" | '[^']*' | [^)"'\s]* ) \s* \)/xi
+    private_constant :CSS_URL
+
+    CSS_COMMENT = %r{/\*.*?\*/}m
+    private_constant :CSS_COMMENT
 
     # Takes the path part of the URL `asset_path` returns (which may carry an
     # asset host) and maps it onto a real file under `public/`.
@@ -223,7 +385,15 @@ module Sghtmltopdf
       "ico" => "image/vnd.microsoft.icon",
       "tif" => "image/tiff",
       "tiff" => "image/tiff",
-      "svg" => "image/svg+xml"
+      "svg" => "image/svg+xml",
+      # Reached through a stylesheet's `url()`, not through `image_tag`.
+      "otf" => "font/otf",
+      "ttf" => "font/ttf",
+      "ttc" => "font/collection",
+      "woff" => "font/woff",
+      "woff2" => "font/woff2",
+      "eot" => "application/vnd.ms-fontobject",
+      "css" => "text/css"
     }.freeze
     private_constant :MIME_TYPES
 

--- a/bindings/ruby/spec/dummy/app/assets/stylesheets/pipeline.css
+++ b/bindings/ruby/spec/dummy/app/assets/stylesheets/pipeline.css
@@ -1,0 +1,6 @@
+/* 実体は`app/assets/images/pipeline-logo.png`。このファイルの隣には無いので、
+   ロードパスの論理パスとして引かれる経路になる。 */
+body {
+  background-image: url(pipeline-logo.png);
+  background-size: 20px 16px;
+}

--- a/bindings/ruby/spec/pipeline_spec.rb
+++ b/bindings/ruby/spec/pipeline_spec.rb
@@ -103,6 +103,50 @@ RSpec.describe "アセットパイプラインを入れたアプリ" do
     expect(lines).to eq(%w[true false true])
   end
 
+  # 開発環境ではヘルパがコンパイル前のCSSを引くので、`url()`はパイプラインに
+  # 書き換えられておらず論理パスのまま残る。エンジンは文書のbase_url基準でしか
+  # 解決できないので、ここでロードパスを引いて実体へ指し直す。
+  it "パイプラインのCSSのurl()はロードパス越しに実体を指す" do
+    lines = in_pipeline_app(<<~'RUBY')
+      html = view.sghtmltopdf_stylesheet_link_tag("pipeline")
+      src = html[/url\("([^"]+)"\)/, 1]
+      puts src == File.join(root, "app/assets/images/pipeline-logo.png")
+      puts html.include?("data:")
+      # 20x16のPNGがXObjectとして埋まる。
+      puts Sghtmltopdf.render(html + "<p>x</p>").include?("/Width 20")
+    RUBY
+
+    expect(lines).to eq(%w[true false true])
+  end
+
+  # devでは`public/assets`に何も無いので、`/assets/…`はロードパスの論理パスへ
+  # 読み替える。マウント位置(`config.assets.prefix`)は論理パスの一部ではない。
+  it "/assets/の参照はマウント位置を外してロードパスから引く" do
+    lines = in_pipeline_app(<<~'RUBY')
+      require "fileutils"
+      css = File.join(root, "public/rooted.css")
+      begin
+        File.write(css, %(body { background-image: url("/assets/pipeline-logo.png"); }))
+        html = view.sghtmltopdf_stylesheet_link_tag("rooted")
+        puts html.include?(File.join(root, "app/assets/images/pipeline-logo.png"))
+      ensure
+        FileUtils.rm_f(css)
+      end
+    RUBY
+
+    expect(lines).to eq(%w[true])
+  end
+
+  it "allow_pathを絞るとCSSのurl()も埋め込みに倒す" do
+    lines = in_pipeline_app(<<~RUBY)
+      Sghtmltopdf.configure { |c| c.allow_path = [File.join(root, "public")] }
+      html = view.sghtmltopdf_stylesheet_link_tag("pipeline")
+      puts html.include?("url(\\"data:image/png;base64,")
+    RUBY
+
+    expect(lines).to eq(%w[true])
+  end
+
   it "allow_pathを絞ると読めなくなるので埋め込みに倒す" do
     lines = in_pipeline_app(<<~RUBY)
       Sghtmltopdf.configure { |c| c.allow_path = [File.join(root, "public")] }

--- a/bindings/ruby/spec/rails_spec.rb
+++ b/bindings/ruby/spec/rails_spec.rb
@@ -1,10 +1,15 @@
 # frozen_string_literal: true
 
+require "fileutils"
 require "rails_helper"
 require "tmpdir"
 
 # ダミーのRailsアプリ(spec/dummy)のコントローラからPDFが返ること。
 RSpec.describe "Railsのコントローラ", type: :rails do
+  # `@font-face`の経路を見るために使う。ダミーアプリには置かず、
+  # 例ごとに`public/`へ複製して消す。
+  FONT_FIXTURE = File.expand_path("../../../core/tests/fonts/DejaVuSansMono.ttf", __dir__)
+
   describe "render pdf:" do
     it "PDFを返す" do
       get "/invoices/show"
@@ -311,6 +316,173 @@ RSpec.describe "Railsのコントローラ", type: :rails do
         expect(last_response.body).to include("/Subtype /Image")
         expect(last_response.body).to include("/Width 20")
         expect(last_response.body).to include("/Height 16")
+      end
+    end
+
+    # #45: precompileしたCSSの`url()`はパイプラインが`asset_path`で書き換えた
+    # あとなので、`asset_host`があればHTTPSの絶対URLになる。PDF生成はHTTP
+    # サーバを通らないので取得できず、`@font-face`は無言で既定フォントに
+    # 落ちる。ヘルパはこれをディスク上のファイルへ指し直す。
+    describe "sghtmltopdf_stylesheet_link_tag" do
+      let(:view) { InvoicesController.new.view_context }
+
+      # フォントをダミーアプリに置きっぱなしにしないよう、`public/`の下へ
+      # 一式を作って例ごとに消す。
+      around do |example|
+        @dir = Rails.root.join("public/css-fixtures")
+        FileUtils.mkdir_p(@dir.join("fonts"))
+        FileUtils.cp(FONT_FIXTURE, @dir.join("fonts/gyre.ttf"))
+        FileUtils.cp(Rails.root.join("public/logo.png"), @dir.join("seal.png"))
+        example.run
+      ensure
+        FileUtils.rm_rf(@dir)
+      end
+
+      # `public/css-fixtures/main.css`に`css`を書いて、ヘルパの出力を返す。
+      def inline(css, name: "main")
+        File.write(@dir.join("#{name}.css"), css)
+        view.sghtmltopdf_stylesheet_link_tag("css-fixtures/#{name}")
+      end
+
+      it "asset_hostのついた絶対URLをローカルのファイルへ指し直す" do
+        html = inline(<<~CSS)
+          @font-face {
+            font-family: "Gyre";
+            src: url(https://cdn.example.com/css-fixtures/fonts/gyre.ttf);
+          }
+        CSS
+
+        expect(html).to include(%(url("css-fixtures/fonts/gyre.ttf")))
+        expect(html).not_to include("https://")
+      end
+
+      it "ルート相対の参照をローカルのファイルへ指し直す" do
+        html = inline(%(body { background-image: url("/css-fixtures/seal.png"); }))
+
+        expect(html).to include(%(url("css-fixtures/seal.png")))
+      end
+
+      # エンジンは全CSSソースを連結してから解決するので、相対`url()`は
+      # 文書のbase_url基準になる。CSSファイルの実パスを知っているのは
+      # こちら側だけなので、ここで解決してから流し込む。
+      it "相対参照はCSSファイル自身のディレクトリ基準で解決する" do
+        html = inline(%(body { background-image: url(seal.png); }))
+
+        expect(html).to include(%(url("css-fixtures/seal.png")))
+      end
+
+      it "..で親をたどる参照も解決する" do
+        html = inline(%(body { background-image: url("../../logo.png"); }), name: "fonts/deep")
+
+        expect(html).to include(%(url("logo.png")))
+      end
+
+      it "クエリとフラグメントは落とす" do
+        html = inline(%(@font-face { src: url(fonts/gyre.ttf?v=2#iefix); }))
+
+        expect(html).to include(%(url("css-fixtures/fonts/gyre.ttf")))
+        expect(html).not_to include("iefix")
+      end
+
+      it "data: URIと素のフラグメントは素通しする" do
+        html = inline(<<~CSS)
+          @font-face { src: url(data:font/ttf;base64,AAEAAA); }
+          .mask { mask: url(#clip); }
+        CSS
+
+        expect(html).to include("url(data:font/ttf;base64,AAEAAA)")
+        expect(html).to include("url(#clip)")
+      end
+
+      it "ローカルに無いリモートURLは素通しする" do
+        html = inline(%(@font-face { src: url(https://fonts.gstatic.com/s/x.woff2); }))
+
+        expect(html).to include("url(https://fonts.gstatic.com/s/x.woff2)")
+      end
+
+      # `local()`はファイル参照ではないので触らない。
+      it "local()には手を付けない" do
+        html = inline(%(@font-face { src: local("Gyre"), url(fonts/gyre.ttf); }))
+
+        expect(html).to include(%(local("Gyre")))
+        expect(html).to include(%(url("css-fixtures/fonts/gyre.ttf")))
+      end
+
+      # 読めない場所のファイルをパスで指すと、取得失敗が既定で無視される
+      # ぶん無言で消える。`@font-face`は`abort`にしても中断されないので、
+      # なおさら埋め込みへ倒す。
+      it "エンジンが読めない場所のファイルは埋め込みに倒す" do
+        Sghtmltopdf.configure { |c| c.server_url = "http://127.0.0.1:1" }
+
+        html = inline(%(@font-face { src: url(fonts/gyre.ttf); }))
+
+        expect(html).to include("data:font/ttf;base64,")
+      end
+
+      it "@importを再帰的に展開し、取り込んだ先のurl()も書き換える" do
+        File.write(@dir.join("fonts/child.css"), %(body { background-image: url(../seal.png); }))
+        html = inline(%(@import url("fonts/child.css");\nh1 { color: red; }))
+
+        expect(html).not_to include("@import")
+        expect(html).to include(%(url("css-fixtures/seal.png")))
+        expect(html).to include("h1 { color: red; }")
+      end
+
+      it "引用符だけの@importとメディア条件つきの@importも展開する" do
+        File.write(@dir.join("a.css"), "h1 { color: red; }")
+        File.write(@dir.join("b.css"), "h2 { color: blue; }")
+        html = inline(%(@import "a.css";\n@import url(b.css) print;))
+
+        expect(html).to include("h1 { color: red; }")
+        expect(html).to include("h2 { color: blue; }")
+        expect(html).not_to include("print")
+      end
+
+      it "コメントアウトされた@importは展開しない" do
+        File.write(@dir.join("a.css"), "h1 { color: red; }")
+        html = inline(%(/* @import "a.css"; */\nh2 { color: blue; }))
+
+        expect(html).not_to include("color: red")
+        expect(html).to include(%(/* @import "a.css"; */))
+      end
+
+      # 自分の祖先を取り込むCSSは、深さ上限まで展開すると読み込み回数が
+      # 分岐ぶん膨らむ。連鎖に出てきたファイルはそこで止めてエンジンに任せる。
+      it "循環した@importはそのまま残す" do
+        File.write(@dir.join("a.css"), %(@import "main.css";\nh1 { color: red; }))
+        html = inline(%(@import url("a.css");))
+
+        expect(html).to include("h1 { color: red; }")
+        expect(html).to include(%(@import "main.css";))
+      end
+
+      it "ローカルに無い@importはそのまま残してエンジンに任せる" do
+        html = inline(%(@import url("https://example.com/x.css");))
+
+        expect(html).to include(%(@import url("https://example.com/x.css");))
+      end
+
+      # 埋め込まれたフォントはPDF上どれも`/EmbeddedFont`という名前になるので、
+      # 名前では見分けられない。#45の症状そのもの、つまり「取得に失敗すると
+      # `font-family`の次の候補ではなくエンジン既定へ落ちる」を突き合わせる。
+      it "指し直した@font-faceのフォントが実際に効く" do
+        css = <<~CSS
+          @font-face {
+            font-family: "Gyre";
+            src: url(https://cdn.example.com/css-fixtures/fonts/gyre.ttf);
+          }
+          body { font-family: "Gyre"; }
+        CSS
+        body = "<p>Hello</p>"
+
+        rewritten = Sghtmltopdf.render(inline(css) + body)
+        # 書き換える前のCSSをそのまま流し込んだ場合(修正前の挙動)。
+        verbatim = Sghtmltopdf.render(%(<style type="text/css">#{css}</style>#{body}))
+        without = Sghtmltopdf.render(body)
+
+        expect(rewritten).to include("/FontFile2")
+        expect(normalize(verbatim)).to eq(normalize(without))
+        expect(normalize(rewritten)).not_to eq(normalize(without))
       end
     end
   end

--- a/docs/po/en.po
+++ b/docs/po/en.po
@@ -1,7 +1,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: sghtmltopdf\n"
-"POT-Creation-Date: 2026-09-05T18:47:48+09:00\n"
+"POT-Creation-Date: 2026-09-05T20:58:43+09:00\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -70,7 +70,7 @@ msgstr "Selectors, values, and at-rules"
 
 #: src/SUMMARY.md:22 src/usage/cli/reference.md:60 src/usage/ruby_rails.md:95
 #: src/supports/fonts.md:1 src/migration/wkhtmltopdf.md:18
-#: src/migration/wicked-pdf.md:129
+#: src/migration/wicked-pdf.md:133
 msgid "フォント"
 msgstr "Fonts"
 
@@ -1998,9 +1998,9 @@ msgid ""
 "`--allow-path`を1つ以上指定すると、ローカル参照はそのディレクトリ配下だけに限"
 "定されます。 `<img src>`・外部CSS・`@font-face`のすべてに効きます。"
 msgstr ""
-"Given one or more `--allow-path` directories, local references are "
-"confined to those directories. This applies to `<img src>`, external CSS, "
-"and `@font-face` alike."
+"Given one or more `--allow-path` directories, local references are confined "
+"to those directories. This applies to `<img src>`, external CSS, and `@font-"
+"face` alike."
 
 #: src/usage/cli/reference.md:187
 msgid ""
@@ -2049,9 +2049,9 @@ msgid ""
 "辿ります。 シンボリックリンクの先まで含めて閉じたい場合は`--allow-path`を使っ"
 "てください(こちらは実パスで判定します)。"
 msgstr ""
-"The check is lexical, so symlinks under the base directory are followed. "
-"Use `--allow-path` when you want the boundary to hold across symlinks as "
-"well (that check resolves real paths)."
+"The check is lexical, so symlinks under the base directory are followed. Use "
+"`--allow-path` when you want the boundary to hold across symlinks as well "
+"(that check resolves real paths)."
 
 #: src/usage/cli/reference.md:213
 msgid "`/`で始まる参照"
@@ -2078,10 +2078,10 @@ msgid ""
 "れば`--allow-path`が要ります。"
 msgstr ""
 "Only when there is no file there is the same string read again as a "
-"filesystem path. It is the fallback for a document written as `<img "
-"src=\"/var/www/app/public/logo.png\">`. What may be read is then decided "
-"by the same rules as for any other reference: an absolute path inside the "
-"base directory is read as it is, one outside it needs `--allow-path`."
+"filesystem path. It is the fallback for a document written as `<img src=\"/"
+"var/www/app/public/logo.png\">`. What may be read is then decided by the "
+"same rules as for any other reference: an absolute path inside the base "
+"directory is read as it is, one outside it needs `--allow-path`."
 
 #: src/usage/cli/reference.md:223
 msgid ""
@@ -3203,7 +3203,7 @@ msgstr ""
 "the same parser."
 
 #: src/usage/ruby_rails.md:50 src/usage/ruby_rails.md:87
-#: src/usage/ruby_rails.md:142 src/usage/ruby_rails.md:210
+#: src/usage/ruby_rails.md:142 src/usage/ruby_rails.md:230
 #: src/migration/wicked-pdf.md:34
 msgid "\"A4\""
 msgstr "\"A4\""
@@ -3357,7 +3357,7 @@ msgid "# config/initializers/sghtmltopdf.rb など\n"
 msgstr "# for example config/initializers/sghtmltopdf.rb\n"
 
 #: src/usage/ruby_rails.md:88 src/migration/wicked-pdf.md:36
-#: src/migration/wicked-pdf.md:136
+#: src/migration/wicked-pdf.md:140
 msgid "\"vendor/fonts/NotoSansJP-Regular.ttf\""
 msgstr "\"vendor/fonts/NotoSansJP-Regular.ttf\""
 
@@ -3515,14 +3515,14 @@ msgstr "\"invoice\""
 msgid "# ファイル名(.pdfは自動で付く)\n"
 msgstr "# the file name; .pdf is appended for you\n"
 
-#: src/usage/ruby_rails.md:140 src/usage/ruby_rails.md:281
+#: src/usage/ruby_rails.md:140 src/usage/ruby_rails.md:301
 #: src/migration/wicked-pdf.md:22 src/migration/wicked-pdf.md:92
 msgid "\"invoices/show\""
 msgstr "\"invoices/show\""
 
 #: src/usage/ruby_rails.md:141 src/usage/ruby_rails.md:178
-#: src/usage/ruby_rails.md:281 src/migration/wicked-pdf.md:22
-#: src/migration/wicked-pdf.md:116
+#: src/usage/ruby_rails.md:301 src/migration/wicked-pdf.md:22
+#: src/migration/wicked-pdf.md:120
 msgid "\"pdf\""
 msgstr "\"pdf\""
 
@@ -3631,15 +3631,14 @@ msgid ""
 "場合も足してください。"
 msgstr ""
 "Both can be overridden with `Sghtmltopdf.configure`, regardless of "
-"initializer order. The `allow_path` default exists so that user input "
-"mixed into a template cannot read files outside the document; if you "
-"reference something outside the application, such as `/usr/share/fonts`, "
-"add it explicitly. It is made up of `public/` and `config.assets.paths` "
-"(the Propshaft or Sprockets load paths), which includes assets that live "
-"outside `Rails.root`, such as the ones a gem or an engine provides. "
-"`config/` and `db/` are not in it, so add those too if you reference "
-"somewhere that is not an asset, such as "
-"`Rails.root.join(\"tmp/chart.png\")`."
+"initializer order. The `allow_path` default exists so that user input mixed "
+"into a template cannot read files outside the document; if you reference "
+"something outside the application, such as `/usr/share/fonts`, add it "
+"explicitly. It is made up of `public/` and `config.assets.paths` (the "
+"Propshaft or Sprockets load paths), which includes assets that live outside "
+"`Rails.root`, such as the ones a gem or an engine provides. `config/` and "
+"`db/` are not in it, so add those too if you reference somewhere that is not "
+"an asset, such as `Rails.root.join(\"tmp/chart.png\")`."
 
 #: src/usage/ruby_rails.md:175
 msgid ""
@@ -3650,7 +3649,7 @@ msgstr ""
 "` yet, there are helpers that put the asset itself into the document."
 
 #: src/usage/ruby_rails.md:179 src/usage/ruby_rails.md:180
-#: src/supports/images.md:148 src/migration/wicked-pdf.md:117
+#: src/supports/images.md:148 src/migration/wicked-pdf.md:121
 msgid "\"logo.png\""
 msgstr "\"logo.png\""
 
@@ -3671,11 +3670,103 @@ msgstr ""
 "made up by the pipeline at request time, and no file of that name is on disk."
 
 #: src/usage/ruby_rails.md:187
-msgid "`sghtmltopdf_stylesheet_link_tag`はCSSの中身を`<style>`へ展開します。"
+msgid ""
+"`sghtmltopdf_stylesheet_link_tag`はCSSの中身を`<style>`へ展開します。 このと"
+"き中身をそのまま写すのではなく、`url()`の参照先をエンジンが読める形へ指し直"
+"し、`@import`を再帰的に取り込みます。"
 msgstr ""
-"`sghtmltopdf_stylesheet_link_tag` expands the CSS itself into a `<style>`."
+"`sghtmltopdf_stylesheet_link_tag` expands the CSS itself into a `<style>`. "
+"It does not copy the file verbatim: every `url()` is pointed at something "
+"the engine can read, and every `@import` is spliced in."
 
-#: src/usage/ruby_rails.md:189
+#: src/usage/ruby_rails.md:190
+msgid ""
+"指し直しが必要なのは、アセットパイプラインがprecompile時に`url()`を"
+"`asset_path`で書き換えるためです。 `asset_host`を設定していればHTTPSの絶対URL"
+"になり(Sprocketsの場合)、そうでなければダイジェスト付きの`/assets/…`になりま"
+"す。 PDFのレンダリングはHTTPサーバを介さないので、どちらもそのままでは取得で"
+"きません。 `@font-face`の取得に失敗しても`font-family`の次の候補には進まず、"
+"エンジン既定のフォントに落ちるだけなので、気づきにくい形で見た目が変わりま"
+"す。"
+msgstr ""
+"That is needed because the asset pipeline rewrites every `url()` through "
+"`asset_path` while precompiling. With `asset_host` set it becomes an "
+"absolute HTTPS URL (under Sprockets), and without it a digested `/assets/…` "
+"path. Rendering a PDF does not go through an HTTP server, so neither can be "
+"fetched as it is. A `@font-face` that fails to load does not move on to the "
+"next `font-family` candidate either: it falls back to the engine's default "
+"font, so the appearance changes in a way that is easy to miss."
+
+#: src/usage/ruby_rails.md:195
+msgid "CSS中の`url()`"
+msgstr "`url()` in the CSS"
+
+#: src/usage/ruby_rails.md:195
+msgid "指し直し先"
+msgstr "Pointed at"
+
+#: src/usage/ruby_rails.md:197
+msgid "`https://cdn.example.com/assets/x-<digest>.otf`"
+msgstr "`https://cdn.example.com/assets/x-<digest>.otf`"
+
+#: src/usage/ruby_rails.md:197
+msgid "パス部分をローカルのファイルに対応付ける"
+msgstr "The path part is mapped onto a local file"
+
+#: src/usage/ruby_rails.md:198
+msgid "`/assets/x-<digest>.otf`"
+msgstr "`/assets/x-<digest>.otf`"
+
+#: src/usage/ruby_rails.md:198
+msgid "`public/`、次にパイプラインのロードパス"
+msgstr "`public/`, then the asset pipeline load path"
+
+#: src/usage/ruby_rails.md:199
+msgid "`fonts/x.otf`"
+msgstr "`fonts/x.otf`"
+
+#: src/usage/ruby_rails.md:199
+msgid "まずCSSファイル自身のディレクトリ、次にパイプラインのロードパス"
+msgstr ""
+"The stylesheet's own directory first, then the asset pipeline load path"
+
+#: src/usage/ruby_rails.md:200
+msgid "`data:`、`#fragment`のみ"
+msgstr "`data:`, a bare `#fragment`"
+
+#: src/usage/ruby_rails.md:200
+msgid "そのまま"
+msgstr "Left alone"
+
+#: src/usage/ruby_rails.md:201
+msgid "ローカルに見つからないURL"
+msgstr "A URL that names no local file"
+
+#: src/usage/ruby_rails.md:201
+msgid "そのまま(CDNのフォントなど本物のリモート参照)"
+msgstr ""
+"Left alone (a genuine remote reference, such as a font served by a CDN)"
+
+#: src/usage/ruby_rails.md:203
+msgid ""
+"絶対URLはホスト名を`asset_host`と突き合わせません。 `asset_host`はProcや`%d`"
+"を含む文字列も取れるため、逆引きの一般解がないからです。 代わりにパス部分が"
+"ディスク上に実在するかどうかで判定します。"
+msgstr ""
+"The host of an absolute URL is not compared against `asset_host`. It may be "
+"a Proc, or a string holding `%d`, so there is no general way to recognise "
+"one in reverse. Whether the path part exists on disk decides instead."
+
+#: src/usage/ruby_rails.md:207
+msgid ""
+"指し直したあとの形は`sghtmltopdf_image_tag`と同じで、`base_url`の下なら相対パ"
+"ス、読める場所にあれば絶対パス、読めなければ`data:`URIです。"
+msgstr ""
+"What comes out takes the same shape as `sghtmltopdf_image_tag`: a path "
+"relative to `base_url` when the file sits under it, an absolute path when "
+"the engine may read it elsewhere, and a `data:` URI when it may not."
+
+#: src/usage/ruby_rails.md:209
 msgid ""
 "`sghtmltopdf_image_tag`は画像をパスで指します。 `base_url`の下にあれば相対パ"
 "ス、そうでなければ絶対パスです。 エンジンは`base_url`から解決できない絶対パス"
@@ -3688,7 +3779,7 @@ msgstr ""
 "`base_url`, so a file in `app/assets` in development can be pointed at as it "
 "is."
 
-#: src/usage/ruby_rails.md:193
+#: src/usage/ruby_rails.md:213
 msgid ""
 "パスで指せるのはエンジンがそこを読める場合だけなので、`allow_path`(未設定なら"
 "`base_url`)の外にあるファイルは`data:`URIとして埋め込みます。 取得の失敗は既"
@@ -3698,20 +3789,20 @@ msgid ""
 msgstr ""
 "A path only works where the engine is allowed to read, so a file outside "
 "`allow_path` (or outside `base_url`, when `allow_path` is not set) is "
-"embedded as a `data:` URI instead. A failed fetch is ignored by default, "
-"so an image pointed at by a path the engine cannot read would silently "
-"vanish. The same goes for delegating to another process with `server_url`, "
-"which may not be looking at this filesystem."
+"embedded as a `data:` URI instead. A failed fetch is ignored by default, so "
+"an image pointed at by a path the engine cannot read would silently vanish. "
+"The same goes for delegating to another process with `server_url`, which may "
+"not be looking at this filesystem."
 
-#: src/usage/ruby_rails.md:197
+#: src/usage/ruby_rails.md:217
 msgid "`inline: true`を渡すと常に埋め込みます。"
 msgstr "Pass `inline: true` to embed unconditionally."
 
-#: src/usage/ruby_rails.md:199
+#: src/usage/ruby_rails.md:219
 msgid "サーバへ委譲する"
 msgstr "Delegating to a server"
 
-#: src/usage/ruby_rails.md:201
+#: src/usage/ruby_rails.md:221
 msgid ""
 "`server_url`を指定すると、変換を[HTTPサーバモード](../server/index.md)で動く "
 "別プロセスへ投げます。 アプリのCPUを使いたくない場合や、gemの対応プラット"
@@ -3722,21 +3813,21 @@ msgstr ""
 "the application's CPU on rendering, or when you run somewhere the gem does "
 "not support, such as Windows."
 
-#: src/usage/ruby_rails.md:207 src/migration/wicked-pdf.md:146
+#: src/usage/ruby_rails.md:227 src/migration/wicked-pdf.md:150
 msgid "\"http://pdf.internal:8080\""
 msgstr "\"http://pdf.internal:8080\""
 
-#: src/usage/ruby_rails.md:210
+#: src/usage/ruby_rails.md:230
 msgid "# 委譲される\n"
 msgstr "# delegated\n"
 
-#: src/usage/ruby_rails.md:213
+#: src/usage/ruby_rails.md:233
 msgid "URLは1つだけです。負荷分散はLB(nginx・k8s Service)を前段に置く前提です"
 msgstr ""
 "Only one URL is accepted. Load balancing is expected to be handled by "
 "something in front, such as nginx or a Kubernetes Service"
 
-#: src/usage/ruby_rails.md:214
+#: src/usage/ruby_rails.md:234
 msgid ""
 "到達できないときはローカルへフォールバックしません(`ServerError`)。 サーバ起"
 "動時にだけ指定できるフォントが効かず、出力が変わってしまうためです"
@@ -3745,7 +3836,7 @@ msgstr ""
 "it raises `ServerError`. Fonts can only be set when the server starts, so "
 "falling back would silently change the output"
 
-#: src/usage/ruby_rails.md:216
+#: src/usage/ruby_rails.md:236
 msgid ""
 "HTTPのステータスは上のエラー分類へ対応します(400→`UsageError`、"
 "413→`InputError`、500→`RenderError`、その他→`ServerError`)"
@@ -3753,11 +3844,11 @@ msgstr ""
 "The HTTP statuses map onto the error classes above: 400 to `UsageError`, 413 "
 "to `InputError`, 500 to `RenderError`, and anything else to `ServerError`"
 
-#: src/usage/ruby_rails.md:218
+#: src/usage/ruby_rails.md:238
 msgid "サーバでは指定できないオプション"
 msgstr "Options that cannot be set against a server"
 
-#: src/usage/ruby_rails.md:220
+#: src/usage/ruby_rails.md:240
 msgid ""
 "ローカルパスを取るものと出力先・アクセス制御はサーバ起動時にしか設定できませ"
 "ん(指定すると`UsageError`)。"
@@ -3766,22 +3857,22 @@ msgstr ""
 "controls can only be set when the server starts; passing them raises "
 "`UsageError`."
 
-#: src/usage/ruby_rails.md:230
+#: src/usage/ruby_rails.md:250
 msgid ""
 "Railtieが入れる`base_url`/`allow_path`の既定値は自動的に外れるので、Railsでそ"
 "のまま`server_url`を足しても400にはなりません。 `configure`で明示的に設定して"
 "いる場合は、サーバ側の起動オプションへ移してください。"
 msgstr ""
-"The `base_url` and `allow_path` defaults supplied by the Railtie are "
-"dropped automatically, so simply adding `server_url` in a Rails app does "
-"not produce a 400. If you set them explicitly with `configure`, move them "
-"to the server's startup options."
+"The `base_url` and `allow_path` defaults supplied by the Railtie are dropped "
+"automatically, so simply adding `server_url` in a Rails app does not produce "
+"a 400. If you set them explicitly with `configure`, move them to the "
+"server's startup options."
 
-#: src/usage/ruby_rails.md:233
+#: src/usage/ruby_rails.md:253
 msgid "チャンクごとに受け取る"
 msgstr "Receiving the PDF in chunks"
 
-#: src/usage/ruby_rails.md:235
+#: src/usage/ruby_rails.md:255
 msgid ""
 "ブロックを渡すと、PDF全体を組み立ててから返す代わりにチャンクごとにブロックが"
 "呼ばれます(返り値は`nil`)。 Rackの`response.stream`へ流したり、S3のマルチパー"
@@ -3791,7 +3882,7 @@ msgstr ""
 "assembled and returned; the return value is `nil`. This is the hook for "
 "writing into Rack's `response.stream` or feeding an S3 multipart upload."
 
-#: src/usage/ruby_rails.md:242
+#: src/usage/ruby_rails.md:262
 msgid ""
 "ローカル変換でもサーバ委譲でも、PDF全体が組み上がるのを待たずに書き出せま"
 "す。 ローカルは確定したページから順に、サーバはその`?stream=1`(chunked "
@@ -3802,7 +3893,7 @@ msgstr ""
 "is finalised; with a server, its `?stream=1` response, sent with chunked "
 "transfer encoding, is passed straight through."
 
-#: src/usage/ruby_rails.md:245
+#: src/usage/ruby_rails.md:265
 msgid ""
 "ただし逐次になるのはPDFの書き出しだけで、HTMLのパースとレイアウトは文書全体に"
 "対して先に行います。 そのため最初のチャンクが届くのは変換の終盤で、ピークメモ"
@@ -3815,7 +3906,7 @@ msgstr ""
 "block. To have pages finalised while the HTML is still being read, combine "
 "this with [streaming mode](#when-you-need-to-keep-memory-down)."
 
-#: src/usage/ruby_rails.md:249
+#: src/usage/ruby_rails.md:269
 msgid ""
 "1回に渡すバイト数の目安は`chunk_size:`で変えられます(既定64KiB、ローカル変換"
 "のみ)。 小さくすると細かく届きますが、そのたびにGVLを取り直すのでレンダリング"
@@ -3826,11 +3917,11 @@ msgstr ""
 "more finely, but the GVL has to be reacquired each time, which slows "
 "rendering down."
 
-#: src/usage/ruby_rails.md:256
+#: src/usage/ruby_rails.md:276
 msgid "`Thread#kill`とタイムアウトが効く"
 msgstr "`Thread#kill` and timeouts work"
 
-#: src/usage/ruby_rails.md:258
+#: src/usage/ruby_rails.md:278
 msgid ""
 "ブロックの呼び出しはRubyのメソッド呼び出しなので、その時点で保留中の割り込み"
 "が処理されます。 ブロック付きで呼んでいる限り、`Thread#kill`や`Timeout."
@@ -3840,11 +3931,11 @@ msgstr ""
 "is handled at that point. As long as you pass a block, `Thread#kill`, "
 "`Timeout.timeout`, and `Rack::Timeout` all take effect at chunk boundaries."
 
-#: src/usage/ruby_rails.md:263
+#: src/usage/ruby_rails.md:283
 msgid "# 10秒で中断できる\n"
 msgstr "# can be interrupted after 10 seconds\n"
 
-#: src/usage/ruby_rails.md:267
+#: src/usage/ruby_rails.md:287
 msgid ""
 "ブロックを渡さない`render`/`render_to_file`は変換の間まったくRubyへ戻らないた"
 "め、途中で止められません。 長い変換に上限をかけたい場合はブロック付きで呼んで"
@@ -3854,11 +3945,11 @@ msgstr ""
 "the conversion and therefore cannot be stopped part way. To put a limit on a "
 "long conversion, call them with a block."
 
-#: src/usage/ruby_rails.md:270
+#: src/usage/ruby_rails.md:290
 msgid "Railsで逐次返却する"
 msgstr "Streaming the response from Rails"
 
-#: src/usage/ruby_rails.md:272
+#: src/usage/ruby_rails.md:292
 msgid ""
 "`render pdf:`のレンダラは、組み上がったPDFを`send_data`で一括返却します。 確"
 "定したページから順に返したい場合は`ActionController::Live`と組み合わせます。"
@@ -3867,15 +3958,15 @@ msgstr ""
 "`send_data`. To send pages as they are finalised, combine it with "
 "`ActionController::Live`."
 
-#: src/usage/ruby_rails.md:280
+#: src/usage/ruby_rails.md:300
 msgid "\"Content-Type\""
 msgstr "\"Content-Type\""
 
-#: src/usage/ruby_rails.md:280 src/usage/ruby_rails.md:299
+#: src/usage/ruby_rails.md:300 src/usage/ruby_rails.md:319
 msgid "\"application/pdf\""
 msgstr "\"application/pdf\""
 
-#: src/usage/ruby_rails.md:289
+#: src/usage/ruby_rails.md:309
 msgid ""
 "途中まで書き出したあとに失敗すると、クライアントには壊れたPDFが届きます(ヘッ"
 "ダは既に送信済みなのでステータスを変えられません)。 サーバモードの`?stream=1`"
@@ -3885,11 +3976,11 @@ msgstr ""
 "broken PDF, because the headers have already gone out and the status can no "
 "longer be changed. This is the same property as `?stream=1` in server mode."
 
-#: src/usage/ruby_rails.md:292
+#: src/usage/ruby_rails.md:312
 msgid "S3へ直接上げる"
 msgstr "Uploading straight to S3"
 
-#: src/usage/ruby_rails.md:294
+#: src/usage/ruby_rails.md:314
 msgid ""
 "gemはS3向けの実装を持ちません(依存を増やさず、書き方も短いためです)。 マルチ"
 "パートアップロードは最後のパート以外は5MB以上という制約があるので、溜めてから"
@@ -3899,20 +3990,20 @@ msgstr ""
 "the code is short anyway. A multipart upload requires every part except the "
 "last to be at least 5MB, so buffer before sending."
 
-#: src/usage/ruby_rails.md:300
+#: src/usage/ruby_rails.md:320
 msgid "\"\""
 msgstr "\"\""
 
-#: src/usage/ruby_rails.md:323
+#: src/usage/ruby_rails.md:343
 msgid "小さいPDFなら`put_object(body: Sghtmltopdf.render(html))`で十分です。"
 msgstr ""
 "For a small PDF, `put_object(body: Sghtmltopdf.render(html))` is enough."
 
-#: src/usage/ruby_rails.md:325
+#: src/usage/ruby_rails.md:345
 msgid "メモリを抑えたいとき"
 msgstr "When you need to keep memory down"
 
-#: src/usage/ruby_rails.md:327
+#: src/usage/ruby_rails.md:347
 msgid ""
 "数万要素規模のHTMLでは、エンジンの[ストリーミングモード](./cli/streaming.md)"
 "を使うとメモリが大きく減ります(実測: 60,000要素で 228MB → 28MB。[メモリと処理"
@@ -3923,7 +4014,7 @@ msgstr ""
 "goes from 228MB to 28MB. See [Memory and processing time](./cli/streaming."
 "md#memory-and-processing-time)."
 
-#: src/usage/ruby_rails.md:333
+#: src/usage/ruby_rails.md:353
 msgid ""
 "その代わり、文書全体を見ないと決まらないもの(`toc`・`counter(pages)`・"
 "`<body>`より後の`<style>`など)が使えません。 制約の一覧は[ストリーミングモー"
@@ -7137,12 +7228,12 @@ msgid ""
 "うため、経路自体を塞いでいます。`data:` URIは対象外 (SVG自身の中で完結してい"
 "るため許可されます)"
 msgstr ""
-"External references from inside an SVG, such as `<image href=\"...\">`, "
-"are not resolved. Each one is ignored with a warning. Reading a file from "
-"inside an SVG would bypass the containment that applies to `<img>` (the "
-"base directory, `--allow-path`, and `--disable-local-file-access`), so the "
-"path is closed off entirely. `data:` URIs are exempt (they are "
-"self-contained within the SVG itself)"
+"External references from inside an SVG, such as `<image href=\"...\">`, are "
+"not resolved. Each one is ignored with a warning. Reading a file from inside "
+"an SVG would bypass the containment that applies to `<img>` (the base "
+"directory, `--allow-path`, and `--disable-local-file-access`), so the path "
+"is closed off entirely. `data:` URIs are exempt (they are self-contained "
+"within the SVG itself)"
 
 #: src/supports/images.md:138
 msgid ""
@@ -7354,8 +7445,8 @@ msgid ""
 "信頼できないHTMLを変換する場合は、`--allow-path`でローカル参照の範囲も併せて"
 "絞ってください。"
 msgstr ""
-"When converting untrusted HTML, narrow the range of local references as "
-"well with `--allow-path`."
+"When converting untrusted HTML, narrow the range of local references as well "
+"with `--allow-path`."
 
 #: src/supports/images.md:224
 msgid "JPEGはそのまま埋め込まれる"
@@ -8456,9 +8547,8 @@ msgid ""
 "ローカル読み込みを許可するディレクトリ。sghtmltopdfでの綴りは`--allow-path`"
 "で、`--allow`は別名として受ける。サーバモードでは特に重要"
 msgstr ""
-"The directories local reads are confined to. sghtmltopdf spells it "
-"`--allow-path` and takes `--allow` as an alias; it matters most in server "
-"mode"
+"The directories local reads are confined to. sghtmltopdf spells it `--allow-"
+"path` and takes `--allow` as an alias; it matters most in server mode"
 
 #: src/migration/wkhtmltopdf-options.md:79
 msgid "`--background` / `--no-background`"
@@ -9282,15 +9372,15 @@ msgstr "— (`sghtmltopdf_image_tag` with `inline: true`)"
 
 #: src/migration/wicked-pdf.md:108
 msgid ""
-"素の`stylesheet_link_tag`/`image_tag`も、アセットが`public/`配下へprecompile"
-"されていればそのまま動きます。 PDFのレンダリングはHTTPサーバを介さないので、"
-"`/assets/…`のようなURLは`--base-url`(Railsでの既定は`Rails.root/public`)を基"
-"準にローカルファイルとして解決される。"
+"素の`image_tag`も、アセットが`public/`配下へprecompileされていればそのまま動"
+"きます。 PDFのレンダリングはHTTPサーバを介さないので、`/assets/…`のようなURL"
+"は`--base-url`(Railsでの既定は`Rails.root/public`)を基準にローカルファイルと"
+"して解決される。"
 msgstr ""
-"A plain `stylesheet_link_tag` or `image_tag` works as it is, as long as the "
-"assets have been precompiled into `public/`. Rendering does not go through "
-"an HTTP server, so a URL such as `/assets/…` is resolved as a local file "
-"against `--base-url`, which defaults to `Rails.root/public` under Rails."
+"A plain `image_tag` works as it is, as long as the assets have been "
+"precompiled into `public/`. Rendering does not go through an HTTP server, so "
+"a URL such as `/assets/…` is resolved as a local file against `--base-url`, "
+"which defaults to `Rails.root/public` under Rails."
 
 #: src/migration/wicked-pdf.md:111
 msgid ""
@@ -9308,11 +9398,25 @@ msgstr ""
 "`wicked_pdf_image_tag` emitted a `file://` URL, here the engine reads it as "
 "a local file."
 
-#: src/migration/wicked-pdf.md:120
+#: src/migration/wicked-pdf.md:115
+msgid ""
+"CSSについては素の`stylesheet_link_tag`では足りません。 パイプラインは"
+"precompile時にCSS中の`url()`も書き換えるため、`asset_host`を設定していると"
+"`@font-face`の参照がHTTPSの絶対URLになり、取得できずにフォントが既定へ落ちま"
+"す。 `sghtmltopdf_stylesheet_link_tag`は展開時にこれをディスク上のファイルへ"
+"指し直します。"
+msgstr ""
+"A plain `stylesheet_link_tag` is not enough for CSS. The pipeline rewrites "
+"the `url()`s inside the CSS too, so with `asset_host` set a `@font-face` "
+"reference becomes an absolute HTTPS URL, which cannot be fetched and leaves "
+"the font falling back to the default. `sghtmltopdf_stylesheet_link_tag` "
+"points those at the file on disk while it expands the CSS."
+
+#: src/migration/wicked-pdf.md:124
 msgid "既定値の違い"
 msgstr "Differences in the defaults"
 
-#: src/migration/wicked-pdf.md:122
+#: src/migration/wicked-pdf.md:126
 msgid ""
 "マージン: wkhtmltopdfは四辺10mm。sghtmltopdfは四辺1in(96px)。 同じ見た目にし"
 "たければ`margin_*`を明示する"
@@ -9320,7 +9424,7 @@ msgstr ""
 "Margins: wkhtmltopdf uses 10mm on all four sides, sghtmltopdf 1in (96px) on "
 "all four sides. State `margin_*` explicitly to keep the same look"
 
-#: src/migration/wicked-pdf.md:124
+#: src/migration/wicked-pdf.md:128
 msgid ""
 "CLIオプションとCSSの`@page`: wkhtmltopdfはCLIが勝つが、sghtmltopdfは `@page` "
 "が勝つ(オプションは初期値)"
@@ -9328,7 +9432,7 @@ msgstr ""
 "CLI options versus `@page` in CSS: in wkhtmltopdf the CLI wins, in "
 "sghtmltopdf `@page` wins and the options are initial values"
 
-#: src/migration/wicked-pdf.md:125
+#: src/migration/wicked-pdf.md:129
 msgid ""
 "ローカルファイルの参照範囲: Railsでは`--allow-path`(旧`--allow`。別名として受"
 "ける)の既定が`public/`とアセットパイプラインのロードパスになる。そこから外れ"
@@ -9338,15 +9442,14 @@ msgid ""
 "(`gothic_font`など)で渡すフォントはこの制限を受けない"
 msgstr ""
 "Range of local file references: on Rails the `--allow-path` default "
-"(formerly `--allow`, still accepted as an alias) is `public/` plus the "
-"asset pipeline load paths. If you reference a file outside those, say "
-"`/usr/share/fonts` or `Rails.root.join(\"tmp\")`, from an `<img>` or a "
-"`url()` in `@font-face`, name it explicitly with `Sghtmltopdf.configure { "
-"|c| c.allow_path += [\"/usr/share/fonts\"] }`. Fonts passed through the "
-"`--font` options (`gothic_font` and friends) are not subject to this "
-"restriction."
+"(formerly `--allow`, still accepted as an alias) is `public/` plus the asset "
+"pipeline load paths. If you reference a file outside those, say `/usr/share/"
+"fonts` or `Rails.root.join(\"tmp\")`, from an `<img>` or a `url()` in `@font-"
+"face`, name it explicitly with `Sghtmltopdf.configure { |c| c.allow_path += "
+"[\"/usr/share/fonts\"] }`. Fonts passed through the `--font` options "
+"(`gothic_font` and friends) are not subject to this restriction."
 
-#: src/migration/wicked-pdf.md:126
+#: src/migration/wicked-pdf.md:130
 msgid ""
 "リモート取得: `http(s)`のアセット取得は既定で無効。必要なら"
 "`allow_remote_assets: true`"
@@ -9354,20 +9457,20 @@ msgstr ""
 "Remote fetching: retrieving `http(s)` assets is off by default. Turn it on "
 "with `allow_remote_assets: true` if you need it"
 
-#: src/migration/wicked-pdf.md:127
+#: src/migration/wicked-pdf.md:131
 msgid ""
 "`disable_local_file_access`との併用: `--allow-path`は読み取り範囲を狭めるだけ"
 "で、許可を与えるものではない。wicked_pdfで`disable_local_file_access: true`と"
 "`allow: [dir]`を併用して「dirだけ読める」状態にしていた場合、そのまま持ち込む"
 "とローカル読み取りが全て止まる。`allow_path`だけを残すこと"
 msgstr ""
-"Combining with `disable_local_file_access`: `--allow-path` only narrows "
-"the range of local reads, it does not grant them. If you used "
-"`disable_local_file_access: true` together with `allow: [dir]` in "
-"wicked_pdf to mean \"only dir is readable\", carrying both across stops "
-"local reads entirely. Keep `allow_path` on its own."
+"Combining with `disable_local_file_access`: `--allow-path` only narrows the "
+"range of local reads, it does not grant them. If you used "
+"`disable_local_file_access: true` together with `allow: [dir]` in wicked_pdf "
+"to mean \"only dir is readable\", carrying both across stops local reads "
+"entirely. Keep `allow_path` on its own."
 
-#: src/migration/wicked-pdf.md:131
+#: src/migration/wicked-pdf.md:135
 msgid ""
 "wkhtmltopdfはシステムのフォント設定に依存するが、sghtmltopdfは`gothic_font`/"
 "`serif_font`/`mono_font`で指定できる。 日本語を出す場合は、コンテナのフォント"
@@ -9378,11 +9481,11 @@ msgstr ""
 "Japanese output it is safer to state them, so that you are not at the mercy "
 "of what a container happens to have."
 
-#: src/migration/wicked-pdf.md:140
+#: src/migration/wicked-pdf.md:144
 msgid "別プロセスへ逃がす(wicked_pdfには無い選択肢)"
 msgstr "Moving the work to another process, which wicked_pdf could not do"
 
-#: src/migration/wicked-pdf.md:142
+#: src/migration/wicked-pdf.md:146
 msgid ""
 "wicked_pdfはリクエストごとにwkhtmltopdfのプロセスを起動するが、sghtmltopdfの"
 "gemはアプリのプロセス内で変換する(重い処理の間はGVLを解放するのでPumaの他ス"
@@ -9395,7 +9498,7 @@ msgstr ""
 "still do not want to spend the application's CPU on it, `server_url` "
 "delegates to a separate `sghtmltopdf server` process."
 
-#: src/migration/wicked-pdf.md:149
+#: src/migration/wicked-pdf.md:153
 msgid ""
 "負荷分散はLB(nginx・k8s Service)を前段に置く前提で、URLは1つだけ受ける。 到達"
 "できないときは`Sghtmltopdf::ServerError`になり、ローカル変換へはフォールバッ"
@@ -9406,7 +9509,7 @@ msgstr ""
 "reached you get `Sghtmltopdf::ServerError`; it does not fall back to "
 "converting locally."
 
-#: src/migration/wicked-pdf.md:152
+#: src/migration/wicked-pdf.md:156
 msgid ""
 "サーバモードでは`base_url`・`allow_path`・フォント指定などローカルパスを取る"
 "オプションはリクエストから指定できない(サーバ起動時にだけ設定できる)。 "
@@ -9416,19 +9519,19 @@ msgstr ""
 "In server mode, options that take a local path, such as `base_url`, "
 "`allow_path`, and the font settings, cannot be given per request; they are "
 "only settable when the server starts. The defaults supplied by the Railtie "
-"are dropped automatically, but anything you set explicitly with "
-"`configure` produces a 400 and a `UsageError`, so move those to the "
-"server's startup options."
+"are dropped automatically, but anything you set explicitly with `configure` "
+"produces a 400 and a `UsageError`, so move those to the server's startup "
+"options."
 
-#: src/migration/wicked-pdf.md:155
+#: src/migration/wicked-pdf.md:159
 msgid "まだ無いもの"
 msgstr "Not there yet"
 
-#: src/migration/wicked-pdf.md:157
+#: src/migration/wicked-pdf.md:161
 msgid "PDFの結合・アウトライン: 非対応"
 msgstr "Merging PDFs and PDF outlines are not supported"
 
-#: src/migration/wicked-pdf.md:159
+#: src/migration/wicked-pdf.md:163
 msgid ""
 "なお逐次出力(ストリーミング)はwicked_pdfには無い機能で、ブロック付きの"
 "`render`で使える。 `ActionController::Live`と組み合わせれば、確定したページか"
@@ -9747,6 +9850,11 @@ msgstr ""
 "Embedding a JavaScript engine remains something to consider if the need "
 "arises. Items above that are not deliberate non-goals, such as PDF outlines, "
 "may well be supported later."
+
+#~ msgid ""
+#~ "`sghtmltopdf_stylesheet_link_tag`はCSSの中身を`<style>`へ展開します。"
+#~ msgstr ""
+#~ "`sghtmltopdf_stylesheet_link_tag` expands the CSS itself into a `<style>`."
 
 #~ msgid "`allow`"
 #~ msgstr "`allow`"

--- a/docs/po/messages.pot
+++ b/docs/po/messages.pot
@@ -2,7 +2,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: sghtmltopdf\n"
-"POT-Creation-Date: 2026-09-05T18:47:48+09:00\n"
+"POT-Creation-Date: 2026-09-05T20:58:43+09:00\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -71,7 +71,7 @@ msgstr ""
 
 #: src/SUMMARY.md:22 src/usage/cli/reference.md:60 src/usage/ruby_rails.md:95
 #: src/supports/fonts.md:1 src/migration/wkhtmltopdf.md:18
-#: src/migration/wicked-pdf.md:129
+#: src/migration/wicked-pdf.md:133
 msgid "フォント"
 msgstr ""
 
@@ -2548,7 +2548,7 @@ msgid "CLIのロングオプションから`--`を取り、`-`を`_`にした名
 msgstr ""
 
 #: src/usage/ruby_rails.md:50 src/usage/ruby_rails.md:87
-#: src/usage/ruby_rails.md:142 src/usage/ruby_rails.md:210
+#: src/usage/ruby_rails.md:142 src/usage/ruby_rails.md:230
 #: src/migration/wicked-pdf.md:34
 msgid "\"A4\""
 msgstr ""
@@ -2691,7 +2691,7 @@ msgid "# config/initializers/sghtmltopdf.rb など\n"
 msgstr ""
 
 #: src/usage/ruby_rails.md:88 src/migration/wicked-pdf.md:36
-#: src/migration/wicked-pdf.md:136
+#: src/migration/wicked-pdf.md:140
 msgid "\"vendor/fonts/NotoSansJP-Regular.ttf\""
 msgstr ""
 
@@ -2818,14 +2818,14 @@ msgstr ""
 msgid "# ファイル名(.pdfは自動で付く)\n"
 msgstr ""
 
-#: src/usage/ruby_rails.md:140 src/usage/ruby_rails.md:281
+#: src/usage/ruby_rails.md:140 src/usage/ruby_rails.md:301
 #: src/migration/wicked-pdf.md:22 src/migration/wicked-pdf.md:92
 msgid "\"invoices/show\""
 msgstr ""
 
 #: src/usage/ruby_rails.md:141 src/usage/ruby_rails.md:178
-#: src/usage/ruby_rails.md:281 src/migration/wicked-pdf.md:22
-#: src/migration/wicked-pdf.md:116
+#: src/usage/ruby_rails.md:301 src/migration/wicked-pdf.md:22
+#: src/migration/wicked-pdf.md:120
 msgid "\"pdf\""
 msgstr ""
 
@@ -2924,7 +2924,7 @@ msgid "開発環境のようにアセットがまだ`public/`へ書き出され�
 msgstr ""
 
 #: src/usage/ruby_rails.md:179 src/usage/ruby_rails.md:180
-#: src/supports/images.md:148 src/migration/wicked-pdf.md:117
+#: src/supports/images.md:148 src/migration/wicked-pdf.md:121
 msgid "\"logo.png\""
 msgstr ""
 
@@ -2939,175 +2939,245 @@ msgid ""
 msgstr ""
 
 #: src/usage/ruby_rails.md:187
-msgid "`sghtmltopdf_stylesheet_link_tag`はCSSの中身を`<style>`へ展開します。"
+msgid ""
+"`sghtmltopdf_stylesheet_link_tag`はCSSの中身を`<style>`へ展開します。 "
+"このとき中身をそのまま写すのではなく、`url()`の参照先をエンジンが読める形へ指し直し、`@import`を再帰的に取り込みます。"
 msgstr ""
 
-#: src/usage/ruby_rails.md:189
+#: src/usage/ruby_rails.md:190
+msgid ""
+"指し直しが必要なのは、アセットパイプラインがprecompile時に`url()`を`asset_path`で書き換えるためです。 "
+"`asset_host`を設定していればHTTPSの絶対URLになり(Sprocketsの場合)、そうでなければダイジェスト付きの`/assets/…`になります。 "
+"PDFのレンダリングはHTTPサーバを介さないので、どちらもそのままでは取得できません。 "
+"`@font-face`の取得に失敗しても`font-family`の次の候補には進まず、エンジン既定のフォントに落ちるだけなので、気づきにくい形で見た目が変わります。"
+msgstr ""
+
+#: src/usage/ruby_rails.md:195
+msgid "CSS中の`url()`"
+msgstr ""
+
+#: src/usage/ruby_rails.md:195
+msgid "指し直し先"
+msgstr ""
+
+#: src/usage/ruby_rails.md:197
+msgid "`https://cdn.example.com/assets/x-<digest>.otf`"
+msgstr ""
+
+#: src/usage/ruby_rails.md:197
+msgid "パス部分をローカルのファイルに対応付ける"
+msgstr ""
+
+#: src/usage/ruby_rails.md:198
+msgid "`/assets/x-<digest>.otf`"
+msgstr ""
+
+#: src/usage/ruby_rails.md:198
+msgid "`public/`、次にパイプラインのロードパス"
+msgstr ""
+
+#: src/usage/ruby_rails.md:199
+msgid "`fonts/x.otf`"
+msgstr ""
+
+#: src/usage/ruby_rails.md:199
+msgid "まずCSSファイル自身のディレクトリ、次にパイプラインのロードパス"
+msgstr ""
+
+#: src/usage/ruby_rails.md:200
+msgid "`data:`、`#fragment`のみ"
+msgstr ""
+
+#: src/usage/ruby_rails.md:200
+msgid "そのまま"
+msgstr ""
+
+#: src/usage/ruby_rails.md:201
+msgid "ローカルに見つからないURL"
+msgstr ""
+
+#: src/usage/ruby_rails.md:201
+msgid "そのまま(CDNのフォントなど本物のリモート参照)"
+msgstr ""
+
+#: src/usage/ruby_rails.md:203
+msgid ""
+"絶対URLはホスト名を`asset_host`と突き合わせません。 "
+"`asset_host`はProcや`%d`を含む文字列も取れるため、逆引きの一般解がないからです。 "
+"代わりにパス部分がディスク上に実在するかどうかで判定します。"
+msgstr ""
+
+#: src/usage/ruby_rails.md:207
+msgid ""
+"指し直したあとの形は`sghtmltopdf_image_tag`と同じで、`base_url`の下なら相対パス、読める場所にあれば絶対パス、読めなければ`data:`URIです。"
+msgstr ""
+
+#: src/usage/ruby_rails.md:209
 msgid ""
 "`sghtmltopdf_image_tag`は画像をパスで指します。 `base_url`の下にあれば相対パス、そうでなければ絶対パスです。 "
 "エンジンは`base_url`から解決できない絶対パスをファイルシステムのパスとして読むので、開発環境で`app/assets`にあるファイルもそのまま指せます。"
 msgstr ""
 
-#: src/usage/ruby_rails.md:193
+#: src/usage/ruby_rails.md:213
 msgid ""
 "パスで指せるのはエンジンがそこを読める場合だけなので、`allow_path`(未設定なら`base_url`)の外にあるファイルは`data:`URIとして埋め込みます。 "
 "取得の失敗は既定で無視されるため、パスで指したまま読めないと画像が無言で消えてしまうからです。 "
 "同じ理由で、`server_url`を設定して別プロセスへ委譲する場合も埋め込みます。委譲先が同じファイルシステムを見ているとは限りません。"
 msgstr ""
 
-#: src/usage/ruby_rails.md:197
+#: src/usage/ruby_rails.md:217
 msgid "`inline: true`を渡すと常に埋め込みます。"
 msgstr ""
 
-#: src/usage/ruby_rails.md:199
+#: src/usage/ruby_rails.md:219
 msgid "サーバへ委譲する"
 msgstr ""
 
-#: src/usage/ruby_rails.md:201
+#: src/usage/ruby_rails.md:221
 msgid ""
 "`server_url`を指定すると、変換を[HTTPサーバモード](../server/index.md)で動く 別プロセスへ投げます。 "
 "アプリのCPUを使いたくない場合や、gemの対応プラットフォーム外(Windowsなど)で動かす場合に使います。"
 msgstr ""
 
-#: src/usage/ruby_rails.md:207 src/migration/wicked-pdf.md:146
+#: src/usage/ruby_rails.md:227 src/migration/wicked-pdf.md:150
 msgid "\"http://pdf.internal:8080\""
 msgstr ""
 
-#: src/usage/ruby_rails.md:210
+#: src/usage/ruby_rails.md:230
 msgid "# 委譲される\n"
 msgstr ""
 
-#: src/usage/ruby_rails.md:213
+#: src/usage/ruby_rails.md:233
 msgid "URLは1つだけです。負荷分散はLB(nginx・k8s Service)を前段に置く前提です"
 msgstr ""
 
-#: src/usage/ruby_rails.md:214
+#: src/usage/ruby_rails.md:234
 msgid ""
 "到達できないときはローカルへフォールバックしません(`ServerError`)。 "
 "サーバ起動時にだけ指定できるフォントが効かず、出力が変わってしまうためです"
 msgstr ""
 
-#: src/usage/ruby_rails.md:216
+#: src/usage/ruby_rails.md:236
 msgid ""
 "HTTPのステータスは上のエラー分類へ対応します(400→`UsageError`、413→`InputError`、500→`RenderError`、その他→`ServerError`)"
 msgstr ""
 
-#: src/usage/ruby_rails.md:218
+#: src/usage/ruby_rails.md:238
 msgid "サーバでは指定できないオプション"
 msgstr ""
 
-#: src/usage/ruby_rails.md:220
+#: src/usage/ruby_rails.md:240
 msgid "ローカルパスを取るものと出力先・アクセス制御はサーバ起動時にしか設定できません(指定すると`UsageError`)。"
 msgstr ""
 
-#: src/usage/ruby_rails.md:230
+#: src/usage/ruby_rails.md:250
 msgid ""
 "Railtieが入れる`base_url`/`allow_path`の既定値は自動的に外れるので、Railsでそのまま`server_url`を足しても400にはなりません。 "
 "`configure`で明示的に設定している場合は、サーバ側の起動オプションへ移してください。"
 msgstr ""
 
-#: src/usage/ruby_rails.md:233
+#: src/usage/ruby_rails.md:253
 msgid "チャンクごとに受け取る"
 msgstr ""
 
-#: src/usage/ruby_rails.md:235
+#: src/usage/ruby_rails.md:255
 msgid ""
 "ブロックを渡すと、PDF全体を組み立ててから返す代わりにチャンクごとにブロックが呼ばれます(返り値は`nil`)。 "
 "Rackの`response.stream`へ流したり、S3のマルチパートアップロードへ繋いだりするための口です。"
 msgstr ""
 
-#: src/usage/ruby_rails.md:242
+#: src/usage/ruby_rails.md:262
 msgid ""
 "ローカル変換でもサーバ委譲でも、PDF全体が組み上がるのを待たずに書き出せます。 "
 "ローカルは確定したページから順に、サーバはその`?stream=1`(chunked transfer encoding)をそのまま流します。"
 msgstr ""
 
-#: src/usage/ruby_rails.md:245
+#: src/usage/ruby_rails.md:265
 msgid ""
 "ただし逐次になるのはPDFの書き出しだけで、HTMLのパースとレイアウトは文書全体に対して先に行います。 "
 "そのため最初のチャンクが届くのは変換の終盤で、ピークメモリもブロックを渡さない場合と変わりません。 "
 "HTMLを読みながらページを確定させたい場合は[ストリーミングモード](#メモリを抑えたいとき)と併せて使ってください。"
 msgstr ""
 
-#: src/usage/ruby_rails.md:249
+#: src/usage/ruby_rails.md:269
 msgid ""
 "1回に渡すバイト数の目安は`chunk_size:`で変えられます(既定64KiB、ローカル変換のみ)。 "
 "小さくすると細かく届きますが、そのたびにGVLを取り直すのでレンダリングは遅くなります。"
 msgstr ""
 
-#: src/usage/ruby_rails.md:256
+#: src/usage/ruby_rails.md:276
 msgid "`Thread#kill`とタイムアウトが効く"
 msgstr ""
 
-#: src/usage/ruby_rails.md:258
+#: src/usage/ruby_rails.md:278
 msgid ""
 "ブロックの呼び出しはRubyのメソッド呼び出しなので、その時点で保留中の割り込みが処理されます。 "
 "ブロック付きで呼んでいる限り、`Thread#kill`や`Timeout.timeout`・`Rack::Timeout`がチャンク境界で効きます。"
 msgstr ""
 
-#: src/usage/ruby_rails.md:263
+#: src/usage/ruby_rails.md:283
 msgid "# 10秒で中断できる\n"
 msgstr ""
 
-#: src/usage/ruby_rails.md:267
+#: src/usage/ruby_rails.md:287
 msgid ""
 "ブロックを渡さない`render`/`render_to_file`は変換の間まったくRubyへ戻らないため、途中で止められません。 "
 "長い変換に上限をかけたい場合はブロック付きで呼んでください。"
 msgstr ""
 
-#: src/usage/ruby_rails.md:270
+#: src/usage/ruby_rails.md:290
 msgid "Railsで逐次返却する"
 msgstr ""
 
-#: src/usage/ruby_rails.md:272
+#: src/usage/ruby_rails.md:292
 msgid ""
 "`render pdf:`のレンダラは、組み上がったPDFを`send_data`で一括返却します。 "
 "確定したページから順に返したい場合は`ActionController::Live`と組み合わせます。"
 msgstr ""
 
-#: src/usage/ruby_rails.md:280
+#: src/usage/ruby_rails.md:300
 msgid "\"Content-Type\""
 msgstr ""
 
-#: src/usage/ruby_rails.md:280 src/usage/ruby_rails.md:299
+#: src/usage/ruby_rails.md:300 src/usage/ruby_rails.md:319
 msgid "\"application/pdf\""
 msgstr ""
 
-#: src/usage/ruby_rails.md:289
+#: src/usage/ruby_rails.md:309
 msgid ""
 "途中まで書き出したあとに失敗すると、クライアントには壊れたPDFが届きます(ヘッダは既に送信済みなのでステータスを変えられません)。 "
 "サーバモードの`?stream=1`と同じ性質です。"
 msgstr ""
 
-#: src/usage/ruby_rails.md:292
+#: src/usage/ruby_rails.md:312
 msgid "S3へ直接上げる"
 msgstr ""
 
-#: src/usage/ruby_rails.md:294
+#: src/usage/ruby_rails.md:314
 msgid ""
 "gemはS3向けの実装を持ちません(依存を増やさず、書き方も短いためです)。 "
 "マルチパートアップロードは最後のパート以外は5MB以上という制約があるので、溜めてから上げます。"
 msgstr ""
 
-#: src/usage/ruby_rails.md:300
+#: src/usage/ruby_rails.md:320
 msgid "\"\""
 msgstr ""
 
-#: src/usage/ruby_rails.md:323
+#: src/usage/ruby_rails.md:343
 msgid "小さいPDFなら`put_object(body: Sghtmltopdf.render(html))`で十分です。"
 msgstr ""
 
-#: src/usage/ruby_rails.md:325
+#: src/usage/ruby_rails.md:345
 msgid "メモリを抑えたいとき"
 msgstr ""
 
-#: src/usage/ruby_rails.md:327
+#: src/usage/ruby_rails.md:347
 msgid ""
 "数万要素規模のHTMLでは、エンジンの[ストリーミングモード](./cli/streaming.md)を使うとメモリが大きく減ります(実測: "
 "60,000要素で 228MB → 28MB。[メモリと処理時間](./cli/streaming.md#メモリと処理時間))。"
 msgstr ""
 
-#: src/usage/ruby_rails.md:333
+#: src/usage/ruby_rails.md:353
 msgid ""
 "その代わり、文書全体を見ないと決まらないもの(`toc`・`counter(pages)`・`<body>`より後の`<style>`など)が使えません。 "
 "制約の一覧は[ストリーミングモード](./cli/streaming.md)を参照してください。"
@@ -7364,7 +7434,7 @@ msgstr ""
 
 #: src/migration/wicked-pdf.md:108
 msgid ""
-"素の`stylesheet_link_tag`/`image_tag`も、アセットが`public/`配下へprecompileされていればそのまま動きます。 "
+"素の`image_tag`も、アセットが`public/`配下へprecompileされていればそのまま動きます。 "
 "PDFのレンダリングはHTTPサーバを介さないので、`/assets/…`のようなURLは`--base-url`(Railsでの既定は`Rails.root/public`)を基準にローカルファイルとして解決される。"
 msgstr ""
 
@@ -7375,21 +7445,28 @@ msgid ""
 "`wicked_pdf_image_tag`が`file://`のURLを出していたのに対し、こちらはエンジンがローカルファイルとして読む形になる。"
 msgstr ""
 
-#: src/migration/wicked-pdf.md:120
+#: src/migration/wicked-pdf.md:115
+msgid ""
+"CSSについては素の`stylesheet_link_tag`では足りません。 "
+"パイプラインはprecompile時にCSS中の`url()`も書き換えるため、`asset_host`を設定していると`@font-face`の参照がHTTPSの絶対URLになり、取得できずにフォントが既定へ落ちます。 "
+"`sghtmltopdf_stylesheet_link_tag`は展開時にこれをディスク上のファイルへ指し直します。"
+msgstr ""
+
+#: src/migration/wicked-pdf.md:124
 msgid "既定値の違い"
 msgstr ""
 
-#: src/migration/wicked-pdf.md:122
+#: src/migration/wicked-pdf.md:126
 msgid ""
 "マージン: wkhtmltopdfは四辺10mm。sghtmltopdfは四辺1in(96px)。 同じ見た目にしたければ`margin_*`を明示する"
 msgstr ""
 
-#: src/migration/wicked-pdf.md:124
+#: src/migration/wicked-pdf.md:128
 msgid ""
 "CLIオプションとCSSの`@page`: wkhtmltopdfはCLIが勝つが、sghtmltopdfは `@page` が勝つ(オプションは初期値)"
 msgstr ""
 
-#: src/migration/wicked-pdf.md:125
+#: src/migration/wicked-pdf.md:129
 msgid ""
 "ローカルファイルの参照範囲: "
 "Railsでは`--allow-path`(旧`--allow`。別名として受ける)の既定が`public/`とアセットパイプラインのロードパスになる。そこから外れるファイル(例: "
@@ -7398,11 +7475,11 @@ msgid ""
 "}`のように明示する。`--font`系(`gothic_font`など)で渡すフォントはこの制限を受けない"
 msgstr ""
 
-#: src/migration/wicked-pdf.md:126
+#: src/migration/wicked-pdf.md:130
 msgid "リモート取得: `http(s)`のアセット取得は既定で無効。必要なら`allow_remote_assets: true`"
 msgstr ""
 
-#: src/migration/wicked-pdf.md:127
+#: src/migration/wicked-pdf.md:131
 msgid ""
 "`disable_local_file_access`との併用: "
 "`--allow-path`は読み取り範囲を狭めるだけで、許可を与えるものではない。wicked_pdfで`disable_local_file_access: "
@@ -7410,43 +7487,43 @@ msgid ""
 "[dir]`を併用して「dirだけ読める」状態にしていた場合、そのまま持ち込むとローカル読み取りが全て止まる。`allow_path`だけを残すこと"
 msgstr ""
 
-#: src/migration/wicked-pdf.md:131
+#: src/migration/wicked-pdf.md:135
 msgid ""
 "wkhtmltopdfはシステムのフォント設定に依存するが、sghtmltopdfは`gothic_font`/`serif_font`/`mono_font`で指定できる。 "
 "日本語を出す場合は、コンテナのフォント事情に左右されないよう明示するのが安全。"
 msgstr ""
 
-#: src/migration/wicked-pdf.md:140
+#: src/migration/wicked-pdf.md:144
 msgid "別プロセスへ逃がす(wicked_pdfには無い選択肢)"
 msgstr ""
 
-#: src/migration/wicked-pdf.md:142
+#: src/migration/wicked-pdf.md:146
 msgid ""
 "wicked_pdfはリクエストごとにwkhtmltopdfのプロセスを起動するが、sghtmltopdfのgemはアプリのプロセス内で変換する(重い処理の間はGVLを解放するのでPumaの他スレッドは止まらない)。 "
 "それでもアプリのCPUを使いたくない場合は、`server_url`で別プロセス(`sghtmltopdf server`)へ委譲できる。"
 msgstr ""
 
-#: src/migration/wicked-pdf.md:149
+#: src/migration/wicked-pdf.md:153
 msgid ""
 "負荷分散はLB(nginx・k8s Service)を前段に置く前提で、URLは1つだけ受ける。 "
 "到達できないときは`Sghtmltopdf::ServerError`になり、ローカル変換へはフォールバックしない。"
 msgstr ""
 
-#: src/migration/wicked-pdf.md:152
+#: src/migration/wicked-pdf.md:156
 msgid ""
 "サーバモードでは`base_url`・`allow_path`・フォント指定などローカルパスを取るオプションはリクエストから指定できない(サーバ起動時にだけ設定できる)。 "
 "Railtieが入れる既定値は自動的に外れるが、`configure`で明示的に設定している場合は400(`UsageError`)になるので、サーバ側の起動オプションへ移す。"
 msgstr ""
 
-#: src/migration/wicked-pdf.md:155
+#: src/migration/wicked-pdf.md:159
 msgid "まだ無いもの"
 msgstr ""
 
-#: src/migration/wicked-pdf.md:157
+#: src/migration/wicked-pdf.md:161
 msgid "PDFの結合・アウトライン: 非対応"
 msgstr ""
 
-#: src/migration/wicked-pdf.md:159
+#: src/migration/wicked-pdf.md:163
 msgid ""
 "なお逐次出力(ストリーミング)はwicked_pdfには無い機能で、ブロック付きの`render`で使える。 "
 "`ActionController::Live`と組み合わせれば、確定したページから順にレスポンスへ流せます → [Ruby / "

--- a/docs/src/migration/wicked-pdf.md
+++ b/docs/src/migration/wicked-pdf.md
@@ -105,12 +105,16 @@ end
 | `wicked_pdf_javascript_include_tag` | — (JSを実行しないので不要) |
 | `wicked_pdf_asset_base64` | — (`sghtmltopdf_image_tag`に`inline: true`) |
 
-素の`stylesheet_link_tag`/`image_tag`も、アセットが`public/`配下へprecompileされていればそのまま動きます。
+素の`image_tag`も、アセットが`public/`配下へprecompileされていればそのまま動きます。
 PDFのレンダリングはHTTPサーバを介さないので、`/assets/…`のようなURLは`--base-url`(Railsでの既定は`Rails.root/public`)を基準にローカルファイルとして解決される。
 
 開発環境のようにアセットがまだ`public/`に無い場合は、パイプラインのロードパスから実ファイルを引くヘルパを使う。
 `sghtmltopdf_stylesheet_link_tag`はCSSを`<style>`へ展開し、`sghtmltopdf_image_tag`は画像をパスで指す(読めない場所にある場合は`data:`URIで埋め込む)。
 `wicked_pdf_image_tag`が`file://`のURLを出していたのに対し、こちらはエンジンがローカルファイルとして読む形になる。
+
+CSSについては素の`stylesheet_link_tag`では足りません。
+パイプラインはprecompile時にCSS中の`url()`も書き換えるため、`asset_host`を設定していると`@font-face`の参照がHTTPSの絶対URLになり、取得できずにフォントが既定へ落ちます。
+`sghtmltopdf_stylesheet_link_tag`は展開時にこれをディスク上のファイルへ指し直します。
 
 ```erb
 <%= sghtmltopdf_stylesheet_link_tag "pdf" %>

--- a/docs/src/usage/ruby_rails.md
+++ b/docs/src/usage/ruby_rails.md
@@ -185,6 +185,26 @@ Railtieが次の既定値を入れます。
 `image_tag`が出す`/assets/logo-abc123.png`はダイジェストもマウント位置もパイプラインが実行時に作る仮想的なもので、対応するファイルはディスク上にありません。
 
 `sghtmltopdf_stylesheet_link_tag`はCSSの中身を`<style>`へ展開します。
+このとき中身をそのまま写すのではなく、`url()`の参照先をエンジンが読める形へ指し直し、`@import`を再帰的に取り込みます。
+
+指し直しが必要なのは、アセットパイプラインがprecompile時に`url()`を`asset_path`で書き換えるためです。
+`asset_host`を設定していればHTTPSの絶対URLになり(Sprocketsの場合)、そうでなければダイジェスト付きの`/assets/…`になります。
+PDFのレンダリングはHTTPサーバを介さないので、どちらもそのままでは取得できません。
+`@font-face`の取得に失敗しても`font-family`の次の候補には進まず、エンジン既定のフォントに落ちるだけなので、気づきにくい形で見た目が変わります。
+
+| CSS中の`url()` | 指し直し先 |
+|---|---|
+| `https://cdn.example.com/assets/x-<digest>.otf` | パス部分をローカルのファイルに対応付ける |
+| `/assets/x-<digest>.otf` | `public/`、次にパイプラインのロードパス |
+| `fonts/x.otf` | まずCSSファイル自身のディレクトリ、次にパイプラインのロードパス |
+| `data:`、`#fragment`のみ | そのまま |
+| ローカルに見つからないURL | そのまま(CDNのフォントなど本物のリモート参照) |
+
+絶対URLはホスト名を`asset_host`と突き合わせません。
+`asset_host`はProcや`%d`を含む文字列も取れるため、逆引きの一般解がないからです。
+代わりにパス部分がディスク上に実在するかどうかで判定します。
+
+指し直したあとの形は`sghtmltopdf_image_tag`と同じで、`base_url`の下なら相対パス、読める場所にあれば絶対パス、読めなければ`data:`URIです。
 
 `sghtmltopdf_image_tag`は画像をパスで指します。
 `base_url`の下にあれば相対パス、そうでなければ絶対パスです。


### PR DESCRIPTION
Fixed https://github.com/waka/sghtmltopdf/issues/45

## Cause

### The helper copied the stylesheet verbatim
sghtmltopdf_stylesheet_link_tag located the file, read it with File.read and dropped the bytes into a <style>.
It never looked at what was inside. from_public_dir strips an asset host, but only to find the stylesheet itself on disk; the references the stylesheet holds were passed through untouched.

### The asset pipeline has already rewritten every `url()` by then
Both pipelines rewrite `url()` while precompiling, and neither result can be read back.
Sprockets' `AssetUrlProcessor` substitutes `context.asset_path(path)`, which applies `asset_host`, so with `config.action_controller.asset_host` set a `@font-face` source becomes `https://example.com/assets/x-<digest>.otf`.
Propshaft's `CssAssetUrls` substitutes `url_prefix + digested_path`, where `url_prefix` is `relative_url_root + prefix` and carries no host, so it stops at `/assets/x-<digest>.otf`.
Rendering never goes through the HTTP server: the absolute URL cannot be fetched at all (remote assets are off by default, and the reporter's host answered with `text/html` anyway), and the site-root path only resolves while `base_url` happens to be `Rails.root/public`, so it breaks the moment the caller sets `base_url` to anything else.

### A `@font-face` that cannot be loaded fails silently
`load_font_faces` swallows each failed `src` with `.ok()` and, once none is left, warns on stderr and registers nothing for the family.
Text then falls through `FontCollection::select_for_char` to the engine's default font — not to the next entry in `font-family`, which is what the declaration looks like it should do.
`--load-media-error-handling abort` does not catch it either: the abort check only inspects `image_cache.had_errors()` and `css_cache.had_errors()`, while `load_font_faces` calls `fetcher.fetch` directly and is recorded in neither.
So the symptom is a document that renders "fine" in the wrong font.

### The engine has one base for the whole document
`extract_author_stylesheet` concatenates every CSS source — inline `<style>` text and fetched `<link>` bodies alike — into a single string before parsing it once, and `@import` is a textual splice performed before that.
Once concatenated, which rule came from which stylesheet is gone: there is exactly one base, held on `ImageFetcher`, and every `url()` resolves against it.
So the engine cannot fix this on its side for an inlined stylesheet, and leaving an `@import` for it to expand would reintroduce the same problem one level down.

### Development is broken too, for the opposite reason
There the helper reaches the uncompiled source through the pipeline load path, so nothing has been rewritten and a reference is still relative to the stylesheet.
The engine resolves it against the document base instead, so `url(fonts/x.otf)` inside `app/assets/stylesheets/pdf.css` is looked for under `public/fonts/x.otf`.

## Fixed

### Rewrite each `url()` against the stylesheet that wrote it
The helper now expands the CSS through `inline_stylesheet`, which resolves every reference against the directory of the file it appears in — which is what CSS says it means, and the only place that knowledge exists, since the engine has none.
Each reference is mapped back onto a file: the path part for an absolute URL, `public/` then the pipeline load path for a site-root-relative one (with `relative_url_root` and the `/assets` mount point taken off, since neither is part of a path on disk), and the stylesheet's own directory then the load path for a relative one.
A `data:` URI, a bare `#fragment`, and anything that names no file of this application — a font served by a CDN, say — are left exactly as they are.

### Decide by the path on disk, not by the host
An absolute URL's host is not compared against `asset_host`.
`asset_host` may be a callable or carry a `%d` wildcard, so there is no general way to recognise one in reverse, and Propshaft does not write a host at all.
Whether the path part names an existing file decides instead, and what that finds is the very file the reference names.

### Splice `@import` in here
Rewriting the `@import` target alone would hand the engine a readable path but leave the imported stylesheet's own `url()`s resolving against the document base.
The statement is now replaced with the expanded content, each level rewritten against its own directory.
Media conditions on the statement are dropped, which changes nothing: the engine's `resolve_imports` replaces the whole statement too and never reads the media list.

### Write the reference the way `sghtmltopdf_image_tag` writes an image
Relative to `base_url` when the file sits under it, the absolute path when the engine may read it elsewhere, and a `data:` URI when it may not — reusing `engine_readable_src` and `data_uri` unchanged.
The embedding fallback matters more here than it does for an image: a failed asset fetch is ignored by default, and for a font not even `abort` catches it, so a path the engine cannot read would leave no trace at all.
